### PR TITLE
Improve error types and add camera-specific error variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Breaking Change**: Made `ViscaError` enum non-exhaustive to allow adding new error variants in minor releases without breaking semver compatibility
+  - Users must now include a wildcard `_` pattern when matching on `ViscaError` variants
+  - This change allows the library to evolve with new error types without requiring major version bumps
+
 ## [0.3.0] - 2025-01-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - Unreleased
+
+### Added
+- **Improved Error Types**: Enhanced error handling with more specific error variants
+  - Added `ConnectionFailed`, `ConnectionLost`, and `CommandTimeout` for network issues
+  - Added `CameraBusy`, `CameraMoving`, and `CameraNotReady` for camera state errors
+  - Added `InvalidResponse` and `CommandRejected` for protocol errors
+  - Added `OutOfRange` and `PresetNotFound` for value validation
+  - Added `FeatureNotSupported` for camera capability detection
+  - Includes helper methods `is_retryable()` and `suggested_retry_delay()`
 
 ### Changed
-- **Breaking Change**: Made `ViscaError` enum non-exhaustive to allow adding new error variants in minor releases without breaking semver compatibility
-  - Users must now include a wildcard `_` pattern when matching on `ViscaError` variants
-  - This change allows the library to evolve with new error types without requiring major version bumps
+- **Breaking Change**: Reorganized `ViscaError` enum with new variants
+  - Kept traditional exhaustive enum approach for better ergonomics
+  - Users can handle all error cases with compile-time guarantees
+  - Accepted that new error variants require major version bumps
 
 ## [0.3.0] - 2025-01-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafton-visca"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Grant Sparks <grant@grafton.ai>"]
 description = "Rust based VISCA over IP implementation for controlling PTZ Cameras"

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,10 @@ use std::io;
 use std::time::Duration;
 use thiserror::Error;
 
-#[non_exhaustive]
+// Using traditional exhaustive enum approach for ViscaError
+// This provides better ergonomics for library users who need to handle specific errors
+// The VISCA protocol has a well-defined set of error conditions that are unlikely to change frequently
+// Adding new variants will require a major version bump, which is acceptable for this use case
 #[derive(Error, Debug)]
 pub enum ViscaError {
     // Connection errors

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,47 +2,48 @@ use std::io;
 use std::time::Duration;
 use thiserror::Error;
 
+#[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum ViscaError {
     // Connection errors
     #[error("Connection failed to {addr}: {source}")]
     ConnectionFailed { addr: String, source: io::Error },
-    
+
     #[error("Connection lost: {reason}")]
     ConnectionLost { reason: String },
-    
+
     #[error("Command timeout after {duration:?} for command: {command}")]
     CommandTimeout { duration: Duration, command: String },
-    
+
     // Camera state errors
     #[error("Camera is busy executing another command")]
     CameraBusy,
-    
+
     #[error("Camera is still moving, position: pan={pan}, tilt={tilt}")]
     CameraMoving { pan: i16, tilt: i16 },
-    
+
     #[error("Camera not initialized")]
     CameraNotReady,
-    
+
     // Protocol errors
     #[error("Invalid response: expected {expected}, got {actual:?}")]
     InvalidResponse { expected: String, actual: Vec<u8> },
-    
+
     #[error("Command rejected by camera: {reason}")]
     CommandRejected { reason: String },
-    
+
     // Value errors
     #[error("Value {value} out of range [{min}, {max}] for {parameter}")]
-    OutOfRange { 
-        value: i32, 
-        min: i32, 
-        max: i32, 
-        parameter: String 
+    OutOfRange {
+        value: i32,
+        min: i32,
+        max: i32,
+        parameter: String,
     },
-    
+
     #[error("Preset {id} not found")]
     PresetNotFound { id: u8 },
-    
+
     // Feature errors
     #[error("Feature '{feature}' not supported by this camera model")]
     FeatureNotSupported { feature: String },
@@ -104,15 +105,16 @@ impl ViscaError {
     }
 
     pub fn is_retryable(&self) -> bool {
-        matches!(self, 
-            ViscaError::CameraBusy | 
-            ViscaError::CameraMoving { .. } |
-            ViscaError::CommandTimeout { .. } |
-            ViscaError::CommandBufferFull |
-            ViscaError::Timeout
+        matches!(
+            self,
+            ViscaError::CameraBusy
+                | ViscaError::CameraMoving { .. }
+                | ViscaError::CommandTimeout { .. }
+                | ViscaError::CommandBufferFull
+                | ViscaError::Timeout
         )
     }
-    
+
     pub fn suggested_retry_delay(&self) -> Option<Duration> {
         match self {
             ViscaError::CameraBusy => Some(Duration::from_millis(100)),
@@ -233,10 +235,11 @@ mod tests {
         // Retryable errors
         assert!(ViscaError::CameraBusy.is_retryable());
         assert!(ViscaError::CameraMoving { pan: 100, tilt: 50 }.is_retryable());
-        assert!(ViscaError::CommandTimeout { 
-            duration: Duration::from_secs(5), 
-            command: "test".to_string() 
-        }.is_retryable());
+        assert!(ViscaError::CommandTimeout {
+            duration: Duration::from_secs(5),
+            command: "test".to_string()
+        }
+        .is_retryable());
         assert!(ViscaError::CommandBufferFull.is_retryable());
         assert!(ViscaError::Timeout.is_retryable());
 
@@ -259,10 +262,11 @@ mod tests {
             Some(Duration::from_millis(500))
         );
         assert_eq!(
-            ViscaError::CommandTimeout { 
-                duration: Duration::from_secs(5), 
-                command: "test".to_string() 
-            }.suggested_retry_delay(),
+            ViscaError::CommandTimeout {
+                duration: Duration::from_secs(5),
+                command: "test".to_string()
+            }
+            .suggested_retry_delay(),
             Some(Duration::from_secs(1))
         );
         assert_eq!(
@@ -276,6 +280,9 @@ mod tests {
 
         // Errors without retry delays
         assert_eq!(ViscaError::SyntaxError.suggested_retry_delay(), None);
-        assert_eq!(ViscaError::InvalidParameter("test".to_string()).suggested_retry_delay(), None);
+        assert_eq!(
+            ViscaError::InvalidParameter("test".to_string()).suggested_retry_delay(),
+            None
+        );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,53 @@
 use std::io;
+use std::time::Duration;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ViscaError {
+    // Connection errors
+    #[error("Connection failed to {addr}: {source}")]
+    ConnectionFailed { addr: String, source: io::Error },
+    
+    #[error("Connection lost: {reason}")]
+    ConnectionLost { reason: String },
+    
+    #[error("Command timeout after {duration:?} for command: {command}")]
+    CommandTimeout { duration: Duration, command: String },
+    
+    // Camera state errors
+    #[error("Camera is busy executing another command")]
+    CameraBusy,
+    
+    #[error("Camera is still moving, position: pan={pan}, tilt={tilt}")]
+    CameraMoving { pan: i16, tilt: i16 },
+    
+    #[error("Camera not initialized")]
+    CameraNotReady,
+    
+    // Protocol errors
+    #[error("Invalid response: expected {expected}, got {actual:?}")]
+    InvalidResponse { expected: String, actual: Vec<u8> },
+    
+    #[error("Command rejected by camera: {reason}")]
+    CommandRejected { reason: String },
+    
+    // Value errors
+    #[error("Value {value} out of range [{min}, {max}] for {parameter}")]
+    OutOfRange { 
+        value: i32, 
+        min: i32, 
+        max: i32, 
+        parameter: String 
+    },
+    
+    #[error("Preset {id} not found")]
+    PresetNotFound { id: u8 },
+    
+    // Feature errors
+    #[error("Feature '{feature}' not supported by this camera model")]
+    FeatureNotSupported { feature: String },
+
+    // Legacy errors (keeping for backward compatibility)
     #[error("IO error: {0}")]
     Io(#[from] io::Error),
 
@@ -55,6 +100,27 @@ impl ViscaError {
             0x05 => ViscaError::NoSocket,
             0x41 => ViscaError::CommandNotExecutable,
             _ => ViscaError::Unknown(code),
+        }
+    }
+
+    pub fn is_retryable(&self) -> bool {
+        matches!(self, 
+            ViscaError::CameraBusy | 
+            ViscaError::CameraMoving { .. } |
+            ViscaError::CommandTimeout { .. } |
+            ViscaError::CommandBufferFull |
+            ViscaError::Timeout
+        )
+    }
+    
+    pub fn suggested_retry_delay(&self) -> Option<Duration> {
+        match self {
+            ViscaError::CameraBusy => Some(Duration::from_millis(100)),
+            ViscaError::CameraMoving { .. } => Some(Duration::from_millis(500)),
+            ViscaError::CommandTimeout { .. } => Some(Duration::from_secs(1)),
+            ViscaError::CommandBufferFull => Some(Duration::from_millis(200)),
+            ViscaError::Timeout => Some(Duration::from_secs(2)),
+            _ => None,
         }
     }
 }
@@ -160,5 +226,56 @@ mod tests {
         let visca_err = ViscaError::SyntaxError;
         let app_err = AppError::from(visca_err);
         assert!(matches!(app_err, AppError::Visca(ViscaError::SyntaxError)));
+    }
+
+    #[test]
+    fn test_is_retryable() {
+        // Retryable errors
+        assert!(ViscaError::CameraBusy.is_retryable());
+        assert!(ViscaError::CameraMoving { pan: 100, tilt: 50 }.is_retryable());
+        assert!(ViscaError::CommandTimeout { 
+            duration: Duration::from_secs(5), 
+            command: "test".to_string() 
+        }.is_retryable());
+        assert!(ViscaError::CommandBufferFull.is_retryable());
+        assert!(ViscaError::Timeout.is_retryable());
+
+        // Non-retryable errors
+        assert!(!ViscaError::SyntaxError.is_retryable());
+        assert!(!ViscaError::CommandNotExecutable.is_retryable());
+        assert!(!ViscaError::InvalidParameter("test".to_string()).is_retryable());
+        assert!(!ViscaError::PresetNotFound { id: 1 }.is_retryable());
+    }
+
+    #[test]
+    fn test_suggested_retry_delay() {
+        // Errors with retry delays
+        assert_eq!(
+            ViscaError::CameraBusy.suggested_retry_delay(),
+            Some(Duration::from_millis(100))
+        );
+        assert_eq!(
+            ViscaError::CameraMoving { pan: 100, tilt: 50 }.suggested_retry_delay(),
+            Some(Duration::from_millis(500))
+        );
+        assert_eq!(
+            ViscaError::CommandTimeout { 
+                duration: Duration::from_secs(5), 
+                command: "test".to_string() 
+            }.suggested_retry_delay(),
+            Some(Duration::from_secs(1))
+        );
+        assert_eq!(
+            ViscaError::CommandBufferFull.suggested_retry_delay(),
+            Some(Duration::from_millis(200))
+        );
+        assert_eq!(
+            ViscaError::Timeout.suggested_retry_delay(),
+            Some(Duration::from_secs(2))
+        );
+
+        // Errors without retry delays
+        assert_eq!(ViscaError::SyntaxError.suggested_retry_delay(), None);
+        assert_eq!(ViscaError::InvalidParameter("test".to_string()).suggested_retry_delay(), None);
     }
 }


### PR DESCRIPTION
## Summary
- Enhanced ViscaError enum with specific error variants for better error handling
- Added retry logic helpers to identify transient errors

## Fixes #9

## Changes

### New Error Variants
- **Connection errors**: ConnectionFailed, ConnectionLost, CommandTimeout
- **Camera state errors**: CameraBusy, CameraMoving, CameraNotReady  
- **Protocol errors**: InvalidResponse, CommandRejected
- **Value errors**: OutOfRange, PresetNotFound
- **Feature errors**: FeatureNotSupported

### Helper Methods
- `is_retryable()`: Identifies which errors are transient and worth retrying
- `suggested_retry_delay()`: Provides appropriate retry delays for different error types

### Benefits
1. **Better Error Handling**: Applications can handle specific error conditions appropriately
2. **Retry Logic**: Clear guidance on which errors are transient
3. **Debugging**: Much easier to diagnose issues in production
4. **User Experience**: Can provide meaningful error messages to end users

## Test plan
- [x] All existing tests pass
- [x] Added tests for new is_retryable() method
- [x] Added tests for suggested_retry_delay() method
- [x] Maintained backward compatibility with existing error variants