### PR TITLE
Phase A: Transport Foundations for v0.4.0 API Refactoring

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,11 +68,11 @@ jobs:
         run: cargo test --all-features --verbose
       
       # Test individual features
-      - name: Test sync feature only
-        run: cargo test --no-default-features --features sync --verbose
+      - name: Test blocking-client feature only
+        run: cargo test --no-default-features --features blocking-client --verbose
       
-      - name: Test async feature only
-        run: cargo test --no-default-features --features async --verbose
+      - name: Test async-client feature only
+        run: cargo test --no-default-features --features async-client --verbose
       
       # Build examples (only on stable)
       - name: Build examples
@@ -80,7 +80,7 @@ jobs:
         run: |
           cargo build --example hello_visca
           cargo build --example demo
-          cargo build --example async_concurrent --features async
+          cargo build --example async_concurrent --features async-client
 
   # Combined lint and doc check
   lint-and-docs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,45 @@ required-features = ["async-client"]
 name = "async_configurable_timeouts"
 required-features = ["async-client"]
 
+
+[[example]]
+name = "thread_safe_client"
+required-features = ["blocking-client"]
+
+[[example]]
+name = "configurable_timeouts"
+required-features = ["blocking-client"]
+
+[[example]]
+name = "connection_pool"
+required-features = ["blocking-client", "pool"]
+
+[[example]]
+name = "control_demo"
+required-features = ["blocking-client"]
+
+[[example]]
+name = "demo"
+required-features = ["blocking-client"]
+
+[[example]]
+name = "health_check"
+required-features = ["blocking-client"]
+
+[[example]]
+name = "hello_visca"
+required-features = ["blocking-client"]
+
+[[example]]
+name = "inquiry_demo"
+required-features = ["blocking-client"]
+
+[[example]]
+name = "phase_a_test"
+
+[[example]]
+name = "position_conversion"
+
+[[example]]
+name = "reconnecting_transport"
+required-features = ["blocking-client", "reconnect"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,12 @@ exclude = ["target/", ".gitignore", ".github/", ".vscode/"]
 readme = "README.md"
 
 [features]
-default = ["sync"]
-sync = []
-async = ["tokio", "futures"]
-full = ["sync", "async"]
+default = ["blocking-client"]
+blocking-client = []
+async-client = ["tokio", "futures"]
+reconnect = []
+pool = []
+macros = []
 
 [dependencies]
 log = "0.4.22"
@@ -35,25 +37,29 @@ tokio-test = "0.4"
 
 [[example]]
 name = "async_concurrent"
-required-features = ["async"]
+required-features = ["async-client"]
 
 [[example]]
 name = "async_connection_pool"
-required-features = ["async"]
+required-features = ["async-client", "pool"]
 
 [[example]]
 name = "async_health_check"
-required-features = ["async"]
+required-features = ["async-client"]
 
 [[example]]
 name = "async_reconnecting"
-required-features = ["async"]
+required-features = ["async-client", "reconnect"]
 
 [[example]]
 name = "async_inquiry_demo"
-required-features = ["async"]
+required-features = ["async-client"]
 
 [[example]]
 name = "async_control_demo"
-required-features = ["async"]
+required-features = ["async-client"]
+
+[[example]]
+name = "async_configurable_timeouts"
+required-features = ["async-client"]
 

--- a/docs/REFACTORING_PLAN.md
+++ b/docs/REFACTORING_PLAN.md
@@ -1,0 +1,72 @@
+# v0.4.0 API Refactoring Plan
+
+This document outlines the PR structure for the v0.4.0 API refactoring (#23).
+
+## PR Breakdown by Phase
+
+### Phase A: Foundations (PR #24)
+**Branch**: `feature/v0.4.0-phase-a-foundations`
+- A1: Define public crates & update feature flags in Cargo.toml
+- A2: Design new Transport traits (async-first with blocking adapter)
+- A3: Implement minimal UDP/TCP transports
+
+### Phase B: ViscaClient Implementation
+**Branch**: `feature/v0.4.0-phase-b-client`
+- B1: Define private `TransportVariant` enum
+- B2: Implement unified constructors
+- B3: Add semaphore-based concurrency control
+- B4: Implement blocking façade with smart runtime handling
+- B5: Implement async façade
+
+### Phase C: Command Layer
+**Branch**: `feature/v0.4.0-phase-c-commands`
+- C1: Design derive macro crate (`grafton-visca-macros`)
+- C2: Port existing commands to use macro
+- C3: Add validation hooks
+
+### Phase D: Ergonomic APIs
+**Branch**: `feature/v0.4.0-phase-d-ergonomics`
+- D1: Implement PTZ Builder with borrowed reference support
+- D2: Add concurrent/sequential dispatch methods
+- D3: Create `AsyncViscaExt` blanket trait for common operations
+
+### Phase E: Error Handling
+**Branch**: `feature/v0.4.0-phase-e-errors`
+- E1: Finalize `ViscaError` enum design
+- E2: Implement `ViscaResultExt` trait with retry helpers
+
+### Phase F: Feature Modules
+**Branch**: `feature/v0.4.0-phase-f-features`
+- F1: Reconnecting transport decorator (behind `reconnect` flag)
+- F2: Connection pool (behind `pool` flag)
+
+### Phase G: Quality Assurance
+**Branch**: `feature/v0.4.0-phase-g-qa`
+- G1: Comprehensive unit tests
+- G2: Documentation and examples
+- G3: Enforce `#![deny(missing_docs)]` and Clippy lints
+- G4: CI matrix for feature combinations
+
+## Development Workflow
+
+1. Each phase gets its own feature branch and PR
+2. PRs should be kept focused on their phase's tasks
+3. Each PR should maintain backward compatibility where possible
+4. Breaking changes should be clearly documented
+5. PRs can be merged incrementally as long as they don't break main
+
+## Review Guidelines
+
+- Each PR should compile under all feature combinations
+- Tests should pass for the implemented functionality
+- Documentation should be updated for new APIs
+- Examples should be updated/added as needed
+
+## Dependencies Between Phases
+
+- Phase B depends on Phase A (Transport traits)
+- Phase C can start in parallel with B
+- Phase D depends on B and C
+- Phase E can start early but needs B for integration
+- Phase F depends on A, B
+- Phase G depends on all others

--- a/examples/async_configurable_timeouts.rs
+++ b/examples/async_configurable_timeouts.rs
@@ -1,18 +1,18 @@
 //! Example demonstrating configurable timeouts for different command types with async transports.
 //!
-//! Run with: cargo run --example async_configurable_timeouts --features async
+//! Run with: cargo run --example async_configurable_timeouts --features async-client
 //!
 //! This example shows how to use the TimeoutConfig to set different timeout
 //! durations for various categories of VISCA commands when using async transports,
 //! allowing fine-tuned control over command execution timeouts.
 
-#[cfg(not(feature = "async"))]
+#[cfg(not(feature = "async-client"))]
 fn main() {
     eprintln!("This example requires the 'async' feature. Run with:");
-    eprintln!("cargo run --example async_configurable_timeouts --features async");
+    eprintln!("cargo run --example async_configurable_timeouts --features async-client");
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use grafton_visca::{
     async_transport::AsyncViscaTransport,
     command::{
@@ -23,14 +23,14 @@ use grafton_visca::{
     },
     AsyncUdpTransport, TimeoutConfigBuilder, ViscaCommand, ViscaError, ViscaResponse,
 };
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use std::error::Error;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use std::net::ToSocketAddrs;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use std::time::Duration;
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
@@ -75,7 +75,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 async fn demonstrate_quick_command(
     transport: &mut dyn AsyncViscaTransport,
 ) -> Result<(), Box<dyn Error>> {
@@ -102,7 +102,7 @@ async fn demonstrate_quick_command(
     Ok(())
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 async fn demonstrate_movement_command(
     transport: &mut dyn AsyncViscaTransport,
 ) -> Result<(), Box<dyn Error>> {
@@ -140,7 +140,7 @@ async fn demonstrate_movement_command(
     Ok(())
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 async fn demonstrate_preset_command(
     transport: &mut dyn AsyncViscaTransport,
 ) -> Result<(), Box<dyn Error>> {
@@ -170,7 +170,7 @@ async fn demonstrate_preset_command(
 }
 
 /// Helper function to send a command and wait for the appropriate response
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 async fn send_and_wait_async(
     transport: &mut dyn AsyncViscaTransport,
     command: &dyn ViscaCommand,
@@ -230,7 +230,7 @@ async fn send_and_wait_async(
     }
 }
 
-#[cfg(all(test, feature = "async"))]
+#[cfg(all(test, feature = "async-client"))]
 mod tests {
     use super::*;
     use grafton_visca::{CommandCategory, TimeoutConfigBuilder};

--- a/examples/async_health_check.rs
+++ b/examples/async_health_check.rs
@@ -1,17 +1,17 @@
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use grafton_visca::command::power::Power;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use grafton_visca::command::{PanTiltCommand, PowerCommand};
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use grafton_visca::{
     AsyncConnectionManagement, AsyncTcpTransport, AsyncUdpTransport, AsyncViscaTransport,
 };
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use std::net::SocketAddr;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use tokio::time::{sleep, Duration};
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
@@ -126,8 +126,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(not(feature = "async"))]
+#[cfg(not(feature = "async-client"))]
 fn main() {
     eprintln!("This example requires the 'async' feature to be enabled.");
-    eprintln!("Try running with: cargo run --example async_health_check --features async");
+    eprintln!("Try running with: cargo run --example async_health_check --features async-client");
 }

--- a/examples/async_reconnecting.rs
+++ b/examples/async_reconnecting.rs
@@ -1,6 +1,6 @@
 //! Example demonstrating async auto-reconnecting transport functionality.
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use grafton_visca::{
     command::{
         pan_tilt::{PanSpeed, PanTiltCommand, PanTiltDirection, TiltSpeed},
@@ -10,16 +10,16 @@ use grafton_visca::{
     AsyncConnectionEvent, AsyncConnectionManagement, AsyncReconnectingTransport, AsyncTcpTransport,
     AsyncUdpTransport, AsyncViscaTransport, ReconnectionConfig, ViscaError,
 };
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use std::sync::atomic::{AtomicUsize, Ordering};
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use std::sync::{Arc, Mutex};
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use std::time::Duration;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use tokio::time::sleep;
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 async fn demo_async_udp_reconnection() -> Result<(), Box<dyn std::error::Error>> {
     use std::net::SocketAddr;
 
@@ -141,7 +141,7 @@ async fn demo_async_udp_reconnection() -> Result<(), Box<dyn std::error::Error>>
     Ok(())
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 async fn demo_async_tcp_reconnection() -> Result<(), Box<dyn std::error::Error>> {
     use std::net::SocketAddr;
 
@@ -219,7 +219,7 @@ async fn demo_async_tcp_reconnection() -> Result<(), Box<dyn std::error::Error>>
     Ok(())
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 async fn demo_async_event_monitoring() -> Result<(), Box<dyn std::error::Error>> {
     use std::net::SocketAddr;
 
@@ -354,8 +354,8 @@ async fn demo_async_event_monitoring() -> Result<(), Box<dyn std::error::Error>>
     Ok(())
 }
 
-#[cfg(not(feature = "async"))]
+#[cfg(not(feature = "async-client"))]
 fn main() {
     println!("This example requires the 'async' feature to be enabled.");
-    println!("Run with: cargo run --example async_reconnecting --features async");
+    println!("Run with: cargo run --example async_reconnecting --features async-client");
 }

--- a/examples/phase_a_test.rs
+++ b/examples/phase_a_test.rs
@@ -1,8 +1,7 @@
 //! Test example for Phase A transport implementation.
 
-// Access internal transport module for testing
-use grafton_visca::transport;
-use grafton_visca::{ViscaCommand, ViscaError};
+use grafton_visca::transport::{Transport, BlockingAdapter, UdpTransport};
+use grafton_visca::ViscaError;
 use grafton_visca::command::PowerCommand;
 use grafton_visca::command::power::Power;
 

--- a/examples/phase_a_test.rs
+++ b/examples/phase_a_test.rs
@@ -1,0 +1,43 @@
+//! Test example for Phase A transport implementation.
+
+// Access internal transport module for testing
+use grafton_visca::transport;
+use grafton_visca::{ViscaCommand, ViscaError};
+use grafton_visca::command::PowerCommand;
+use grafton_visca::command::power::Power;
+
+#[tokio::main]
+async fn main() -> Result<(), ViscaError> {
+    env_logger::init();
+
+    // Test blocking UDP transport through adapter
+    println!("Testing UDP transport with blocking adapter...");
+    let udp = UdpTransport::new("127.0.0.1:1234").map_err(|e| ViscaError::Io(e))?;
+    let mut udp_adapter = BlockingAdapter(udp);
+    
+    let cmd = PowerCommand { power: Power::On };
+    
+    // This would normally send the command, but will fail since no camera is connected
+    match udp_adapter.send_command(&cmd).await {
+        Ok(_) => println!("Command sent successfully"),
+        Err(e) => println!("Expected error (no camera): {}", e),
+    }
+
+    // Test async UDP transport
+    #[cfg(feature = "async-client")]
+    {
+        use grafton_visca::transport::AsyncUdpTransport;
+        
+        println!("\nTesting async UDP transport...");
+        let mut async_udp = AsyncUdpTransport::new("127.0.0.1:1234").await
+            .map_err(|e| ViscaError::Io(e))?;
+        
+        match async_udp.send_command(&cmd).await {
+            Ok(_) => println!("Command sent successfully"),
+            Err(e) => println!("Expected error (no camera): {}", e),
+        }
+    }
+
+    println!("\nPhase A transport implementation is working!");
+    Ok(())
+}

--- a/examples/phase_a_test.rs
+++ b/examples/phase_a_test.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<(), ViscaError> {
     {
         use grafton_visca::command::power::Power;
         use grafton_visca::command::PowerCommand;
-        use grafton_visca::transport::AsyncUdpTransport;
+        use grafton_visca::transport::{AsyncUdpTransport, Transport};
 
         println!("\nTesting async UDP transport...");
         let mut async_udp = AsyncUdpTransport::new("127.0.0.1:1234")

--- a/examples/phase_a_test.rs
+++ b/examples/phase_a_test.rs
@@ -1,9 +1,9 @@
 //! Test example for Phase A transport implementation.
 
-use grafton_visca::transport::{Transport, BlockingAdapter, UdpTransport};
-use grafton_visca::ViscaError;
-use grafton_visca::command::PowerCommand;
 use grafton_visca::command::power::Power;
+use grafton_visca::command::PowerCommand;
+use grafton_visca::transport::{BlockingAdapter, Transport, UdpTransport};
+use grafton_visca::ViscaError;
 
 #[tokio::main]
 async fn main() -> Result<(), ViscaError> {
@@ -13,9 +13,9 @@ async fn main() -> Result<(), ViscaError> {
     println!("Testing UDP transport with blocking adapter...");
     let udp = UdpTransport::new("127.0.0.1:1234").map_err(|e| ViscaError::Io(e))?;
     let mut udp_adapter = BlockingAdapter(udp);
-    
+
     let cmd = PowerCommand { power: Power::On };
-    
+
     // This would normally send the command, but will fail since no camera is connected
     match udp_adapter.send_command(&cmd).await {
         Ok(_) => println!("Command sent successfully"),
@@ -26,11 +26,12 @@ async fn main() -> Result<(), ViscaError> {
     #[cfg(feature = "async-client")]
     {
         use grafton_visca::transport::AsyncUdpTransport;
-        
+
         println!("\nTesting async UDP transport...");
-        let mut async_udp = AsyncUdpTransport::new("127.0.0.1:1234").await
+        let mut async_udp = AsyncUdpTransport::new("127.0.0.1:1234")
+            .await
             .map_err(|e| ViscaError::Io(e))?;
-        
+
         match async_udp.send_command(&cmd).await {
             Ok(_) => println!("Command sent successfully"),
             Err(e) => println!("Expected error (no camera): {}", e),
@@ -40,3 +41,4 @@ async fn main() -> Result<(), ViscaError> {
     println!("\nPhase A transport implementation is working!");
     Ok(())
 }
+

--- a/examples/phase_a_test.rs
+++ b/examples/phase_a_test.rs
@@ -1,7 +1,10 @@
 //! Test example for Phase A transport implementation.
 
+#[cfg(feature = "blocking-client")]
 use grafton_visca::command::power::Power;
+#[cfg(feature = "blocking-client")]
 use grafton_visca::command::PowerCommand;
+#[cfg(feature = "blocking-client")]
 use grafton_visca::transport::{BlockingAdapter, Transport, UdpTransport};
 use grafton_visca::ViscaError;
 
@@ -9,28 +12,35 @@ use grafton_visca::ViscaError;
 async fn main() -> Result<(), ViscaError> {
     env_logger::init();
 
-    // Test blocking UDP transport through adapter
-    println!("Testing UDP transport with blocking adapter...");
-    let udp = UdpTransport::new("127.0.0.1:1234").map_err(ViscaError::Io)?;
-    let mut udp_adapter = BlockingAdapter(udp);
+    #[cfg(feature = "blocking-client")]
+    {
+        // Test blocking UDP transport through adapter
+        println!("Testing UDP transport with blocking adapter...");
+        let udp = UdpTransport::new("127.0.0.1:1234").map_err(ViscaError::Io)?;
+        let mut udp_adapter = BlockingAdapter(udp);
 
-    let cmd = PowerCommand { power: Power::On };
+        let cmd = PowerCommand { power: Power::On };
 
-    // This would normally send the command, but will fail since no camera is connected
-    match udp_adapter.send_command(&cmd).await {
-        Ok(_) => println!("Command sent successfully"),
-        Err(e) => println!("Expected error (no camera): {}", e),
+        // This would normally send the command, but will fail since no camera is connected
+        match udp_adapter.send_command(&cmd).await {
+            Ok(_) => println!("Command sent successfully"),
+            Err(e) => println!("Expected error (no camera): {}", e),
+        }
     }
 
     // Test async UDP transport
     #[cfg(feature = "async-client")]
     {
+        use grafton_visca::command::power::Power;
+        use grafton_visca::command::PowerCommand;
         use grafton_visca::transport::AsyncUdpTransport;
 
         println!("\nTesting async UDP transport...");
         let mut async_udp = AsyncUdpTransport::new("127.0.0.1:1234")
             .await
             .map_err(ViscaError::Io)?;
+
+        let cmd = PowerCommand { power: Power::On };
 
         match async_udp.send_command(&cmd).await {
             Ok(_) => println!("Command sent successfully"),

--- a/examples/phase_a_test.rs
+++ b/examples/phase_a_test.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), ViscaError> {
 
     // Test blocking UDP transport through adapter
     println!("Testing UDP transport with blocking adapter...");
-    let udp = UdpTransport::new("127.0.0.1:1234").map_err(|e| ViscaError::Io(e))?;
+    let udp = UdpTransport::new("127.0.0.1:1234").map_err(ViscaError::Io)?;
     let mut udp_adapter = BlockingAdapter(udp);
 
     let cmd = PowerCommand { power: Power::On };
@@ -30,7 +30,7 @@ async fn main() -> Result<(), ViscaError> {
         println!("\nTesting async UDP transport...");
         let mut async_udp = AsyncUdpTransport::new("127.0.0.1:1234")
             .await
-            .map_err(|e| ViscaError::Io(e))?;
+            .map_err(ViscaError::Io)?;
 
         match async_udp.send_command(&cmd).await {
             Ok(_) => println!("Command sent successfully"),

--- a/examples/phase_a_test.rs
+++ b/examples/phase_a_test.rs
@@ -41,4 +41,3 @@ async fn main() -> Result<(), ViscaError> {
     println!("\nPhase A transport implementation is working!");
     Ok(())
 }
-

--- a/examples/thread_safe_client.rs
+++ b/examples/thread_safe_client.rs
@@ -3,7 +3,7 @@
 //! This example shows how to use ViscaClient to control a camera
 //! from multiple threads without needing RefCell or manual locking.
 
-#[cfg(not(all(feature = "sync", feature = "async")))]
+#[cfg(not(all(feature = "blocking-client", feature = "async-client")))]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     use grafton_visca::{
         command::{
@@ -132,7 +132,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(all(feature = "sync", feature = "async"))]
+#[cfg(all(feature = "blocking-client", feature = "async-client"))]
 fn main() {
     println!("This example requires the new ViscaClient which is not available when both sync and async features are enabled.");
     println!("Run with: cargo run --example thread_safe_client");

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -16,7 +16,7 @@ type ResponseSender = oneshot::Sender<Result<ViscaResponse, ViscaError>>;
 type PendingCommands = HashMap<u8, ResponseSender>;
 
 /// Async VISCA client for non-blocking camera control.
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 #[derive(Clone)]
 pub struct AsyncViscaClient {
     transport: Arc<Mutex<Box<dyn AsyncViscaTransport>>>,
@@ -26,7 +26,7 @@ pub struct AsyncViscaClient {
     shutdown: Arc<watch::Sender<()>>,
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 impl AsyncViscaClient {
     /// Connect to a camera using UDP transport.
     pub async fn connect_udp(camera_addr: &str) -> Result<Self, ViscaError> {

--- a/src/async_reconnecting_transport.rs
+++ b/src/async_reconnecting_transport.rs
@@ -1,35 +1,35 @@
 //! Async auto-reconnecting transport wrapper.
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use crate::{
     async_transport::{AsyncViscaTransport, TransportFuture},
     connection::{AsyncConnectionManagement, ConnectionStats},
     reconnecting_transport::ReconnectionConfig,
     ViscaCommand, ViscaError,
 };
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use std::future::Future;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use std::pin::Pin;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use std::sync::Arc;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use std::time::Instant;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use tokio::sync::RwLock;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use tokio::time::{sleep, Duration};
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 type CreateTransportFn<T> =
     Arc<dyn Fn() -> Pin<Box<dyn Future<Output = Result<T, ViscaError>> + Send>> + Send + Sync>;
 
 /// Connection/disconnection event callback
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 pub type ConnectionEventCallback = Arc<dyn Fn(ConnectionEvent) + Send + Sync>;
 
 /// Events that can occur during connection management
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 #[derive(Debug, Clone)]
 pub enum ConnectionEvent {
     /// Connection established successfully
@@ -45,7 +45,7 @@ pub enum ConnectionEvent {
 }
 
 /// Inner state for the async reconnecting transport
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 struct AsyncInnerState<T> {
     /// The underlying transport (None when disconnected)
     transport: Option<T>,
@@ -58,7 +58,7 @@ struct AsyncInnerState<T> {
 }
 
 /// Async version of the reconnecting transport wrapper.
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 pub struct AsyncReconnectingTransport<T> {
     /// All mutable state in a single RwLock for better performance
     inner: Arc<RwLock<AsyncInnerState<T>>>,
@@ -70,7 +70,7 @@ pub struct AsyncReconnectingTransport<T> {
     event_callback: Option<ConnectionEventCallback>,
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 impl<T> AsyncReconnectingTransport<T>
 where
     T: AsyncViscaTransport + AsyncConnectionManagement + Send + 'static,
@@ -264,7 +264,7 @@ where
     }
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 impl<T> AsyncViscaTransport for AsyncReconnectingTransport<T>
 where
     T: AsyncViscaTransport + AsyncConnectionManagement + Send + Sync + 'static,
@@ -374,7 +374,7 @@ where
     }
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 impl<T> AsyncConnectionManagement for AsyncReconnectingTransport<T>
 where
     T: AsyncViscaTransport + AsyncConnectionManagement + Send + Sync + 'static,
@@ -416,7 +416,7 @@ where
     }
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 impl<T> AsyncReconnectingTransport<T>
 where
     T: AsyncViscaTransport + AsyncConnectionManagement + Send + 'static,

--- a/src/async_tcp_transport.rs
+++ b/src/async_tcp_transport.rs
@@ -10,7 +10,7 @@ use tokio::time::{timeout, Duration};
 const MAX_BUFFER_SIZE: usize = 64 * 1024; // 64KB max buffer size
 
 /// Async TCP transport for VISCA over IP communication.
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 pub struct AsyncTcpTransport {
     stream: TcpStream,
     buffer: Vec<u8>,
@@ -20,7 +20,7 @@ pub struct AsyncTcpTransport {
     stats: ConnectionStats,
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 impl AsyncTcpTransport {
     /// Create a new async TCP transport.
     pub async fn new(camera_addr: SocketAddr) -> Result<Self, ViscaError> {
@@ -77,7 +77,7 @@ impl AsyncTcpTransport {
     }
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 impl AsyncViscaTransport for AsyncTcpTransport {
     fn send_command<'a>(&'a mut self, command: &'a dyn ViscaCommand) -> TransportFuture<'a, ()> {
         Box::pin(async move {
@@ -193,7 +193,7 @@ impl AsyncViscaTransport for AsyncTcpTransport {
     }
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 impl Drop for AsyncTcpTransport {
     fn drop(&mut self) {
         // Best effort to shutdown the TCP connection gracefully
@@ -203,7 +203,7 @@ impl Drop for AsyncTcpTransport {
     }
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 impl crate::AsyncConnectionManagement for AsyncTcpTransport {
     fn is_healthy(&mut self) -> TransportFuture<'_, bool> {
         Box::pin(async move {

--- a/src/async_transport.rs
+++ b/src/async_transport.rs
@@ -9,7 +9,7 @@ pub type TransportFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, ViscaErr
 ///
 /// This trait provides the async equivalent of ViscaTransport, allowing for
 /// concurrent command execution and non-blocking network operations.
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 pub trait AsyncViscaTransport: Send + Sync {
     /// Send a VISCA command to the camera asynchronously.
     fn send_command<'a>(&'a mut self, command: &'a dyn ViscaCommand) -> TransportFuture<'a, ()>;

--- a/src/async_udp_transport.rs
+++ b/src/async_udp_transport.rs
@@ -7,7 +7,7 @@ use tokio::net::UdpSocket;
 use tokio::time::{timeout, Duration};
 
 /// Async UDP transport for VISCA over IP communication.
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 pub struct AsyncUdpTransport {
     socket: UdpSocket,
     camera_addr: SocketAddr,
@@ -17,7 +17,7 @@ pub struct AsyncUdpTransport {
     stats: ConnectionStats,
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 impl AsyncUdpTransport {
     /// Create a new async UDP transport.
     pub async fn new(camera_addr: SocketAddr) -> Result<Self, ViscaError> {
@@ -70,7 +70,7 @@ impl AsyncUdpTransport {
     }
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 impl AsyncViscaTransport for AsyncUdpTransport {
     fn send_command<'a>(&'a mut self, command: &'a dyn ViscaCommand) -> TransportFuture<'a, ()> {
         Box::pin(async move {
@@ -143,7 +143,7 @@ impl AsyncViscaTransport for AsyncUdpTransport {
     }
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 impl Drop for AsyncUdpTransport {
     fn drop(&mut self) {
         // UDP sockets don't require explicit shutdown
@@ -152,7 +152,7 @@ impl Drop for AsyncUdpTransport {
     }
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 impl crate::AsyncConnectionManagement for AsyncUdpTransport {
     fn is_healthy(&mut self) -> TransportFuture<'_, bool> {
         Box::pin(async move {

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,7 +4,7 @@
 //! eliminating the need for RefCell in user code and enabling safe
 //! concurrent access from multiple threads.
 
-#![cfg(not(all(feature = "sync", feature = "async")))]
+#![cfg(all(feature = "blocking-client", not(feature = "async-client")))]
 
 use crate::{send_command_and_wait, ViscaCommand, ViscaError, ViscaResponse, ViscaTransport};
 use std::sync::{Arc, Mutex};

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -235,11 +235,11 @@ pub trait ConnectionManagement {
     fn connection_stats(&self) -> &ConnectionStats;
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use crate::async_transport::TransportFuture;
 
 /// Async version of the connection management trait
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 pub trait AsyncConnectionManagement: Send + Sync {
     /// Check if the connection is healthy by sending a simple inquiry
     fn is_healthy(&mut self) -> TransportFuture<'_, bool>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //! ### Using ViscaClient (Recommended for Thread Safety)
 //!
 //! ```no_run
-//! # #[cfg(feature = "blocking-client")]
+//! # #[cfg(all(feature = "blocking-client", not(feature = "async-client")))]
 //! # {
 //! use grafton_visca::{ViscaClient, UdpTransport};
 //! use grafton_visca::command::{PanTiltCommand, ZoomCommand};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //! ### Using ViscaClient (Recommended for Thread Safety)
 //!
 //! ```no_run
-//! # #[cfg(not(all(feature = "sync", feature = "async")))]
+//! # #[cfg(feature = "blocking-client")]
 //! # {
 //! use grafton_visca::{ViscaClient, UdpTransport};
 //! use grafton_visca::command::{PanTiltCommand, ZoomCommand};
@@ -97,7 +97,7 @@
 //! The library provides async support for non-blocking camera control:
 //!
 //! ```no_run
-//! # #[cfg(feature = "async")]
+//! # #[cfg(feature = "async-client")]
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! use grafton_visca::{AsyncViscaClient, ViscaResponse};
 //! use grafton_visca::command::{PanTiltCommand, ZoomCommand};
@@ -209,6 +209,14 @@ pub use command::{
 
 pub mod constants;
 
+pub mod transport;
+// Temporarily commenting out to avoid naming conflicts with old transport impls
+// #[cfg(feature = "blocking-client")]
+// pub use transport::{TcpTransport, UdpTransport};
+// #[cfg(feature = "async-client")]
+// pub use transport::{AsyncTcpTransport, AsyncUdpTransport};
+// pub use transport::Transport;
+
 mod camera_detection;
 pub use camera_detection::detect_camera_model;
 
@@ -240,19 +248,19 @@ pub use focus_ext::ViscaFocusExt;
 mod preset_ext;
 pub use preset_ext::ViscaPresetExt;
 
-#[cfg(not(all(feature = "sync", feature = "async")))]
+#[cfg(all(feature = "blocking-client", not(feature = "async-client")))]
 mod client;
-#[cfg(not(all(feature = "sync", feature = "async")))]
+#[cfg(all(feature = "blocking-client", not(feature = "async-client")))]
 pub use client::ViscaClient;
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 mod async_inquiry_ext;
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 mod async_control_ext;
 
 pub mod connection;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 pub use connection::AsyncConnectionManagement;
 pub use connection::{ConnectionManagement, ConnectionStats, ConnectionStatsSnapshot};
 
@@ -266,42 +274,42 @@ pub use connection_pool::{
     CameraInfo, PoolConfig, PooledCameraStats, PooledConnectionGuard, ViscaConnectionPool,
 };
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 mod async_reconnecting_transport;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 pub use async_reconnecting_transport::{
     AsyncReconnectingTransport, ConnectionEvent as AsyncConnectionEvent,
 };
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 mod async_connection_pool;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 pub use async_connection_pool::{
     AsyncPoolConfig, AsyncPooledCameraStats, AsyncPooledConnectionGuard, AsyncViscaConnectionPool,
     CameraInfo as AsyncCameraInfo,
 };
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 mod async_client;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 mod async_tcp_transport;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 pub mod async_transport;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 mod async_udp_transport;
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 pub use async_client::AsyncViscaClient;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 pub use async_tcp_transport::AsyncTcpTransport;
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 pub use async_transport::{AsyncViscaTransport, TransportFuture};
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 pub use async_udp_transport::AsyncUdpTransport;
 
-#[cfg(all(feature = "sync", feature = "async"))]
+#[cfg(all(feature = "blocking-client", feature = "async-client"))]
 mod sync_wrapper;
-#[cfg(all(feature = "sync", feature = "async"))]
+#[cfg(all(feature = "blocking-client", feature = "async-client"))]
 pub use sync_wrapper::{send_command_and_wait_compat, ViscaClient};
 
 pub mod timeout;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,13 +209,11 @@ pub use command::{
 
 pub mod constants;
 
+// New v0.4.0 transport module - will replace the implementations below in Phase B
 pub mod transport;
-// Temporarily commenting out to avoid naming conflicts with old transport impls
-// #[cfg(feature = "blocking-client")]
-// pub use transport::{TcpTransport, UdpTransport};
-// #[cfg(feature = "async-client")]
-// pub use transport::{AsyncTcpTransport, AsyncUdpTransport};
-// pub use transport::Transport;
+// NOTE: Not exporting new transports yet to avoid breaking changes.
+// The old UdpTransport and TcpTransport below are still in use throughout
+// the codebase. They will be replaced with the new transport module in Phase B.
 
 mod camera_detection;
 pub use camera_detection::detect_camera_model;
@@ -320,6 +318,9 @@ pub use timeout::{CommandCategory, TimeoutConfig, TimeoutConfigBuilder};
 /// This trait abstracts the underlying transport mechanism (UDP or TCP) and provides
 /// a uniform interface for VISCA communication.
 ///
+/// **Note**: This trait will be replaced by `transport::Transport` in v0.4.0.
+/// New code should prepare for the migration.
+///
 /// # Example
 /// ```no_run
 /// # use grafton_visca::{ViscaTransport, UdpTransport, ViscaCommand, ViscaError};
@@ -359,6 +360,8 @@ pub trait ViscaTransport {
 ///
 /// This transport uses UDP sockets for communication with VISCA cameras.
 /// It binds to an ephemeral local port and sends commands to the specified camera address.
+///
+/// **Note**: This implementation will be replaced by `transport::UdpTransport` in v0.4.0.
 ///
 /// # Example
 /// ```no_run
@@ -436,6 +439,8 @@ impl UdpTransport {
 ///
 /// This transport uses TCP sockets for reliable communication with VISCA cameras.
 /// It maintains a persistent connection to the camera.
+///
+/// **Note**: This implementation will be replaced by `transport::TcpTransport` in v0.4.0.
 ///
 /// # Example
 /// ```no_run

--- a/src/sync_wrapper.rs
+++ b/src/sync_wrapper.rs
@@ -1,19 +1,19 @@
 use crate::{ViscaCommand, ViscaError, ViscaResponse};
 
-#[cfg(feature = "async")]
+#[cfg(feature = "async-client")]
 use crate::async_client::AsyncViscaClient;
 
 /// Synchronous VISCA client wrapper around the async implementation.
 ///
 /// This provides a blocking API for users who don't need async functionality.
 /// Internally, it manages a tokio runtime to execute async operations.
-#[cfg(all(feature = "sync", feature = "async"))]
+#[cfg(all(feature = "blocking-client", feature = "async-client"))]
 pub struct ViscaClient {
     runtime: tokio::runtime::Runtime,
     async_client: AsyncViscaClient,
 }
 
-#[cfg(all(feature = "sync", feature = "async"))]
+#[cfg(all(feature = "blocking-client", feature = "async-client"))]
 impl ViscaClient {
     /// Connect to a camera using UDP transport (blocking).
     pub fn connect_udp(camera_addr: &str) -> Result<Self, ViscaError> {
@@ -61,7 +61,7 @@ impl ViscaClient {
     }
 }
 
-#[cfg(all(feature = "sync", feature = "async"))]
+#[cfg(all(feature = "blocking-client", feature = "async-client"))]
 impl Drop for ViscaClient {
     fn drop(&mut self) {
         // The runtime will be dropped automatically, which will:
@@ -77,7 +77,7 @@ impl Drop for ViscaClient {
 /// This function provides the same interface as the original `send_command_and_wait`
 /// but uses the new async implementation internally when both sync and async features
 /// are enabled.
-#[cfg(all(feature = "sync", feature = "async"))]
+#[cfg(all(feature = "blocking-client", feature = "async-client"))]
 pub fn send_command_and_wait_compat(
     camera_addr: &str,
     command: &dyn ViscaCommand,

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -112,7 +112,7 @@ mod tests {
             }
             
             fn command_category(&self) -> crate::timeout::CommandCategory {
-                crate::timeout::CommandCategory::Regular
+                crate::timeout::CommandCategory::Quick
             }
         }
         

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! # TODO for Phase B Integration
 //!
-//! The current implementation is minimal and missing several features from the 
+//! The current implementation is minimal and missing several features from the
 //! old transport implementations in lib.rs:
 //!
 //! 1. **TimeoutConfig support** - The old transports support configurable timeouts
@@ -99,23 +99,23 @@ mod tests {
     #[tokio::test]
     async fn test_blocking_adapter() {
         let mut adapter = BlockingAdapter(MockBlockingTransport);
-        
+
         // Test that we can use the blocking transport through the async interface
         struct DummyCommand;
         impl ViscaCommand for DummyCommand {
             fn to_bytes(&self) -> Result<Vec<u8>, ViscaError> {
                 Ok(vec![0x81, 0x01, 0x04, 0x00, 0x02, 0xFF])
             }
-            
+
             fn response_type(&self) -> Option<crate::command::ViscaResponseType> {
                 None
             }
-            
+
             fn command_category(&self) -> crate::timeout::CommandCategory {
                 crate::timeout::CommandCategory::Quick
             }
         }
-        
+
         let cmd = DummyCommand;
         adapter.send_command(&cmd).await.unwrap();
         let responses = adapter.receive_response().await.unwrap();
@@ -123,3 +123,4 @@ mod tests {
         assert_eq!(responses[0], vec![0x90, 0x50, 0xFF]);
     }
 }
+

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -123,4 +123,3 @@ mod tests {
         assert_eq!(responses[0], vec![0x90, 0x50, 0xFF]);
     }
 }
-

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,0 +1,111 @@
+//! Unified transport layer for VISCA communication.
+//!
+//! This module provides the core transport abstractions for the v0.4.0 API,
+//! featuring an async-first design with optional blocking adapters.
+
+mod tcp;
+mod udp;
+
+#[cfg(feature = "blocking-client")]
+pub use tcp::TcpTransport;
+#[cfg(feature = "blocking-client")]
+pub use udp::UdpTransport;
+
+#[cfg(feature = "async-client")]
+pub use tcp::AsyncTcpTransport;
+#[cfg(feature = "async-client")]
+pub use udp::AsyncUdpTransport;
+
+use crate::{ViscaCommand, ViscaError};
+use std::future::Future;
+use std::pin::Pin;
+
+/// Type alias for the future returned by async transport methods
+pub type TransportFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, ViscaError>> + Send + 'a>>;
+
+/// Primary async transport trait for VISCA communication.
+///
+/// This is the main transport abstraction in v0.4.0, designed to be async-first
+/// while supporting blocking operations through adapters.
+pub trait Transport: Send + Sync {
+    /// Send a VISCA command to the camera asynchronously.
+    fn send_command<'a>(&'a mut self, command: &'a dyn ViscaCommand) -> TransportFuture<'a, ()>;
+
+    /// Receive response frames from the camera asynchronously.
+    ///
+    /// Returns a vector of response frames that have been received.
+    /// Each frame is a complete VISCA response (starts with 0x90 and ends with 0xFF).
+    fn receive_response(&mut self) -> TransportFuture<'_, Vec<Vec<u8>>>;
+}
+
+/// Trait for blocking transport implementations.
+///
+/// This trait provides the blocking interface that can be adapted to the async Transport trait.
+#[doc(hidden)]
+pub trait BlockingTransport {
+    /// Send a VISCA command to the camera synchronously.
+    fn send_command_blocking(&mut self, command: &dyn ViscaCommand) -> Result<(), ViscaError>;
+
+    /// Receive response frames from the camera synchronously.
+    fn receive_response_blocking(&mut self) -> Result<Vec<Vec<u8>>, ViscaError>;
+}
+
+/// Adapter that implements the async Transport trait for any BlockingTransport.
+///
+/// This allows blocking implementations to be used through the async interface.
+#[doc(hidden)]
+pub struct BlockingAdapter<T: BlockingTransport>(pub T);
+
+impl<T: BlockingTransport + Send + Sync> Transport for BlockingAdapter<T> {
+    fn send_command<'a>(&'a mut self, command: &'a dyn ViscaCommand) -> TransportFuture<'a, ()> {
+        Box::pin(async move { self.0.send_command_blocking(command) })
+    }
+
+    fn receive_response(&mut self) -> TransportFuture<'_, Vec<Vec<u8>>> {
+        Box::pin(async move { self.0.receive_response_blocking() })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockBlockingTransport;
+
+    impl BlockingTransport for MockBlockingTransport {
+        fn send_command_blocking(&mut self, _command: &dyn ViscaCommand) -> Result<(), ViscaError> {
+            Ok(())
+        }
+
+        fn receive_response_blocking(&mut self) -> Result<Vec<Vec<u8>>, ViscaError> {
+            Ok(vec![vec![0x90, 0x50, 0xFF]])
+        }
+    }
+
+    #[tokio::test]
+    async fn test_blocking_adapter() {
+        let mut adapter = BlockingAdapter(MockBlockingTransport);
+        
+        // Test that we can use the blocking transport through the async interface
+        struct DummyCommand;
+        impl ViscaCommand for DummyCommand {
+            fn to_bytes(&self) -> Result<Vec<u8>, ViscaError> {
+                Ok(vec![0x81, 0x01, 0x04, 0x00, 0x02, 0xFF])
+            }
+            
+            fn response_type(&self) -> Option<crate::command::ViscaResponseType> {
+                None
+            }
+            
+            fn command_category(&self) -> crate::timeout::CommandCategory {
+                crate::timeout::CommandCategory::Regular
+            }
+        }
+        
+        let cmd = DummyCommand;
+        adapter.send_command(&cmd).await.unwrap();
+        let responses = adapter.receive_response().await.unwrap();
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0], vec![0x90, 0x50, 0xFF]);
+    }
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -56,6 +56,7 @@ pub trait Transport: Send + Sync {
 ///
 /// This trait provides the blocking interface that can be adapted to the async Transport trait.
 #[doc(hidden)]
+#[cfg(feature = "blocking-client")]
 pub trait BlockingTransport {
     /// Send a VISCA command to the camera synchronously.
     fn send_command_blocking(&mut self, command: &dyn ViscaCommand) -> Result<(), ViscaError>;
@@ -68,8 +69,10 @@ pub trait BlockingTransport {
 ///
 /// This allows blocking implementations to be used through the async interface.
 #[doc(hidden)]
+#[cfg(feature = "blocking-client")]
 pub struct BlockingAdapter<T: BlockingTransport>(pub T);
 
+#[cfg(feature = "blocking-client")]
 impl<T: BlockingTransport + Send + Sync> Transport for BlockingAdapter<T> {
     fn send_command<'a>(&'a mut self, command: &'a dyn ViscaCommand) -> TransportFuture<'a, ()> {
         Box::pin(async move { self.0.send_command_blocking(command) })
@@ -80,7 +83,7 @@ impl<T: BlockingTransport + Send + Sync> Transport for BlockingAdapter<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "blocking-client"))]
 mod tests {
     use super::*;
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -2,6 +2,20 @@
 //!
 //! This module provides the core transport abstractions for the v0.4.0 API,
 //! featuring an async-first design with optional blocking adapters.
+//!
+//! # TODO for Phase B Integration
+//!
+//! The current implementation is minimal and missing several features from the 
+//! old transport implementations in lib.rs:
+//!
+//! 1. **TimeoutConfig support** - The old transports support configurable timeouts
+//!    per command category (Quick, Movement, Preset, LongRunning)
+//! 2. **ConnectionManagement trait** - Health checking with cached results
+//! 3. **parse_response function** - Shared response parsing logic
+//! 4. **More constructors** - `with_timeout_config()` and other variants
+//!
+//! These features will be integrated in Phase B when we replace the old
+//! ViscaTransport trait with the new Transport trait.
 
 mod tcp;
 mod udp;

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -60,13 +60,11 @@ impl BlockingTransport for TcpTransport {
     fn send_command_blocking(&mut self, command: &dyn ViscaCommand) -> Result<(), ViscaError> {
         let bytes = command.to_bytes()?;
         log::debug!("Sending command: {:02X?}", bytes);
-        
-        self.stream
-            .write_all(&bytes)
-            .map_err(ViscaError::Io)?;
-        
+
+        self.stream.write_all(&bytes).map_err(ViscaError::Io)?;
+
         self.stream.flush().map_err(ViscaError::Io)?;
-        
+
         self.stats.record_sent(bytes.len());
         Ok(())
     }
@@ -75,7 +73,7 @@ impl BlockingTransport for TcpTransport {
         let mut buffer = [0u8; 1024];
         let mut responses = Vec::new();
         let mut current_response = Vec::new();
-        
+
         // Keep receiving until we get a completion or error response
         loop {
             match self.stream.read(&mut buffer) {
@@ -83,29 +81,32 @@ impl BlockingTransport for TcpTransport {
                     self.stats.record_error();
                     return Err(ViscaError::Io(io::Error::new(
                         io::ErrorKind::UnexpectedEof,
-                        "Connection closed by camera"
+                        "Connection closed by camera",
                     )));
                 }
                 Ok(size) => {
                     for &byte in &buffer[..size] {
                         current_response.push(byte);
-                        
+
                         // Check for end of VISCA frame
-                        if byte == 0xFF && current_response.len() >= 3 && 
-                           current_response[0] == 0x90 {
+                        if byte == 0xFF
+                            && current_response.len() >= 3
+                            && current_response[0] == 0x90
+                        {
                             log::debug!("Received response: {:02X?}", current_response);
-                            
+
                             self.stats.record_received(current_response.len());
                             responses.push(current_response.clone());
-                            
+
                             // Check for completion or error
-                            if current_response.len() >= 3 && 
-                               (current_response[1] == 0x50 || 
-                                current_response[1] == 0x51 || 
-                                (current_response[1] & 0x60) == 0x60) {
+                            if current_response.len() >= 3
+                                && (current_response[1] == 0x50
+                                    || current_response[1] == 0x51
+                                    || (current_response[1] & 0x60) == 0x60)
+                            {
                                 return Ok(responses);
                             }
-                            
+
                             current_response.clear();
                         }
                     }
@@ -113,9 +114,9 @@ impl BlockingTransport for TcpTransport {
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
                     if responses.is_empty() && current_response.is_empty() {
                         self.stats.record_error();
-                        return Err(ViscaError::CommandTimeout { 
-                            duration: Duration::from_secs(10), 
-                            command: "receive_response".to_string() 
+                        return Err(ViscaError::CommandTimeout {
+                            duration: Duration::from_secs(10),
+                            command: "receive_response".to_string(),
                         });
                     }
                     if !current_response.is_empty() {
@@ -123,7 +124,7 @@ impl BlockingTransport for TcpTransport {
                         self.stats.record_error();
                         return Err(ViscaError::Io(io::Error::new(
                             io::ErrorKind::InvalidData,
-                            "Incomplete VISCA frame"
+                            "Incomplete VISCA frame",
                         )));
                     }
                     return Ok(responses);
@@ -167,14 +168,14 @@ impl Transport for AsyncTcpTransport {
         Box::pin(async move {
             let bytes = command.to_bytes()?;
             log::debug!("Sending command: {:02X?}", bytes);
-            
+
             self.stream
                 .write_all(&bytes)
                 .await
                 .map_err(ViscaError::Io)?;
-            
+
             self.stream.flush().await.map_err(ViscaError::Io)?;
-            
+
             self.stats.record_sent(bytes.len());
             Ok(())
         })
@@ -185,40 +186,42 @@ impl Transport for AsyncTcpTransport {
             let mut buffer = [0u8; 1024];
             let mut responses = Vec::new();
             let mut current_response = Vec::new();
-            
+
             // Keep receiving until we get a completion or error response
             loop {
-                match tokio::time::timeout(
-                    Duration::from_secs(10),
-                    self.stream.read(&mut buffer)
-                ).await {
+                match tokio::time::timeout(Duration::from_secs(10), self.stream.read(&mut buffer))
+                    .await
+                {
                     Ok(Ok(0)) => {
                         self.stats.record_error();
                         return Err(ViscaError::Io(io::Error::new(
                             io::ErrorKind::UnexpectedEof,
-                            "Connection closed by camera"
+                            "Connection closed by camera",
                         )));
                     }
                     Ok(Ok(size)) => {
                         for &byte in &buffer[..size] {
                             current_response.push(byte);
-                            
+
                             // Check for end of VISCA frame
-                            if byte == 0xFF && current_response.len() >= 3 && 
-                               current_response[0] == 0x90 {
+                            if byte == 0xFF
+                                && current_response.len() >= 3
+                                && current_response[0] == 0x90
+                            {
                                 log::debug!("Received response: {:02X?}", current_response);
-                                
+
                                 self.stats.record_received(current_response.len());
                                 responses.push(current_response.clone());
-                                
+
                                 // Check for completion or error
-                                if current_response.len() >= 3 && 
-                                   (current_response[1] == 0x50 || 
-                                    current_response[1] == 0x51 || 
-                                    (current_response[1] & 0x60) == 0x60) {
+                                if current_response.len() >= 3
+                                    && (current_response[1] == 0x50
+                                        || current_response[1] == 0x51
+                                        || (current_response[1] & 0x60) == 0x60)
+                                {
                                     return Ok(responses);
                                 }
-                                
+
                                 current_response.clear();
                             }
                         }
@@ -230,17 +233,17 @@ impl Transport for AsyncTcpTransport {
                     Err(_) => {
                         if responses.is_empty() && current_response.is_empty() {
                             self.stats.record_error();
-                            return Err(ViscaError::CommandTimeout { 
-                            duration: Duration::from_secs(10), 
-                            command: "receive_response".to_string() 
-                        });
+                            return Err(ViscaError::CommandTimeout {
+                                duration: Duration::from_secs(10),
+                                command: "receive_response".to_string(),
+                            });
                         }
                         if !current_response.is_empty() {
                             // Incomplete frame
                             self.stats.record_error();
                             return Err(ViscaError::Io(io::Error::new(
                                 io::ErrorKind::InvalidData,
-                                "Incomplete VISCA frame"
+                                "Incomplete VISCA frame",
                             )));
                         }
                         return Ok(responses);
@@ -250,3 +253,4 @@ impl Transport for AsyncTcpTransport {
         })
     }
 }
+

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -1,11 +1,18 @@
 //! TCP transport implementation for VISCA over IP.
 
+#[cfg(feature = "blocking-client")]
 use super::BlockingTransport;
 #[cfg(feature = "async-client")]
 use super::{Transport, TransportFuture};
+#[cfg(any(feature = "blocking-client", feature = "async-client"))]
 use crate::{ConnectionStats, ViscaCommand, ViscaError};
-use std::io::{self, Read, Write};
+#[cfg(any(feature = "blocking-client", feature = "async-client"))]
+use std::io;
+#[cfg(feature = "blocking-client")]
+use std::io::{Read, Write};
+#[cfg(feature = "blocking-client")]
 use std::net::TcpStream;
+#[cfg(any(feature = "blocking-client", feature = "async-client"))]
 use std::time::Duration;
 
 #[cfg(feature = "async-client")]
@@ -14,11 +21,13 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream as TokioTcpStream;
 
 /// Blocking TCP transport for VISCA communication.
+#[cfg(feature = "blocking-client")]
 pub struct TcpTransport {
     stream: TcpStream,
     stats: ConnectionStats,
 }
 
+#[cfg(feature = "blocking-client")]
 impl TcpTransport {
     /// Creates a new TCP transport connected to the specified camera address.
     ///
@@ -56,6 +65,7 @@ impl TcpTransport {
     }
 }
 
+#[cfg(feature = "blocking-client")]
 impl BlockingTransport for TcpTransport {
     fn send_command_blocking(&mut self, command: &dyn ViscaCommand) -> Result<(), ViscaError> {
         let bytes = command.to_bytes()?;

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -253,4 +253,3 @@ impl Transport for AsyncTcpTransport {
         })
     }
 }
-

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -63,9 +63,9 @@ impl BlockingTransport for TcpTransport {
         
         self.stream
             .write_all(&bytes)
-            .map_err(|e| ViscaError::Io(e))?;
+            .map_err(ViscaError::Io)?;
         
-        self.stream.flush().map_err(|e| ViscaError::Io(e))?;
+        self.stream.flush().map_err(ViscaError::Io)?;
         
         self.stats.record_sent(bytes.len());
         Ok(())
@@ -171,9 +171,9 @@ impl Transport for AsyncTcpTransport {
             self.stream
                 .write_all(&bytes)
                 .await
-                .map_err(|e| ViscaError::Io(e))?;
+                .map_err(ViscaError::Io)?;
             
-            self.stream.flush().await.map_err(|e| ViscaError::Io(e))?;
+            self.stream.flush().await.map_err(ViscaError::Io)?;
             
             self.stats.record_sent(bytes.len());
             Ok(())

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -1,0 +1,252 @@
+//! TCP transport implementation for VISCA over IP.
+
+use super::BlockingTransport;
+#[cfg(feature = "async-client")]
+use super::{Transport, TransportFuture};
+use crate::{ConnectionStats, ViscaCommand, ViscaError};
+use std::io::{self, Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+#[cfg(feature = "async-client")]
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+#[cfg(feature = "async-client")]
+use tokio::net::TcpStream as TokioTcpStream;
+
+/// Blocking TCP transport for VISCA communication.
+pub struct TcpTransport {
+    stream: TcpStream,
+    stats: ConnectionStats,
+}
+
+impl TcpTransport {
+    /// Creates a new TCP transport connected to the specified camera address.
+    ///
+    /// Sets read and write timeouts of 10 seconds by default.
+    ///
+    /// # Arguments
+    /// * `address` - The camera's IP address and port (e.g., "192.168.1.100:5678")
+    ///
+    /// # Errors
+    /// Returns an error if the connection cannot be established or configured.
+    pub fn new(address: &str) -> io::Result<Self> {
+        let stream = TcpStream::connect(address)?;
+        stream.set_read_timeout(Some(Duration::from_secs(10)))?;
+        stream.set_write_timeout(Some(Duration::from_secs(10)))?;
+        Ok(Self {
+            stream,
+            stats: ConnectionStats::new(),
+        })
+    }
+
+    /// Creates a new TCP transport with a custom timeout.
+    pub fn with_timeout(address: &str, timeout: Duration) -> io::Result<Self> {
+        let stream = TcpStream::connect_timeout(&address.parse().unwrap(), timeout)?;
+        stream.set_read_timeout(Some(timeout))?;
+        stream.set_write_timeout(Some(timeout))?;
+        Ok(Self {
+            stream,
+            stats: ConnectionStats::new(),
+        })
+    }
+
+    /// Returns the connection statistics.
+    pub fn stats(&self) -> &ConnectionStats {
+        &self.stats
+    }
+}
+
+impl BlockingTransport for TcpTransport {
+    fn send_command_blocking(&mut self, command: &dyn ViscaCommand) -> Result<(), ViscaError> {
+        let bytes = command.to_bytes()?;
+        log::debug!("Sending command: {:02X?}", bytes);
+        
+        self.stream
+            .write_all(&bytes)
+            .map_err(|e| ViscaError::Io(e))?;
+        
+        self.stream.flush().map_err(|e| ViscaError::Io(e))?;
+        
+        self.stats.record_sent(bytes.len());
+        Ok(())
+    }
+
+    fn receive_response_blocking(&mut self) -> Result<Vec<Vec<u8>>, ViscaError> {
+        let mut buffer = [0u8; 1024];
+        let mut responses = Vec::new();
+        let mut current_response = Vec::new();
+        
+        // Keep receiving until we get a completion or error response
+        loop {
+            match self.stream.read(&mut buffer) {
+                Ok(0) => {
+                    self.stats.record_error();
+                    return Err(ViscaError::Io(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "Connection closed by camera"
+                    )));
+                }
+                Ok(size) => {
+                    for &byte in &buffer[..size] {
+                        current_response.push(byte);
+                        
+                        // Check for end of VISCA frame
+                        if byte == 0xFF && current_response.len() >= 3 && 
+                           current_response[0] == 0x90 {
+                            log::debug!("Received response: {:02X?}", current_response);
+                            
+                            self.stats.record_received(current_response.len());
+                            responses.push(current_response.clone());
+                            
+                            // Check for completion or error
+                            if current_response.len() >= 3 && 
+                               (current_response[1] == 0x50 || 
+                                current_response[1] == 0x51 || 
+                                (current_response[1] & 0x60) == 0x60) {
+                                return Ok(responses);
+                            }
+                            
+                            current_response.clear();
+                        }
+                    }
+                }
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    if responses.is_empty() && current_response.is_empty() {
+                        self.stats.record_error();
+                        return Err(ViscaError::CommandTimeout { 
+                            duration: Duration::from_secs(10), 
+                            command: "receive_response".to_string() 
+                        });
+                    }
+                    if !current_response.is_empty() {
+                        // Incomplete frame
+                        self.stats.record_error();
+                        return Err(ViscaError::Io(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "Incomplete VISCA frame"
+                        )));
+                    }
+                    return Ok(responses);
+                }
+                Err(e) => {
+                    self.stats.record_error();
+                    return Err(ViscaError::Io(e));
+                }
+            }
+        }
+    }
+}
+
+/// Async TCP transport for VISCA communication.
+#[cfg(feature = "async-client")]
+pub struct AsyncTcpTransport {
+    stream: TokioTcpStream,
+    stats: ConnectionStats,
+}
+
+#[cfg(feature = "async-client")]
+impl AsyncTcpTransport {
+    /// Creates a new async TCP transport.
+    pub async fn new(address: &str) -> io::Result<Self> {
+        let stream = TokioTcpStream::connect(address).await?;
+        Ok(Self {
+            stream,
+            stats: ConnectionStats::new(),
+        })
+    }
+
+    /// Returns the connection statistics.
+    pub fn stats(&self) -> &ConnectionStats {
+        &self.stats
+    }
+}
+
+#[cfg(feature = "async-client")]
+impl Transport for AsyncTcpTransport {
+    fn send_command<'a>(&'a mut self, command: &'a dyn ViscaCommand) -> TransportFuture<'a, ()> {
+        Box::pin(async move {
+            let bytes = command.to_bytes()?;
+            log::debug!("Sending command: {:02X?}", bytes);
+            
+            self.stream
+                .write_all(&bytes)
+                .await
+                .map_err(|e| ViscaError::Io(e))?;
+            
+            self.stream.flush().await.map_err(|e| ViscaError::Io(e))?;
+            
+            self.stats.record_sent(bytes.len());
+            Ok(())
+        })
+    }
+
+    fn receive_response(&mut self) -> TransportFuture<'_, Vec<Vec<u8>>> {
+        Box::pin(async move {
+            let mut buffer = [0u8; 1024];
+            let mut responses = Vec::new();
+            let mut current_response = Vec::new();
+            
+            // Keep receiving until we get a completion or error response
+            loop {
+                match tokio::time::timeout(
+                    Duration::from_secs(10),
+                    self.stream.read(&mut buffer)
+                ).await {
+                    Ok(Ok(0)) => {
+                        self.stats.record_error();
+                        return Err(ViscaError::Io(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "Connection closed by camera"
+                        )));
+                    }
+                    Ok(Ok(size)) => {
+                        for &byte in &buffer[..size] {
+                            current_response.push(byte);
+                            
+                            // Check for end of VISCA frame
+                            if byte == 0xFF && current_response.len() >= 3 && 
+                               current_response[0] == 0x90 {
+                                log::debug!("Received response: {:02X?}", current_response);
+                                
+                                self.stats.record_received(current_response.len());
+                                responses.push(current_response.clone());
+                                
+                                // Check for completion or error
+                                if current_response.len() >= 3 && 
+                                   (current_response[1] == 0x50 || 
+                                    current_response[1] == 0x51 || 
+                                    (current_response[1] & 0x60) == 0x60) {
+                                    return Ok(responses);
+                                }
+                                
+                                current_response.clear();
+                            }
+                        }
+                    }
+                    Ok(Err(e)) => {
+                        self.stats.record_error();
+                        return Err(ViscaError::Io(e));
+                    }
+                    Err(_) => {
+                        if responses.is_empty() && current_response.is_empty() {
+                            self.stats.record_error();
+                            return Err(ViscaError::CommandTimeout { 
+                            duration: Duration::from_secs(10), 
+                            command: "receive_response".to_string() 
+                        });
+                        }
+                        if !current_response.is_empty() {
+                            // Incomplete frame
+                            self.stats.record_error();
+                            return Err(ViscaError::Io(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "Incomplete VISCA frame"
+                            )));
+                        }
+                        return Ok(responses);
+                    }
+                }
+            }
+        })
+    }
+}

--- a/src/transport/udp.rs
+++ b/src/transport/udp.rs
@@ -212,4 +212,3 @@ impl Transport for AsyncUdpTransport {
         })
     }
 }
-

--- a/src/transport/udp.rs
+++ b/src/transport/udp.rs
@@ -62,11 +62,11 @@ impl BlockingTransport for UdpTransport {
     fn send_command_blocking(&mut self, command: &dyn ViscaCommand) -> Result<(), ViscaError> {
         let bytes = command.to_bytes()?;
         log::debug!("Sending command: {:02X?}", bytes);
-        
+
         self.socket
             .send_to(&bytes, &self.address)
             .map_err(ViscaError::Io)?;
-        
+
         self.stats.record_sent(bytes.len());
         Ok(())
     }
@@ -74,23 +74,24 @@ impl BlockingTransport for UdpTransport {
     fn receive_response_blocking(&mut self) -> Result<Vec<Vec<u8>>, ViscaError> {
         let mut buffer = [0u8; 1024];
         let mut responses = Vec::new();
-        
+
         // Keep receiving until we get a completion or error response
         loop {
             match self.socket.recv_from(&mut buffer) {
                 Ok((size, _)) => {
                     let data = buffer[..size].to_vec();
                     log::debug!("Received data: {:02X?}", data);
-                    
+
                     self.stats.record_received(data.len());
-                    
+
                     // Check if this is a complete VISCA response
                     if data.len() >= 3 && data[0] == 0x90 && data[data.len() - 1] == 0xFF {
                         responses.push(data.clone());
-                        
+
                         // Check for completion or error
-                        if data.len() >= 3 && (data[1] == 0x50 || data[1] == 0x51 || 
-                            (data[1] & 0x60) == 0x60) {
+                        if data.len() >= 3
+                            && (data[1] == 0x50 || data[1] == 0x51 || (data[1] & 0x60) == 0x60)
+                        {
                             break;
                         }
                     }
@@ -98,9 +99,9 @@ impl BlockingTransport for UdpTransport {
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
                     if responses.is_empty() {
                         self.stats.record_error();
-                        return Err(ViscaError::CommandTimeout { 
-                            duration: Duration::from_secs(10), 
-                            command: "receive_response".to_string() 
+                        return Err(ViscaError::CommandTimeout {
+                            duration: Duration::from_secs(10),
+                            command: "receive_response".to_string(),
                         });
                     }
                     break;
@@ -111,7 +112,7 @@ impl BlockingTransport for UdpTransport {
                 }
             }
         }
-        
+
         Ok(responses)
     }
 }
@@ -148,12 +149,12 @@ impl Transport for AsyncUdpTransport {
         Box::pin(async move {
             let bytes = command.to_bytes()?;
             log::debug!("Sending command: {:02X?}", bytes);
-            
+
             self.socket
                 .send_to(&bytes, &self.address)
                 .await
                 .map_err(ViscaError::Io)?;
-            
+
             self.stats.record_sent(bytes.len());
             Ok(())
         })
@@ -163,26 +164,29 @@ impl Transport for AsyncUdpTransport {
         Box::pin(async move {
             let mut buffer = [0u8; 1024];
             let mut responses = Vec::new();
-            
+
             // Keep receiving until we get a completion or error response
             loop {
                 match tokio::time::timeout(
                     Duration::from_secs(10),
-                    self.socket.recv_from(&mut buffer)
-                ).await {
+                    self.socket.recv_from(&mut buffer),
+                )
+                .await
+                {
                     Ok(Ok((size, _))) => {
                         let data = buffer[..size].to_vec();
                         log::debug!("Received data: {:02X?}", data);
-                        
+
                         self.stats.record_received(data.len());
-                        
+
                         // Check if this is a complete VISCA response
                         if data.len() >= 3 && data[0] == 0x90 && data[data.len() - 1] == 0xFF {
                             responses.push(data.clone());
-                            
+
                             // Check for completion or error
-                            if data.len() >= 3 && (data[1] == 0x50 || data[1] == 0x51 || 
-                                (data[1] & 0x60) == 0x60) {
+                            if data.len() >= 3
+                                && (data[1] == 0x50 || data[1] == 0x51 || (data[1] & 0x60) == 0x60)
+                            {
                                 break;
                             }
                         }
@@ -194,17 +198,18 @@ impl Transport for AsyncUdpTransport {
                     Err(_) => {
                         if responses.is_empty() {
                             self.stats.record_error();
-                            return Err(ViscaError::CommandTimeout { 
-                            duration: Duration::from_secs(10), 
-                            command: "receive_response".to_string() 
-                        });
+                            return Err(ViscaError::CommandTimeout {
+                                duration: Duration::from_secs(10),
+                                command: "receive_response".to_string(),
+                            });
                         }
                         break;
                     }
                 }
             }
-            
+
             Ok(responses)
         })
     }
 }
+

--- a/src/transport/udp.rs
+++ b/src/transport/udp.rs
@@ -1,23 +1,30 @@
 //! UDP transport implementation for VISCA over IP.
 
+#[cfg(feature = "blocking-client")]
 use super::BlockingTransport;
 #[cfg(feature = "async-client")]
 use super::{Transport, TransportFuture};
+#[cfg(any(feature = "blocking-client", feature = "async-client"))]
 use crate::{ConnectionStats, ViscaCommand, ViscaError};
+#[cfg(any(feature = "blocking-client", feature = "async-client"))]
 use std::io;
+#[cfg(feature = "blocking-client")]
 use std::net::UdpSocket;
+#[cfg(any(feature = "blocking-client", feature = "async-client"))]
 use std::time::Duration;
 
 #[cfg(feature = "async-client")]
 use tokio::net::UdpSocket as TokioUdpSocket;
 
 /// Blocking UDP transport for VISCA communication.
+#[cfg(feature = "blocking-client")]
 pub struct UdpTransport {
     socket: UdpSocket,
     address: String,
     stats: ConnectionStats,
 }
 
+#[cfg(feature = "blocking-client")]
 impl UdpTransport {
     /// Creates a new UDP transport connected to the specified camera address.
     ///
@@ -58,6 +65,7 @@ impl UdpTransport {
     }
 }
 
+#[cfg(feature = "blocking-client")]
 impl BlockingTransport for UdpTransport {
     fn send_command_blocking(&mut self, command: &dyn ViscaCommand) -> Result<(), ViscaError> {
         let bytes = command.to_bytes()?;

--- a/src/transport/udp.rs
+++ b/src/transport/udp.rs
@@ -1,0 +1,213 @@
+//! UDP transport implementation for VISCA over IP.
+
+use super::BlockingTransport;
+#[cfg(feature = "async-client")]
+use super::{Transport, TransportFuture};
+use crate::{ConnectionStats, ViscaCommand, ViscaError};
+use std::io;
+use std::net::UdpSocket;
+use std::time::Duration;
+
+#[cfg(feature = "async-client")]
+use tokio::net::UdpSocket as TokioUdpSocket;
+
+/// Blocking UDP transport for VISCA communication.
+pub struct UdpTransport {
+    socket: UdpSocket,
+    address: String,
+    stats: ConnectionStats,
+    timeout: Option<Duration>,
+}
+
+impl UdpTransport {
+    /// Creates a new UDP transport connected to the specified camera address.
+    ///
+    /// Sets read and write timeouts of 10 seconds by default.
+    ///
+    /// # Arguments
+    /// * `address` - The camera's IP address and port (e.g., "192.168.1.100:5678")
+    ///
+    /// # Errors
+    /// Returns an error if the socket cannot be created or configured.
+    pub fn new(address: &str) -> io::Result<Self> {
+        let socket = UdpSocket::bind("0.0.0.0:0")?;
+        let timeout = Some(Duration::from_secs(10));
+        socket.set_read_timeout(timeout)?;
+        socket.set_write_timeout(timeout)?;
+        Ok(Self {
+            socket,
+            address: address.to_string(),
+            stats: ConnectionStats::new(),
+            timeout,
+        })
+    }
+
+    /// Creates a new UDP transport with a custom timeout.
+    pub fn with_timeout(address: &str, timeout: Duration) -> io::Result<Self> {
+        let socket = UdpSocket::bind("0.0.0.0:0")?;
+        socket.set_read_timeout(Some(timeout))?;
+        socket.set_write_timeout(Some(timeout))?;
+        Ok(Self {
+            socket,
+            address: address.to_string(),
+            stats: ConnectionStats::new(),
+            timeout: Some(timeout),
+        })
+    }
+
+    /// Returns the connection statistics.
+    pub fn stats(&self) -> &ConnectionStats {
+        &self.stats
+    }
+}
+
+impl BlockingTransport for UdpTransport {
+    fn send_command_blocking(&mut self, command: &dyn ViscaCommand) -> Result<(), ViscaError> {
+        let bytes = command.to_bytes()?;
+        log::debug!("Sending command: {:02X?}", bytes);
+        
+        self.socket
+            .send_to(&bytes, &self.address)
+            .map_err(|e| ViscaError::Io(e))?;
+        
+        self.stats.record_sent(bytes.len());
+        Ok(())
+    }
+
+    fn receive_response_blocking(&mut self) -> Result<Vec<Vec<u8>>, ViscaError> {
+        let mut buffer = [0u8; 1024];
+        let mut responses = Vec::new();
+        
+        // Keep receiving until we get a completion or error response
+        loop {
+            match self.socket.recv_from(&mut buffer) {
+                Ok((size, _)) => {
+                    let data = buffer[..size].to_vec();
+                    log::debug!("Received data: {:02X?}", data);
+                    
+                    self.stats.record_received(data.len());
+                    
+                    // Check if this is a complete VISCA response
+                    if data.len() >= 3 && data[0] == 0x90 && data[data.len() - 1] == 0xFF {
+                        responses.push(data.clone());
+                        
+                        // Check for completion or error
+                        if data.len() >= 3 && (data[1] == 0x50 || data[1] == 0x51 || 
+                            (data[1] & 0x60) == 0x60) {
+                            break;
+                        }
+                    }
+                }
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    if responses.is_empty() {
+                        self.stats.record_error();
+                        return Err(ViscaError::CommandTimeout { 
+                            duration: Duration::from_secs(10), 
+                            command: "receive_response".to_string() 
+                        });
+                    }
+                    break;
+                }
+                Err(e) => {
+                    self.stats.record_error();
+                    return Err(ViscaError::Io(e));
+                }
+            }
+        }
+        
+        Ok(responses)
+    }
+}
+
+/// Async UDP transport for VISCA communication.
+#[cfg(feature = "async-client")]
+pub struct AsyncUdpTransport {
+    socket: TokioUdpSocket,
+    address: String,
+    stats: ConnectionStats,
+}
+
+#[cfg(feature = "async-client")]
+impl AsyncUdpTransport {
+    /// Creates a new async UDP transport.
+    pub async fn new(address: &str) -> io::Result<Self> {
+        let socket = TokioUdpSocket::bind("0.0.0.0:0").await?;
+        Ok(Self {
+            socket,
+            address: address.to_string(),
+            stats: ConnectionStats::new(),
+        })
+    }
+
+    /// Returns the connection statistics.
+    pub fn stats(&self) -> &ConnectionStats {
+        &self.stats
+    }
+}
+
+#[cfg(feature = "async-client")]
+impl Transport for AsyncUdpTransport {
+    fn send_command<'a>(&'a mut self, command: &'a dyn ViscaCommand) -> TransportFuture<'a, ()> {
+        Box::pin(async move {
+            let bytes = command.to_bytes()?;
+            log::debug!("Sending command: {:02X?}", bytes);
+            
+            self.socket
+                .send_to(&bytes, &self.address)
+                .await
+                .map_err(|e| ViscaError::Io(e))?;
+            
+            self.stats.record_sent(bytes.len());
+            Ok(())
+        })
+    }
+
+    fn receive_response(&mut self) -> TransportFuture<'_, Vec<Vec<u8>>> {
+        Box::pin(async move {
+            let mut buffer = [0u8; 1024];
+            let mut responses = Vec::new();
+            
+            // Keep receiving until we get a completion or error response
+            loop {
+                match tokio::time::timeout(
+                    Duration::from_secs(10),
+                    self.socket.recv_from(&mut buffer)
+                ).await {
+                    Ok(Ok((size, _))) => {
+                        let data = buffer[..size].to_vec();
+                        log::debug!("Received data: {:02X?}", data);
+                        
+                        self.stats.record_received(data.len());
+                        
+                        // Check if this is a complete VISCA response
+                        if data.len() >= 3 && data[0] == 0x90 && data[data.len() - 1] == 0xFF {
+                            responses.push(data.clone());
+                            
+                            // Check for completion or error
+                            if data.len() >= 3 && (data[1] == 0x50 || data[1] == 0x51 || 
+                                (data[1] & 0x60) == 0x60) {
+                                break;
+                            }
+                        }
+                    }
+                    Ok(Err(e)) => {
+                        self.stats.record_error();
+                        return Err(ViscaError::Io(e));
+                    }
+                    Err(_) => {
+                        if responses.is_empty() {
+                            self.stats.record_error();
+                            return Err(ViscaError::CommandTimeout { 
+                            duration: Duration::from_secs(10), 
+                            command: "receive_response".to_string() 
+                        });
+                        }
+                        break;
+                    }
+                }
+            }
+            
+            Ok(responses)
+        })
+    }
+}

--- a/src/transport/udp.rs
+++ b/src/transport/udp.rs
@@ -16,7 +16,6 @@ pub struct UdpTransport {
     socket: UdpSocket,
     address: String,
     stats: ConnectionStats,
-    timeout: Option<Duration>,
 }
 
 impl UdpTransport {
@@ -38,7 +37,6 @@ impl UdpTransport {
             socket,
             address: address.to_string(),
             stats: ConnectionStats::new(),
-            timeout,
         })
     }
 
@@ -51,7 +49,6 @@ impl UdpTransport {
             socket,
             address: address.to_string(),
             stats: ConnectionStats::new(),
-            timeout: Some(timeout),
         })
     }
 
@@ -68,7 +65,7 @@ impl BlockingTransport for UdpTransport {
         
         self.socket
             .send_to(&bytes, &self.address)
-            .map_err(|e| ViscaError::Io(e))?;
+            .map_err(ViscaError::Io)?;
         
         self.stats.record_sent(bytes.len());
         Ok(())
@@ -155,7 +152,7 @@ impl Transport for AsyncUdpTransport {
             self.socket
                 .send_to(&bytes, &self.address)
                 .await
-                .map_err(|e| ViscaError::Io(e))?;
+                .map_err(ViscaError::Io)?;
             
             self.stats.record_sent(bytes.len());
             Ok(())

--- a/tests/async_session_tests.rs
+++ b/tests/async_session_tests.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "async")]
+#![cfg(feature = "async-client")]
 
 use grafton_visca::{ViscaError, ViscaInquiryResponse, ViscaResponse, ViscaSession};
 use std::sync::Arc;

--- a/tests/async_tests.rs
+++ b/tests/async_tests.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "async")]
+#![cfg(feature = "async-client")]
 
 use grafton_visca::command::{power::Power, PowerCommand};
 use grafton_visca::{

--- a/tests/connection_management_tests.rs
+++ b/tests/connection_management_tests.rs
@@ -182,7 +182,7 @@ mod tests {
 }
 
 // Mock transport for testing
-#[cfg(all(test, not(feature = "async")))]
+#[cfg(all(test, not(feature = "async-client")))]
 mod sync_health_tests {
     use grafton_visca::connection::ConnectionStats;
     use grafton_visca::{ConnectionManagement, ViscaCommand, ViscaError, ViscaTransport};
@@ -275,7 +275,7 @@ mod sync_health_tests {
 }
 
 // Async tests
-#[cfg(all(test, feature = "async"))]
+#[cfg(all(test, feature = "async-client"))]
 mod async_health_tests {
     use grafton_visca::async_transport::TransportFuture;
     use grafton_visca::connection::ConnectionStats;

--- a/tests/phase_a_transport_tests.rs
+++ b/tests/phase_a_transport_tests.rs
@@ -6,6 +6,7 @@ mod tests {
     use grafton_visca::{ViscaCommand, ViscaError};
 
     // Mock command for testing
+    #[allow(dead_code)]
     struct TestCommand;
 
     impl ViscaCommand for TestCommand {
@@ -25,6 +26,7 @@ mod tests {
     #[test]
     fn test_transport_trait_exists() {
         // This test verifies that the Transport trait exists and is usable
+        #[allow(dead_code)]
         fn accepts_transport<T: Transport>(_t: &T) {}
 
         // The test passes if this compiles

--- a/tests/phase_a_transport_tests.rs
+++ b/tests/phase_a_transport_tests.rs
@@ -1,0 +1,72 @@
+//! Tests for Phase A transport implementation.
+
+#[cfg(test)]
+mod tests {
+    use grafton_visca::transport::*;
+    use grafton_visca::{ViscaCommand, ViscaError};
+    
+    // Mock command for testing
+    struct TestCommand;
+    
+    impl ViscaCommand for TestCommand {
+        fn to_bytes(&self) -> Result<Vec<u8>, ViscaError> {
+            Ok(vec![0x81, 0x01, 0x04, 0x00, 0x02, 0xFF])
+        }
+        
+        fn response_type(&self) -> Option<grafton_visca::ViscaResponseType> {
+            None
+        }
+        
+        fn command_category(&self) -> grafton_visca::timeout::CommandCategory {
+            grafton_visca::timeout::CommandCategory::Quick
+        }
+    }
+    
+    #[test]
+    fn test_transport_trait_exists() {
+        // This test verifies that the Transport trait exists and is usable
+        fn accepts_transport<T: Transport>(_t: &T) {}
+        
+        // The test passes if this compiles
+    }
+    
+    #[test]
+    fn test_blocking_transport_exists() {
+        // This test verifies that BlockingTransport can be used
+        struct MockBlockingTransport;
+        
+        impl BlockingTransport for MockBlockingTransport {
+            fn send_command_blocking(&mut self, _command: &dyn ViscaCommand) -> Result<(), ViscaError> {
+                Ok(())
+            }
+            
+            fn receive_response_blocking(&mut self) -> Result<Vec<Vec<u8>>, ViscaError> {
+                Ok(vec![vec![0x90, 0x50, 0xFF]])
+            }
+        }
+        
+        let transport = MockBlockingTransport;
+        let adapter = BlockingAdapter(transport);
+        
+        // Verify it implements Transport
+        fn accepts_transport<T: Transport>(_t: &T) {}
+        accepts_transport(&adapter);
+    }
+    
+    #[cfg(feature = "blocking-client")]
+    #[test]
+    fn test_udp_transport_creation() {
+        // Test that UdpTransport can be created
+        let result = UdpTransport::new("127.0.0.1:1234");
+        assert!(result.is_ok(), "Failed to create UDP transport");
+    }
+    
+    #[cfg(feature = "blocking-client")]
+    #[test]
+    fn test_tcp_transport_creation() {
+        // Test that TcpTransport can be created (will fail to connect but that's OK)
+        let result = TcpTransport::new("127.0.0.1:1234");
+        // We expect this to fail since there's no server
+        assert!(result.is_err(), "Expected connection to fail");
+    }
+}

--- a/tests/phase_a_transport_tests.rs
+++ b/tests/phase_a_transport_tests.rs
@@ -2,7 +2,14 @@
 
 #[cfg(test)]
 mod tests {
-    use grafton_visca::transport::*;
+    #[cfg(not(feature = "blocking-client"))]
+    use grafton_visca::transport::Transport;
+    #[cfg(feature = "async-client")]
+    use grafton_visca::transport::{AsyncTcpTransport, AsyncUdpTransport};
+    #[cfg(feature = "blocking-client")]
+    use grafton_visca::transport::{
+        BlockingAdapter, BlockingTransport, TcpTransport, Transport, UdpTransport,
+    };
     use grafton_visca::{ViscaCommand, ViscaError};
 
     // Mock command for testing
@@ -32,6 +39,7 @@ mod tests {
         // The test passes if this compiles
     }
 
+    #[cfg(feature = "blocking-client")]
     #[test]
     fn test_blocking_transport_exists() {
         // This test verifies that BlockingTransport can be used

--- a/tests/phase_a_transport_tests.rs
+++ b/tests/phase_a_transport_tests.rs
@@ -92,4 +92,3 @@ mod tests {
         assert!(result.is_err(), "Expected async TCP connection to fail");
     }
 }
-

--- a/tests/phase_a_transport_tests.rs
+++ b/tests/phase_a_transport_tests.rs
@@ -69,4 +69,21 @@ mod tests {
         // We expect this to fail since there's no server
         assert!(result.is_err(), "Expected connection to fail");
     }
+    
+    #[cfg(feature = "async-client")]
+    #[tokio::test]
+    async fn test_async_udp_transport_creation() {
+        // Test that AsyncUdpTransport can be created
+        let result = AsyncUdpTransport::new("127.0.0.1:1234").await;
+        assert!(result.is_ok(), "Failed to create async UDP transport");
+    }
+    
+    #[cfg(feature = "async-client")]
+    #[tokio::test]
+    async fn test_async_tcp_transport_creation() {
+        // Test that AsyncTcpTransport can be created (will fail to connect but that's OK)
+        let result = AsyncTcpTransport::new("127.0.0.1:1234").await;
+        // We expect this to fail since there's no server
+        assert!(result.is_err(), "Expected async TCP connection to fail");
+    }
 }

--- a/tests/phase_a_transport_tests.rs
+++ b/tests/phase_a_transport_tests.rs
@@ -4,55 +4,58 @@
 mod tests {
     use grafton_visca::transport::*;
     use grafton_visca::{ViscaCommand, ViscaError};
-    
+
     // Mock command for testing
     struct TestCommand;
-    
+
     impl ViscaCommand for TestCommand {
         fn to_bytes(&self) -> Result<Vec<u8>, ViscaError> {
             Ok(vec![0x81, 0x01, 0x04, 0x00, 0x02, 0xFF])
         }
-        
+
         fn response_type(&self) -> Option<grafton_visca::ViscaResponseType> {
             None
         }
-        
+
         fn command_category(&self) -> grafton_visca::timeout::CommandCategory {
             grafton_visca::timeout::CommandCategory::Quick
         }
     }
-    
+
     #[test]
     fn test_transport_trait_exists() {
         // This test verifies that the Transport trait exists and is usable
         fn accepts_transport<T: Transport>(_t: &T) {}
-        
+
         // The test passes if this compiles
     }
-    
+
     #[test]
     fn test_blocking_transport_exists() {
         // This test verifies that BlockingTransport can be used
         struct MockBlockingTransport;
-        
+
         impl BlockingTransport for MockBlockingTransport {
-            fn send_command_blocking(&mut self, _command: &dyn ViscaCommand) -> Result<(), ViscaError> {
+            fn send_command_blocking(
+                &mut self,
+                _command: &dyn ViscaCommand,
+            ) -> Result<(), ViscaError> {
                 Ok(())
             }
-            
+
             fn receive_response_blocking(&mut self) -> Result<Vec<Vec<u8>>, ViscaError> {
                 Ok(vec![vec![0x90, 0x50, 0xFF]])
             }
         }
-        
+
         let transport = MockBlockingTransport;
         let adapter = BlockingAdapter(transport);
-        
+
         // Verify it implements Transport
         fn accepts_transport<T: Transport>(_t: &T) {}
         accepts_transport(&adapter);
     }
-    
+
     #[cfg(feature = "blocking-client")]
     #[test]
     fn test_udp_transport_creation() {
@@ -60,7 +63,7 @@ mod tests {
         let result = UdpTransport::new("127.0.0.1:1234");
         assert!(result.is_ok(), "Failed to create UDP transport");
     }
-    
+
     #[cfg(feature = "blocking-client")]
     #[test]
     fn test_tcp_transport_creation() {
@@ -69,7 +72,7 @@ mod tests {
         // We expect this to fail since there's no server
         assert!(result.is_err(), "Expected connection to fail");
     }
-    
+
     #[cfg(feature = "async-client")]
     #[tokio::test]
     async fn test_async_udp_transport_creation() {
@@ -77,7 +80,7 @@ mod tests {
         let result = AsyncUdpTransport::new("127.0.0.1:1234").await;
         assert!(result.is_ok(), "Failed to create async UDP transport");
     }
-    
+
     #[cfg(feature = "async-client")]
     #[tokio::test]
     async fn test_async_tcp_transport_creation() {
@@ -87,3 +90,4 @@ mod tests {
         assert!(result.is_err(), "Expected async TCP connection to fail");
     }
 }
+


### PR DESCRIPTION
## Overview
This PR implements Phase A (Foundations) of the v0.4.0 API refactoring outlined in #23.

## Phase A Tasks
- [x] A1: Define public crates & update feature flags in Cargo.toml
- [x] A2: Design new Transport traits (async-first with blocking adapter)
- [x] A3: Implement minimal UDP/TCP transports

## Implementation Details

### A1: Feature Flags Updated
- Replaced `sync` with `blocking-client` (default)
- Replaced `async` with `async-client` 
- Added `reconnect`, `pool`, and `macros` features for future phases

### A2: New Transport Design
- **Primary trait**: `Transport` - async-first design
- **Internal trait**: `BlockingTransport` - for sync implementations
- **Adapter**: `BlockingAdapter<T>` - wraps blocking transports for async usage
- Located in new `src/transport/` module

### A3: Transport Implementations
- **Blocking**: `UdpTransport`, `TcpTransport` (implement `BlockingTransport`)
- **Async**: `AsyncUdpTransport`, `AsyncTcpTransport` (implement `Transport` directly)
- Both UDP and TCP support connection statistics tracking
- Proper error handling with existing `ViscaError` types

## Breaking Changes
- Feature flags renamed (`sync` → `blocking-client`, `async` → `async-client`)
- Transport trait signatures unified to async-first design
- Old transport implementations temporarily coexist with new ones (will be replaced in Phase B)

## Testing
- [x] All feature combinations compile
- [x] Unit tests for transport adapters pass
- [x] Integration tests verify transport creation

## Notes
- Old transport implementations are temporarily kept to avoid breaking existing code
- They will be removed/replaced in Phase B when the new `ViscaClient` is implemented
- The new transports are in `src/transport/` to avoid naming conflicts

Part of #23