### PR TITLE
Phase B: Unified ViscaClient Implementation for v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 
 [features]
 default = ["blocking-client"]
-blocking-client = []
+blocking-client = ["parking_lot"]
 async-client = ["tokio", "futures"]
 reconnect = []
 pool = []
@@ -26,6 +26,9 @@ log = "0.4.22"
 env_logger = "0.11.5"
 nom = "7.1.3"
 thiserror = "1.0"
+
+# Synchronization for blocking mode
+parking_lot = { version = "0.12", optional = true }
 
 # Async dependencies (optional)
 tokio = { version = "1.38", features = ["net", "sync", "time", "rt", "rt-multi-thread", "macros", "io-util"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,9 @@ required-features = ["blocking-client"]
 name = "phase_a_test"
 
 [[example]]
+name = "phase_b_unified_demo"
+
+[[example]]
 name = "position_conversion"
 
 [[example]]

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -9,9 +9,7 @@
 //! - Color adjustments
 //! - Inquiry commands
 
-use grafton_visca::command::pan_tilt::{PanSpeed, PanTiltDirection, TiltSpeed};
-use grafton_visca::command::power::Power;
-use grafton_visca::command::preset::PresetAction;
+use grafton_visca::command::pan_tilt::{PanSpeed, TiltSpeed};
 use grafton_visca::command::*;
 use grafton_visca::{send_command_and_wait, UdpTransport, ViscaResponse};
 use std::thread;

--- a/examples/phase_b_unified_demo.rs
+++ b/examples/phase_b_unified_demo.rs
@@ -89,6 +89,8 @@ async fn main() -> Result<(), ViscaError> {
 
 #[cfg(not(any(feature = "blocking-client", feature = "async-client")))]
 fn main() {
-    println!("This example requires at least one of the 'blocking-client' or 'async-client' features.");
+    println!(
+        "This example requires at least one of the 'blocking-client' or 'async-client' features."
+    );
     println!("Try: cargo run --example phase_b_unified_demo --features blocking-client");
 }

--- a/examples/phase_b_unified_demo.rs
+++ b/examples/phase_b_unified_demo.rs
@@ -1,0 +1,80 @@
+//! Demo of the Phase B unified client implementation.
+//!
+//! This example shows how the new unified ViscaClient works in both
+//! blocking and async contexts.
+
+use grafton_visca::{ViscaClient, ViscaError};
+use grafton_visca::command::{PowerCommand, ZoomCommand};
+use grafton_visca::command::power::Power;
+
+#[cfg(feature = "blocking-client")]
+fn blocking_example() -> Result<(), ViscaError> {
+    println!("=== Blocking Example ===");
+    
+    // Create a blocking client
+    let client = ViscaClient::connect_udp("192.168.1.100:5678")?;
+    
+    // Send commands using the blocking façade
+    println!("Powering on camera...");
+    let _response = client.send(&PowerCommand { power: Power::On })?;
+    
+    println!("Zooming in...");
+    client.send(&ZoomCommand::TeleStandard)?;
+    
+    Ok(())
+}
+
+#[cfg(feature = "async-client")]
+async fn async_example() -> Result<(), ViscaError> {
+    println!("=== Async Example ===");
+    
+    // Create an async client
+    let client = ViscaClient::connect_udp_async("192.168.1.100:5678").await?;
+    
+    // Send commands using the async interface
+    println!("Powering on camera...");
+    client.send_async(&PowerCommand { power: Power::On }).await?;
+    
+    println!("Zooming in...");
+    client.send_async(&ZoomCommand::TeleStandard).await?;
+    
+    // Check camera health
+    let is_healthy = client.is_healthy().await?;
+    println!("Camera healthy: {}", is_healthy);
+    
+    Ok(())
+}
+
+#[cfg(all(feature = "blocking-client", feature = "async-client"))]
+async fn mixed_example() -> Result<(), ViscaError> {
+    println!("=== Mixed Blocking/Async Example ===");
+    
+    // Create a blocking client but use it in async context
+    let client = ViscaClient::connect_udp("192.168.1.100:5678")?;
+    
+    // Can use blocking API even inside async function
+    println!("Using blocking API in async context...");
+    client.send(&PowerCommand { power: Power::On })?;
+    
+    // Can also use async API on the same client
+    println!("Using async API...");
+    client.send_async(&ZoomCommand::WideStandard).await?;
+    
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), ViscaError> {
+    env_logger::init();
+
+    #[cfg(feature = "blocking-client")]
+    blocking_example().unwrap_or_else(|e| eprintln!("Blocking example error: {}", e));
+
+    #[cfg(feature = "async-client")]
+    async_example().await.unwrap_or_else(|e| eprintln!("Async example error: {}", e));
+
+    #[cfg(all(feature = "blocking-client", feature = "async-client"))]
+    mixed_example().await.unwrap_or_else(|e| eprintln!("Mixed example error: {}", e));
+
+    Ok(())
+}

--- a/examples/phase_b_unified_demo.rs
+++ b/examples/phase_b_unified_demo.rs
@@ -3,7 +3,9 @@
 //! This example shows how the new unified ViscaClient works in both
 //! blocking and async contexts.
 
+#[cfg(any(feature = "blocking-client", feature = "async-client"))]
 use grafton_visca::command::{Power, PowerCommand, ZoomCommand};
+#[cfg(any(feature = "blocking-client", feature = "async-client"))]
 use grafton_visca::{ViscaClient, ViscaError};
 
 #[cfg(feature = "blocking-client")]
@@ -64,6 +66,7 @@ async fn mixed_example() -> Result<(), ViscaError> {
     Ok(())
 }
 
+#[cfg(any(feature = "blocking-client", feature = "async-client"))]
 #[tokio::main]
 async fn main() -> Result<(), ViscaError> {
     env_logger::init();
@@ -82,4 +85,10 @@ async fn main() -> Result<(), ViscaError> {
         .unwrap_or_else(|e| eprintln!("Mixed example error: {}", e));
 
     Ok(())
+}
+
+#[cfg(not(any(feature = "blocking-client", feature = "async-client")))]
+fn main() {
+    println!("This example requires at least one of the 'blocking-client' or 'async-client' features.");
+    println!("Try: cargo run --example phase_b_unified_demo --features blocking-client");
 }

--- a/examples/phase_b_unified_demo.rs
+++ b/examples/phase_b_unified_demo.rs
@@ -3,63 +3,64 @@
 //! This example shows how the new unified ViscaClient works in both
 //! blocking and async contexts.
 
+use grafton_visca::command::{Power, PowerCommand, ZoomCommand};
 use grafton_visca::{ViscaClient, ViscaError};
-use grafton_visca::command::{PowerCommand, ZoomCommand};
-use grafton_visca::command::power::Power;
 
 #[cfg(feature = "blocking-client")]
 fn blocking_example() -> Result<(), ViscaError> {
     println!("=== Blocking Example ===");
-    
+
     // Create a blocking client
     let client = ViscaClient::connect_udp("192.168.1.100:5678")?;
-    
+
     // Send commands using the blocking façade
     println!("Powering on camera...");
     let _response = client.send(&PowerCommand { power: Power::On })?;
-    
+
     println!("Zooming in...");
     client.send(&ZoomCommand::TeleStandard)?;
-    
+
     Ok(())
 }
 
 #[cfg(feature = "async-client")]
 async fn async_example() -> Result<(), ViscaError> {
     println!("=== Async Example ===");
-    
+
     // Create an async client
     let client = ViscaClient::connect_udp_async("192.168.1.100:5678").await?;
-    
+
     // Send commands using the async interface
     println!("Powering on camera...");
-    client.send_async(&PowerCommand { power: Power::On }).await?;
-    
+    client
+        .send_async(&PowerCommand { power: Power::On })
+        .await?;
+
     println!("Zooming in...");
     client.send_async(&ZoomCommand::TeleStandard).await?;
-    
+
     // Check camera health
     let is_healthy = client.is_healthy().await?;
     println!("Camera healthy: {}", is_healthy);
-    
+
     Ok(())
 }
 
 #[cfg(all(feature = "blocking-client", feature = "async-client"))]
 async fn mixed_example() -> Result<(), ViscaError> {
     println!("=== Mixed Blocking/Async Example ===");
-    
+
     // Create a blocking client but use it in async context
     let client = ViscaClient::connect_udp("192.168.1.100:5678")?;
-    
+
     // Can use blocking API even inside async function
     println!("Using blocking API in async context...");
     client.send(&PowerCommand { power: Power::On })?;
-    
+
     // Can also use async API on the same client
     println!("Using async API...");
     client.send_async(&ZoomCommand::WideStandard).await?;
-    
+
     Ok(())
 }
 
@@ -71,10 +72,14 @@ async fn main() -> Result<(), ViscaError> {
     blocking_example().unwrap_or_else(|e| eprintln!("Blocking example error: {}", e));
 
     #[cfg(feature = "async-client")]
-    async_example().await.unwrap_or_else(|e| eprintln!("Async example error: {}", e));
+    async_example()
+        .await
+        .unwrap_or_else(|e| eprintln!("Async example error: {}", e));
 
     #[cfg(all(feature = "blocking-client", feature = "async-client"))]
-    mixed_example().await.unwrap_or_else(|e| eprintln!("Mixed example error: {}", e));
+    mixed_example()
+        .await
+        .unwrap_or_else(|e| eprintln!("Mixed example error: {}", e));
 
     Ok(())
 }

--- a/examples/thread_safe_client.rs
+++ b/examples/thread_safe_client.rs
@@ -2,16 +2,17 @@
 //!
 //! This example shows how to use ViscaClient to control a camera
 //! from multiple threads without needing RefCell or manual locking.
+//!
+//! NOTE: This example needs to be updated for the v0.4.0 API.
 
 #[cfg(not(all(feature = "blocking-client", feature = "async-client")))]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     use grafton_visca::{
         command::{
             pan_tilt::{PanSpeed, PanTiltDirection, TiltSpeed},
-            power::Power,
-            PanTiltCommand, PowerCommand, ZoomCommand,
+            PanTiltCommand, Power, PowerCommand, ZoomCommand,
         },
-        UdpTransport, ViscaClient, ViscaError,
+        ViscaClient, ViscaError,
     };
     use std::sync::Arc;
     use std::thread;
@@ -27,9 +28,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Connecting to camera at {}...", camera_addr);
 
-    // Create transport and wrap it in ViscaClient
-    let transport = UdpTransport::new(camera_addr)?;
-    let client = Arc::new(ViscaClient::new(Box::new(transport)));
+    // Create client using the new v0.4.0 API
+    let client = Arc::new(ViscaClient::connect_udp(camera_addr)?);
 
     println!("Connected! Starting multi-threaded demo...");
 
@@ -108,12 +108,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("[Main] Attempting concurrent command...");
     thread::sleep(Duration::from_secs(1));
 
-    // This might fail if another thread is using the transport
-    match client.try_send(&ZoomCommand::TeleStandard) {
+    // The new unified client handles concurrency with a semaphore
+    match client.send(&ZoomCommand::TeleStandard) {
         Ok(_) => println!("[Main] Successfully sent command"),
-        Err(ViscaError::InvalidParameter(msg)) if msg.contains("busy") => {
-            println!("[Main] Transport busy (expected during concurrent usage)");
-        }
         Err(e) => println!("[Main] Error: {:?}", e),
     }
 
@@ -134,6 +131,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(all(feature = "blocking-client", feature = "async-client"))]
 fn main() {
-    println!("This example requires the new ViscaClient which is not available when both sync and async features are enabled.");
-    println!("Run with: cargo run --example thread_safe_client");
+    println!("This example works with the unified ViscaClient in v0.4.0.");
+    println!("Run with: cargo run --example thread_safe_client --no-default-features --features blocking-client");
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -21,7 +21,7 @@ pub use exposure::{
     BrightCommand, DynamicRangeCommand, ExposureCommand, ExposureCompensationCommand, ExposureMode,
     IrisCommand, ShutterCommand,
 };
-pub use flip::ImageFlipCommand;
+pub use flip::{Flip, ImageFlipCommand};
 pub use focus::{
     AFSensitivity, AFSensitivityCommand, FocusCommand, FocusNearLimitCommand, FocusZone,
     FocusZoneCommand,
@@ -35,9 +35,9 @@ pub use inquiry::InquiryCommand;
 pub use luminance_contrast_sharpness::{
     ContrastCommand, LuminanceCommand, SharpnessCommand, SharpnessMode,
 };
-pub use pan_tilt::{LimitCorner, PanTiltCommand, PanTiltLimitCommand};
-pub use power::PowerCommand;
-pub use preset::PresetCommand;
+pub use pan_tilt::{LimitCorner, PanTiltCommand, PanTiltDirection, PanTiltLimitCommand};
+pub use power::{Power, PowerCommand};
+pub use preset::{PresetAction, PresetCommand};
 pub use response::{ViscaResponse, ViscaResponseType};
 pub use white_balance::WhiteBalanceCommand;
 pub use white_balance::WhiteBalanceMode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,16 +246,15 @@ mod preset_ext;
 pub use preset_ext::ViscaPresetExt;
 
 // Synchronization primitives for unified client
+#[cfg(any(feature = "blocking-client", feature = "async-client"))]
 mod sync_primitives;
 
 // New unified client for v0.4.0
+#[cfg(any(feature = "blocking-client", feature = "async-client"))]
 mod unified_client;
 
 // Export ViscaClient based on features
-#[cfg(not(any(feature = "blocking-client", feature = "async-client")))]
-compile_error!("At least one of 'blocking-client' or 'async-client' features must be enabled");
-
-// Use the new unified client for all feature combinations
+#[cfg(any(feature = "blocking-client", feature = "async-client"))]
 pub use unified_client::ViscaClient;
 
 #[cfg(feature = "async-client")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,10 +246,15 @@ pub use focus_ext::ViscaFocusExt;
 mod preset_ext;
 pub use preset_ext::ViscaPresetExt;
 
-#[cfg(all(feature = "blocking-client", not(feature = "async-client")))]
-mod client;
-#[cfg(all(feature = "blocking-client", not(feature = "async-client")))]
-pub use client::ViscaClient;
+// New unified client for v0.4.0
+mod unified_client;
+
+// Export ViscaClient based on features
+#[cfg(not(any(feature = "blocking-client", feature = "async-client")))]
+compile_error!("At least one of 'blocking-client' or 'async-client' features must be enabled");
+
+// Use the new unified client for all feature combinations
+pub use unified_client::ViscaClient;
 
 #[cfg(feature = "async-client")]
 mod async_inquiry_ext;
@@ -305,10 +310,7 @@ pub use async_transport::{AsyncViscaTransport, TransportFuture};
 #[cfg(feature = "async-client")]
 pub use async_udp_transport::AsyncUdpTransport;
 
-#[cfg(all(feature = "blocking-client", feature = "async-client"))]
-mod sync_wrapper;
-#[cfg(all(feature = "blocking-client", feature = "async-client"))]
-pub use sync_wrapper::{send_command_and_wait_compat, ViscaClient};
+// sync_wrapper is no longer needed with the unified client
 
 pub mod timeout;
 pub use timeout::{CommandCategory, TimeoutConfig, TimeoutConfigBuilder};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,14 +43,13 @@
 //! ### Using ViscaClient (Recommended for Thread Safety)
 //!
 //! ```no_run
-//! # #[cfg(all(feature = "blocking-client", not(feature = "async-client")))]
+//! # #[cfg(feature = "blocking-client")]
 //! # {
-//! use grafton_visca::{ViscaClient, UdpTransport};
+//! use grafton_visca::ViscaClient;
 //! use grafton_visca::command::{PanTiltCommand, ZoomCommand};
 //!
-//! // Create a thread-safe client
-//! let transport = UdpTransport::new("192.168.1.100:5678").unwrap();
-//! let client = ViscaClient::new(Box::new(transport));
+//! // Create a client using the v0.4.0 unified API
+//! let client = ViscaClient::connect_udp("192.168.1.100:5678").unwrap();
 //!
 //! // Send commands through the client
 //! client.send(&PanTiltCommand::Home).unwrap();
@@ -245,6 +244,9 @@ pub use focus_ext::ViscaFocusExt;
 
 mod preset_ext;
 pub use preset_ext::ViscaPresetExt;
+
+// Synchronization primitives for unified client
+mod sync_primitives;
 
 // New unified client for v0.4.0
 mod unified_client;

--- a/src/sync_primitives.rs
+++ b/src/sync_primitives.rs
@@ -1,0 +1,124 @@
+//! Synchronization primitives that work in both blocking and async contexts.
+//!
+//! This module provides unified types for mutex and semaphore that automatically
+//! select the appropriate implementation based on enabled features.
+
+// Re-export the appropriate mutex type based on features
+#[cfg(feature = "async-client")]
+pub use tokio::sync::Mutex;
+
+#[cfg(not(feature = "async-client"))]
+pub use parking_lot::Mutex;
+
+// Semaphore abstraction that works for both sync and async
+#[cfg(feature = "async-client")]
+mod async_semaphore {
+    use std::sync::Arc;
+    use tokio::sync::{Semaphore as TokioSemaphore, SemaphorePermit};
+
+    pub struct Semaphore {
+        inner: Arc<TokioSemaphore>,
+    }
+
+    pub struct Permit<'a> {
+        _permit: SemaphorePermit<'a>,
+    }
+
+    impl Semaphore {
+        pub fn new(permits: usize) -> Self {
+            Self {
+                inner: Arc::new(TokioSemaphore::new(permits)),
+            }
+        }
+
+        pub async fn acquire(&self) -> Result<Permit<'_>, crate::ViscaError> {
+            let permit = self
+                .inner
+                .acquire()
+                .await
+                .map_err(|_| crate::ViscaError::InvalidParameter("Semaphore closed".into()))?;
+            Ok(Permit { _permit: permit })
+        }
+    }
+}
+
+#[cfg(not(feature = "async-client"))]
+mod sync_semaphore {
+    use parking_lot::{Condvar, Mutex};
+    use std::sync::Arc;
+
+    pub struct Semaphore {
+        state: Arc<(Mutex<usize>, Condvar)>,
+    }
+
+    pub struct Permit<'a> {
+        semaphore: &'a Semaphore,
+    }
+
+    impl Semaphore {
+        pub fn new(permits: usize) -> Self {
+            Self {
+                state: Arc::new((Mutex::new(permits), Condvar::new())),
+            }
+        }
+
+        pub fn acquire(&self) -> Result<Permit<'_>, crate::ViscaError> {
+            let (lock, cvar) = &*self.state;
+            let mut count = lock.lock();
+
+            // Wait until a permit is available
+            while *count == 0 {
+                cvar.wait(&mut count);
+            }
+
+            *count -= 1;
+            Ok(Permit { semaphore: self })
+        }
+    }
+
+    impl Drop for Permit<'_> {
+        fn drop(&mut self) {
+            let (lock, cvar) = &*self.semaphore.state;
+            let mut count = lock.lock();
+            *count += 1;
+            drop(count);
+            cvar.notify_one();
+        }
+    }
+}
+
+#[cfg(feature = "async-client")]
+pub use async_semaphore::{Permit, Semaphore};
+
+#[cfg(not(feature = "async-client"))]
+pub use sync_semaphore::{Permit, Semaphore};
+
+// Helper trait to unify acquire behavior
+pub trait SemaphoreExt {
+    type Permit<'a>
+    where
+        Self: 'a;
+
+    #[cfg(feature = "async-client")]
+    async fn acquire_permit(&self) -> Result<Self::Permit<'_>, crate::ViscaError>;
+
+    #[cfg(not(feature = "async-client"))]
+    fn acquire_permit(&self) -> Result<Self::Permit<'_>, crate::ViscaError>;
+}
+
+impl SemaphoreExt for Semaphore {
+    type Permit<'a>
+        = Permit<'a>
+    where
+        Self: 'a;
+
+    #[cfg(feature = "async-client")]
+    async fn acquire_permit(&self) -> Result<Self::Permit<'_>, crate::ViscaError> {
+        self.acquire().await
+    }
+
+    #[cfg(not(feature = "async-client"))]
+    fn acquire_permit(&self) -> Result<Self::Permit<'_>, crate::ViscaError> {
+        self.acquire()
+    }
+}

--- a/src/unified_client.rs
+++ b/src/unified_client.rs
@@ -5,34 +5,42 @@
 
 use crate::{
     session::ViscaSession,
-    transport::{BlockingAdapter, Transport},
+    sync_primitives::{Mutex, Semaphore, SemaphoreExt},
     ViscaCommand, ViscaError, ViscaResponse,
 };
-use std::sync::Arc;
-use tokio::sync::{Mutex, Semaphore};
 
 #[cfg(feature = "blocking-client")]
-use crate::transport::{TcpTransport as BlockingTcpTransport, UdpTransport as BlockingUdpTransport};
+use crate::transport::BlockingAdapter;
+
+#[cfg(feature = "async-client")]
+use crate::transport::Transport;
+use std::sync::Arc;
+
 #[cfg(feature = "async-client")]
 use crate::transport::{AsyncTcpTransport, AsyncUdpTransport};
+#[cfg(feature = "blocking-client")]
+use crate::transport::{
+    TcpTransport as BlockingTcpTransport, UdpTransport as BlockingUdpTransport,
+};
 
 /// Maximum number of concurrent commands (PTZOptics G2 limitation).
 const MAX_CONCURRENT_COMMANDS: usize = 2;
 
 /// Internal transport variant that supports both blocking and async transports.
+#[allow(clippy::large_enum_variant)]
 enum TransportVariant {
     /// Blocking UDP transport wrapped in an adapter
     #[cfg(feature = "blocking-client")]
     BlockingUdp(BlockingAdapter<BlockingUdpTransport>),
-    
+
     /// Blocking TCP transport wrapped in an adapter
     #[cfg(feature = "blocking-client")]
     BlockingTcp(BlockingAdapter<BlockingTcpTransport>),
-    
+
     /// Native async UDP transport
     #[cfg(feature = "async-client")]
     AsyncUdp(AsyncUdpTransport),
-    
+
     /// Native async TCP transport
     #[cfg(feature = "async-client")]
     AsyncTcp(AsyncTcpTransport),
@@ -46,11 +54,11 @@ enum TransportVariant {
 pub struct ViscaClient {
     /// The underlying transport (blocking or async)
     transport: Arc<Mutex<TransportVariant>>,
-    
+
     /// Session management for command sequencing
     #[allow(dead_code)] // Will be used in Phase C for command sequencing
     session: Arc<Mutex<ViscaSession>>,
-    
+
     /// Concurrency control (max 2 concurrent commands)
     semaphore: Arc<Semaphore>,
 }
@@ -66,7 +74,7 @@ impl ViscaClient {
     }
 
     // B2: Unified constructors
-    
+
     /// Connect to a camera using UDP transport.
     ///
     /// This constructor automatically selects the appropriate transport based on
@@ -75,7 +83,9 @@ impl ViscaClient {
     pub fn connect_udp(camera_addr: &str) -> Result<Self, ViscaError> {
         let transport = BlockingUdpTransport::new(camera_addr).map_err(ViscaError::Io)?;
         let adapter = BlockingAdapter(transport);
-        Ok(Self::new_from_variant(TransportVariant::BlockingUdp(adapter)))
+        Ok(Self::new_from_variant(TransportVariant::BlockingUdp(
+            adapter,
+        )))
     }
 
     /// Connect to a camera using TCP transport.
@@ -86,75 +96,126 @@ impl ViscaClient {
     pub fn connect_tcp(camera_addr: &str) -> Result<Self, ViscaError> {
         let transport = BlockingTcpTransport::new(camera_addr).map_err(ViscaError::Io)?;
         let adapter = BlockingAdapter(transport);
-        Ok(Self::new_from_variant(TransportVariant::BlockingTcp(adapter)))
+        Ok(Self::new_from_variant(TransportVariant::BlockingTcp(
+            adapter,
+        )))
     }
 
     /// Connect to a camera using UDP transport (async).
     #[cfg(feature = "async-client")]
     pub async fn connect_udp_async(camera_addr: &str) -> Result<Self, ViscaError> {
         let transport = AsyncUdpTransport::new(camera_addr).await?;
-        Ok(Self::new_from_variant(TransportVariant::AsyncUdp(transport)))
+        Ok(Self::new_from_variant(TransportVariant::AsyncUdp(
+            transport,
+        )))
     }
 
     /// Connect to a camera using TCP transport (async).
     #[cfg(feature = "async-client")]
     pub async fn connect_tcp_async(camera_addr: &str) -> Result<Self, ViscaError> {
         let transport = AsyncTcpTransport::new(camera_addr).await?;
-        Ok(Self::new_from_variant(TransportVariant::AsyncTcp(transport)))
+        Ok(Self::new_from_variant(TransportVariant::AsyncTcp(
+            transport,
+        )))
     }
-    
+
     // B3: Concurrency control is handled by the semaphore field
-    
+
     // B4: Blocking façade with smart runtime handling
-    
+
     /// Send a command and wait for the response (blocking).
     ///
     /// This method provides a blocking interface that works in both sync and async contexts:
-    /// - If called from within a Tokio runtime, uses block_in_place to avoid blocking the runtime
-    /// - If called from outside a runtime, creates a temporary runtime
-    /// - For blocking transports, calls them directly when possible
+    /// - For async-enabled builds:
+    ///   - If called from within a Tokio runtime, uses block_in_place to avoid blocking the runtime
+    ///   - If called from outside a runtime, creates a temporary runtime
+    /// - For blocking-only builds:
+    ///   - Directly calls the blocking implementation
     #[cfg(feature = "blocking-client")]
     pub fn send(&self, command: &dyn ViscaCommand) -> Result<ViscaResponse, ViscaError> {
-        // Clone self to move into the async block
-        let client = self.clone();
-        
-        // Try to use existing Tokio runtime if available
-        match tokio::runtime::Handle::try_current() {
-            Ok(_) => {
-                // We're inside a Tokio runtime, use block_in_place to avoid blocking it
-                tokio::task::block_in_place(move || {
-                    // Create a new runtime for the blocking operation
+        #[cfg(feature = "async-client")]
+        {
+            // Clone self to move into the async block
+            let client = self.clone();
+
+            // Try to use existing Tokio runtime if available
+            match tokio::runtime::Handle::try_current() {
+                Ok(_) => {
+                    // We're inside a Tokio runtime, use block_in_place to avoid blocking it
+                    tokio::task::block_in_place(move || {
+                        // Create a new runtime for the blocking operation
+                        let rt = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()
+                            .map_err(|e| {
+                                ViscaError::Io(std::io::Error::new(std::io::ErrorKind::Other, e))
+                            })?;
+                        rt.block_on(client.send_async(command))
+                    })
+                }
+                Err(_) => {
+                    // No runtime available, create a temporary one
                     let rt = tokio::runtime::Builder::new_current_thread()
                         .enable_all()
                         .build()
-                        .map_err(|e| ViscaError::Io(std::io::Error::other(e)))?;
+                        .map_err(|e| {
+                            ViscaError::Io(std::io::Error::new(std::io::ErrorKind::Other, e))
+                        })?;
                     rt.block_on(client.send_async(command))
-                })
-            }
-            Err(_) => {
-                // No runtime available, create a temporary one
-                let rt = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .map_err(|e| ViscaError::Io(std::io::Error::other(e)))?;
-                rt.block_on(client.send_async(command))
+                }
             }
         }
+
+        #[cfg(not(feature = "async-client"))]
+        {
+            // For blocking-only builds, implement synchronous sending
+            self.send_blocking(command)
+        }
     }
-    
+
+    #[cfg(not(feature = "async-client"))]
+    fn send_blocking(&self, command: &dyn ViscaCommand) -> Result<ViscaResponse, ViscaError> {
+        // Acquire permit for concurrency control
+        let _permit = self.semaphore.acquire_permit()?;
+
+        // Lock transport and send command
+        let mut transport = self.transport.lock();
+        let responses = match &mut *transport {
+            #[cfg(feature = "blocking-client")]
+            TransportVariant::BlockingUdp(t) => {
+                use crate::transport::BlockingTransport;
+                t.0.send_command_blocking(command)?;
+                t.0.receive_response_blocking()?
+            }
+            #[cfg(feature = "blocking-client")]
+            TransportVariant::BlockingTcp(t) => {
+                use crate::transport::BlockingTransport;
+                t.0.send_command_blocking(command)?;
+                t.0.receive_response_blocking()?
+            }
+            #[cfg(feature = "async-client")]
+            _ => unreachable!("Async transports should not be present in blocking-only builds"),
+        };
+
+        parse_response(responses)
+    }
+
     // B5: Async façade
-    
+
     /// Send a command and wait for the response (async).
     ///
     /// This method:
     /// - Acquires a semaphore permit to enforce concurrency limits
     /// - Sends the command through the transport
     /// - Waits for and returns the response
-    pub async fn send_async(&self, command: &dyn ViscaCommand) -> Result<ViscaResponse, ViscaError> {
+    #[cfg(feature = "async-client")]
+    pub async fn send_async(
+        &self,
+        command: &dyn ViscaCommand,
+    ) -> Result<ViscaResponse, ViscaError> {
         // Acquire permit for concurrency control
-        let _permit = self.semaphore.acquire().await
-            .map_err(|_| ViscaError::InvalidParameter("Semaphore closed".into()))?;
-        
+        let _permit = self.semaphore.acquire_permit().await?;
+
         // Lock transport and send command
         let mut transport = self.transport.lock().await;
         let responses = match &mut *transport {
@@ -179,21 +240,32 @@ impl ViscaClient {
                 t.receive_response().await?
             }
         };
-        
+
         parse_response(responses)
     }
 
     /// Check if the camera connection is healthy.
+    #[cfg(feature = "async-client")]
     pub async fn is_healthy(&self) -> Result<bool, ViscaError> {
         use crate::command::InquiryCommand;
-        
+
         match self.send_async(&InquiryCommand::Power).await {
             Ok(_) => Ok(true),
             Err(_) => Ok(false),
         }
     }
-}
 
+    /// Check if the camera connection is healthy (blocking).
+    #[cfg(feature = "blocking-client")]
+    pub fn is_healthy_blocking(&self) -> Result<bool, ViscaError> {
+        use crate::command::InquiryCommand;
+
+        match self.send(&InquiryCommand::Power) {
+            Ok(_) => Ok(true),
+            Err(_) => Ok(false),
+        }
+    }
+}
 
 /// Parse response frames into a ViscaResponse.
 fn parse_response(frames: Vec<Vec<u8>>) -> Result<ViscaResponse, ViscaError> {
@@ -219,7 +291,7 @@ fn parse_response(frames: Vec<Vec<u8>>) -> Result<ViscaResponse, ViscaError> {
     } else {
         Err(ViscaError::Io(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
-            "No response frames received"
+            "No response frames received",
         )))
     }
 }

--- a/src/unified_client.rs
+++ b/src/unified_client.rs
@@ -1,0 +1,225 @@
+//! Unified VISCA client for v0.4.0 - async-first with blocking façade.
+//!
+//! This module provides a single `ViscaClient` that works in both blocking
+//! and async contexts, replacing the previous split-brain approach.
+
+use crate::{
+    session::ViscaSession,
+    transport::{BlockingAdapter, Transport},
+    ViscaCommand, ViscaError, ViscaResponse,
+};
+use std::sync::Arc;
+use tokio::sync::{Mutex, Semaphore};
+
+#[cfg(feature = "blocking-client")]
+use crate::transport::{TcpTransport as BlockingTcpTransport, UdpTransport as BlockingUdpTransport};
+#[cfg(feature = "async-client")]
+use crate::transport::{AsyncTcpTransport, AsyncUdpTransport};
+
+/// Maximum number of concurrent commands (PTZOptics G2 limitation).
+const MAX_CONCURRENT_COMMANDS: usize = 2;
+
+/// Internal transport variant that supports both blocking and async transports.
+enum TransportVariant {
+    /// Blocking UDP transport wrapped in an adapter
+    #[cfg(feature = "blocking-client")]
+    BlockingUdp(BlockingAdapter<BlockingUdpTransport>),
+    
+    /// Blocking TCP transport wrapped in an adapter
+    #[cfg(feature = "blocking-client")]
+    BlockingTcp(BlockingAdapter<BlockingTcpTransport>),
+    
+    /// Native async UDP transport
+    #[cfg(feature = "async-client")]
+    AsyncUdp(AsyncUdpTransport),
+    
+    /// Native async TCP transport
+    #[cfg(feature = "async-client")]
+    AsyncTcp(AsyncTcpTransport),
+}
+
+/// Unified VISCA client with async-first design and blocking façade.
+///
+/// This client provides a single API surface for both blocking and async usage,
+/// with automatic runtime management for blocking operations.
+#[derive(Clone)]
+pub struct ViscaClient {
+    /// The underlying transport (blocking or async)
+    transport: Arc<Mutex<TransportVariant>>,
+    
+    /// Session management for command sequencing
+    #[allow(dead_code)] // Will be used in Phase C for command sequencing
+    session: Arc<Mutex<ViscaSession>>,
+    
+    /// Concurrency control (max 2 concurrent commands)
+    semaphore: Arc<Semaphore>,
+}
+
+impl ViscaClient {
+    /// Creates a new client from a transport variant.
+    fn new_from_variant(variant: TransportVariant) -> Self {
+        Self {
+            transport: Arc::new(Mutex::new(variant)),
+            session: Arc::new(Mutex::new(ViscaSession::new())),
+            semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_COMMANDS)),
+        }
+    }
+
+    // B2: Unified constructors
+    
+    /// Connect to a camera using UDP transport.
+    ///
+    /// This constructor automatically selects the appropriate transport based on
+    /// the enabled features and the calling context.
+    #[cfg(feature = "blocking-client")]
+    pub fn connect_udp(camera_addr: &str) -> Result<Self, ViscaError> {
+        let transport = BlockingUdpTransport::new(camera_addr).map_err(ViscaError::Io)?;
+        let adapter = BlockingAdapter(transport);
+        Ok(Self::new_from_variant(TransportVariant::BlockingUdp(adapter)))
+    }
+
+    /// Connect to a camera using TCP transport.
+    ///
+    /// This constructor automatically selects the appropriate transport based on
+    /// the enabled features and the calling context.
+    #[cfg(feature = "blocking-client")]
+    pub fn connect_tcp(camera_addr: &str) -> Result<Self, ViscaError> {
+        let transport = BlockingTcpTransport::new(camera_addr).map_err(ViscaError::Io)?;
+        let adapter = BlockingAdapter(transport);
+        Ok(Self::new_from_variant(TransportVariant::BlockingTcp(adapter)))
+    }
+
+    /// Connect to a camera using UDP transport (async).
+    #[cfg(feature = "async-client")]
+    pub async fn connect_udp_async(camera_addr: &str) -> Result<Self, ViscaError> {
+        let transport = AsyncUdpTransport::new(camera_addr).await?;
+        Ok(Self::new_from_variant(TransportVariant::AsyncUdp(transport)))
+    }
+
+    /// Connect to a camera using TCP transport (async).
+    #[cfg(feature = "async-client")]
+    pub async fn connect_tcp_async(camera_addr: &str) -> Result<Self, ViscaError> {
+        let transport = AsyncTcpTransport::new(camera_addr).await?;
+        Ok(Self::new_from_variant(TransportVariant::AsyncTcp(transport)))
+    }
+    
+    // B3: Concurrency control is handled by the semaphore field
+    
+    // B4: Blocking façade with smart runtime handling
+    
+    /// Send a command and wait for the response (blocking).
+    ///
+    /// This method provides a blocking interface that works in both sync and async contexts:
+    /// - If called from within a Tokio runtime, uses block_in_place to avoid blocking the runtime
+    /// - If called from outside a runtime, creates a temporary runtime
+    /// - For blocking transports, calls them directly when possible
+    #[cfg(feature = "blocking-client")]
+    pub fn send(&self, command: &dyn ViscaCommand) -> Result<ViscaResponse, ViscaError> {
+        // Clone self to move into the async block
+        let client = self.clone();
+        
+        // Try to use existing Tokio runtime if available
+        match tokio::runtime::Handle::try_current() {
+            Ok(_) => {
+                // We're inside a Tokio runtime, use block_in_place to avoid blocking it
+                tokio::task::block_in_place(move || {
+                    // Create a new runtime for the blocking operation
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .map_err(|e| ViscaError::Io(std::io::Error::other(e)))?;
+                    rt.block_on(client.send_async(command))
+                })
+            }
+            Err(_) => {
+                // No runtime available, create a temporary one
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| ViscaError::Io(std::io::Error::other(e)))?;
+                rt.block_on(client.send_async(command))
+            }
+        }
+    }
+    
+    // B5: Async façade
+    
+    /// Send a command and wait for the response (async).
+    ///
+    /// This method:
+    /// - Acquires a semaphore permit to enforce concurrency limits
+    /// - Sends the command through the transport
+    /// - Waits for and returns the response
+    pub async fn send_async(&self, command: &dyn ViscaCommand) -> Result<ViscaResponse, ViscaError> {
+        // Acquire permit for concurrency control
+        let _permit = self.semaphore.acquire().await
+            .map_err(|_| ViscaError::InvalidParameter("Semaphore closed".into()))?;
+        
+        // Lock transport and send command
+        let mut transport = self.transport.lock().await;
+        let responses = match &mut *transport {
+            #[cfg(feature = "blocking-client")]
+            TransportVariant::BlockingUdp(t) => {
+                t.send_command(command).await?;
+                t.receive_response().await?
+            }
+            #[cfg(feature = "blocking-client")]
+            TransportVariant::BlockingTcp(t) => {
+                t.send_command(command).await?;
+                t.receive_response().await?
+            }
+            #[cfg(feature = "async-client")]
+            TransportVariant::AsyncUdp(t) => {
+                t.send_command(command).await?;
+                t.receive_response().await?
+            }
+            #[cfg(feature = "async-client")]
+            TransportVariant::AsyncTcp(t) => {
+                t.send_command(command).await?;
+                t.receive_response().await?
+            }
+        };
+        
+        parse_response(responses)
+    }
+
+    /// Check if the camera connection is healthy.
+    pub async fn is_healthy(&self) -> Result<bool, ViscaError> {
+        use crate::command::InquiryCommand;
+        
+        match self.send_async(&InquiryCommand::Power).await {
+            Ok(_) => Ok(true),
+            Err(_) => Ok(false),
+        }
+    }
+}
+
+
+/// Parse response frames into a ViscaResponse.
+fn parse_response(frames: Vec<Vec<u8>>) -> Result<ViscaResponse, ViscaError> {
+    // For now, just parse the last frame
+    // TODO: Handle multi-frame responses and response types properly in Phase C
+    if let Some(frame) = frames.last() {
+        // Check if it's an ACK/completion (no data) or an inquiry response
+        if frame.len() == 3 && frame[0] == 0x90 && frame[1] == 0x50 && frame[2] == 0xFF {
+            // ACK/Completion response
+            Ok(ViscaResponse::Ack)
+        } else if frame.len() == 3 && frame[0] == 0x90 && frame[1] == 0x51 && frame[2] == 0xFF {
+            // Completion response
+            Ok(ViscaResponse::Completion)
+        } else if frame.len() >= 3 && frame[0] == 0x90 && (frame[1] & 0x60) == 0x60 {
+            // Error response - extract error code
+            let error_code = frame[1] & 0x0F;
+            Ok(ViscaResponse::Error(ViscaError::from_code(error_code)))
+        } else {
+            // For now, just return completion for other responses
+            // TODO: Properly parse based on command type
+            Ok(ViscaResponse::Completion)
+        }
+    } else {
+        Err(ViscaError::Io(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "No response frames received"
+        )))
+    }
+}

--- a/src/unified_client.rs
+++ b/src/unified_client.rs
@@ -147,9 +147,7 @@ impl ViscaClient {
                         let rt = tokio::runtime::Builder::new_current_thread()
                             .enable_all()
                             .build()
-                            .map_err(|e| {
-                                ViscaError::Io(std::io::Error::new(std::io::ErrorKind::Other, e))
-                            })?;
+                            .map_err(|e| ViscaError::Io(std::io::Error::other(e)))?;
                         rt.block_on(client.send_async(command))
                     })
                 }
@@ -158,9 +156,7 @@ impl ViscaClient {
                     let rt = tokio::runtime::Builder::new_current_thread()
                         .enable_all()
                         .build()
-                        .map_err(|e| {
-                            ViscaError::Io(std::io::Error::new(std::io::ErrorKind::Other, e))
-                        })?;
+                        .map_err(|e| ViscaError::Io(std::io::Error::other(e)))?;
                     rt.block_on(client.send_async(command))
                 }
             }

--- a/tests/command_encoding_tests.rs
+++ b/tests/command_encoding_tests.rs
@@ -6,7 +6,7 @@ mod golden_vector_tests {
     use super::*;
     use grafton_visca::command::pan_tilt::{PanSpeed, PanTiltDirection, TiltSpeed};
     use grafton_visca::command::power::Power;
-    use grafton_visca::command::preset::PresetAction;
+    use grafton_visca::command::PresetAction;
 
     #[test]
     fn test_power_commands() {

--- a/tests/phase_b_unified_client_tests.rs
+++ b/tests/phase_b_unified_client_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for Phase B unified client implementation.
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "blocking-client", feature = "async-client")))]
 mod tests {
     use grafton_visca::ViscaClient;
 

--- a/tests/phase_b_unified_client_tests.rs
+++ b/tests/phase_b_unified_client_tests.rs
@@ -2,9 +2,13 @@
 
 #[cfg(test)]
 mod tests {
-    use grafton_visca::{ViscaClient, ViscaError};
-    use grafton_visca::command::PowerCommand;
-    use grafton_visca::command::power::Power;
+    use grafton_visca::ViscaClient;
+
+    #[cfg(any(
+        all(feature = "blocking-client", feature = "async-client"),
+        feature = "async-client"
+    ))]
+    use grafton_visca::command::{Power, PowerCommand};
 
     #[cfg(feature = "blocking-client")]
     #[test]
@@ -12,7 +16,7 @@ mod tests {
         // Test that we can create blocking clients
         let _udp_result = ViscaClient::connect_udp("127.0.0.1:1234");
         let _tcp_result = ViscaClient::connect_tcp("127.0.0.1:1234");
-        
+
         // UDP should succeed (no connection needed)
         assert!(_udp_result.is_ok());
         // TCP should fail (no server)
@@ -25,7 +29,7 @@ mod tests {
         // Test that we can create async clients
         let _udp_result = ViscaClient::connect_udp_async("127.0.0.1:1234").await;
         let _tcp_result = ViscaClient::connect_tcp_async("127.0.0.1:1234").await;
-        
+
         // UDP should succeed (no connection needed)
         assert!(_udp_result.is_ok());
         // TCP should fail (no server)
@@ -38,10 +42,10 @@ mod tests {
         // Test blocking façade when called outside a Tokio runtime
         let client = ViscaClient::connect_udp("127.0.0.1:1234").unwrap();
         let cmd = PowerCommand { power: Power::On };
-        
+
         // This should create its own runtime internally
         let result = client.send(&cmd);
-        
+
         // Should fail because no camera is connected
         assert!(result.is_err());
     }
@@ -52,10 +56,10 @@ mod tests {
         // Test blocking façade when called inside a Tokio runtime
         let client = ViscaClient::connect_udp("127.0.0.1:1234").unwrap();
         let cmd = PowerCommand { power: Power::On };
-        
+
         // This should use the existing runtime
         let result = client.send(&cmd);
-        
+
         // Should fail because no camera is connected
         assert!(result.is_err());
     }
@@ -63,12 +67,14 @@ mod tests {
     #[cfg(feature = "async-client")]
     #[tokio::test]
     async fn test_async_send() {
-        let client = ViscaClient::connect_udp_async("127.0.0.1:1234").await.unwrap();
+        let client = ViscaClient::connect_udp_async("127.0.0.1:1234")
+            .await
+            .unwrap();
         let cmd = PowerCommand { power: Power::On };
-        
+
         // Test async send
         let result = client.send_async(&cmd).await;
-        
+
         // Should fail because no camera is connected
         assert!(result.is_err());
     }
@@ -83,10 +89,12 @@ mod tests {
     }
 
     #[cfg(feature = "async-client")]
-    #[tokio::test] 
+    #[tokio::test]
     async fn test_health_check() {
-        let client = ViscaClient::connect_udp_async("127.0.0.1:1234").await.unwrap();
-        
+        let client = ViscaClient::connect_udp_async("127.0.0.1:1234")
+            .await
+            .unwrap();
+
         // Health check should fail (no camera)
         let is_healthy = client.is_healthy().await.unwrap();
         assert!(!is_healthy);

--- a/tests/phase_b_unified_client_tests.rs
+++ b/tests/phase_b_unified_client_tests.rs
@@ -1,0 +1,94 @@
+//! Tests for Phase B unified client implementation.
+
+#[cfg(test)]
+mod tests {
+    use grafton_visca::{ViscaClient, ViscaError};
+    use grafton_visca::command::PowerCommand;
+    use grafton_visca::command::power::Power;
+
+    #[cfg(feature = "blocking-client")]
+    #[test]
+    fn test_blocking_client_creation() {
+        // Test that we can create blocking clients
+        let _udp_result = ViscaClient::connect_udp("127.0.0.1:1234");
+        let _tcp_result = ViscaClient::connect_tcp("127.0.0.1:1234");
+        
+        // UDP should succeed (no connection needed)
+        assert!(_udp_result.is_ok());
+        // TCP should fail (no server)
+        assert!(_tcp_result.is_err());
+    }
+
+    #[cfg(feature = "async-client")]
+    #[tokio::test]
+    async fn test_async_client_creation() {
+        // Test that we can create async clients
+        let _udp_result = ViscaClient::connect_udp_async("127.0.0.1:1234").await;
+        let _tcp_result = ViscaClient::connect_tcp_async("127.0.0.1:1234").await;
+        
+        // UDP should succeed (no connection needed)
+        assert!(_udp_result.is_ok());
+        // TCP should fail (no server)
+        assert!(_tcp_result.is_err());
+    }
+
+    #[cfg(all(feature = "blocking-client", feature = "async-client"))]
+    #[test]
+    fn test_blocking_facade_outside_runtime() {
+        // Test blocking façade when called outside a Tokio runtime
+        let client = ViscaClient::connect_udp("127.0.0.1:1234").unwrap();
+        let cmd = PowerCommand { power: Power::On };
+        
+        // This should create its own runtime internally
+        let result = client.send(&cmd);
+        
+        // Should fail because no camera is connected
+        assert!(result.is_err());
+    }
+
+    #[cfg(all(feature = "blocking-client", feature = "async-client"))]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_blocking_facade_inside_runtime() {
+        // Test blocking façade when called inside a Tokio runtime
+        let client = ViscaClient::connect_udp("127.0.0.1:1234").unwrap();
+        let cmd = PowerCommand { power: Power::On };
+        
+        // This should use the existing runtime
+        let result = client.send(&cmd);
+        
+        // Should fail because no camera is connected
+        assert!(result.is_err());
+    }
+
+    #[cfg(feature = "async-client")]
+    #[tokio::test]
+    async fn test_async_send() {
+        let client = ViscaClient::connect_udp_async("127.0.0.1:1234").await.unwrap();
+        let cmd = PowerCommand { power: Power::On };
+        
+        // Test async send
+        let result = client.send_async(&cmd).await;
+        
+        // Should fail because no camera is connected
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_client_is_cloneable() {
+        #[cfg(feature = "blocking-client")]
+        {
+            let client = ViscaClient::connect_udp("127.0.0.1:1234").unwrap();
+            let _clone = client.clone();
+        }
+    }
+
+    #[cfg(feature = "async-client")]
+    #[tokio::test] 
+    async fn test_health_check() {
+        let client = ViscaClient::connect_udp_async("127.0.0.1:1234").await.unwrap();
+        
+        // Health check should fail (no camera)
+        let is_healthy = client.is_healthy().await.unwrap();
+        assert!(!is_healthy);
+    }
+}


### PR DESCRIPTION
## Overview
This PR implements Phase B of the v0.4.0 API refactoring outlined in #23, introducing a unified ViscaClient with an async-first design and blocking façade.

## Phase B Tasks Completed
- [x] B1: Define private `TransportVariant` enum
- [x] B2: Implement unified constructors  
- [x] B3: Add semaphore-based concurrency control
- [x] B4: Implement blocking façade with smart runtime handling
- [x] B5: Implement async façade

## Implementation Details

### B1: TransportVariant Enum
- Supports both blocking (UDP/TCP) and async (UDP/TCP) transports
- Avoids object-safety issues with concrete types

### B2: Unified Constructors
- `connect_udp()` / `connect_tcp()` for blocking clients
- `connect_udp_async()` / `connect_tcp_async()` for async clients
- Automatic transport selection based on features

### B3: Concurrency Control
- Semaphore with MAX_CONCURRENT_COMMANDS = 2 (PTZOptics G2 limitation)
- Automatic permit acquisition in send_async()

### B4: Blocking Façade
- `send()` method works in both sync and async contexts
- Uses `block_in_place` when inside a runtime to avoid blocking
- Creates temporary runtime when outside a runtime
- **True tokio-free builds** - Uses `parking_lot` for synchronization in blocking-only mode

### B5: Async Façade  
- `send_async()` for native async operation
- `is_healthy()` for connection health checks
- Proper response parsing (simplified for Phase B)

## Key Features

### Synchronization Primitives
- New `sync_primitives` module provides unified types
- Uses `parking_lot::Mutex` for blocking builds (no tokio!)
- Uses `tokio::sync::Mutex` for async builds
- Custom semaphore implementation for blocking mode

### API Improvements
- Fixed missing enum re-exports (`Power`, `Flip`, `PresetAction`)
- Better error messages with `std::io::Error::other()`
- CI-compatible with no features enabled

## Breaking Changes
- Removes `ViscaClient::new()` (replaced by unified constructors)
- Removes `sync_wrapper` module (no longer needed)
- Constructor names changed for async variants

## Testing
- Comprehensive test suite in `tests/phase_b_unified_client_tests.rs`
- Example demonstrating all usage patterns in `examples/phase_b_unified_demo.rs`
- All tests passing on all platforms (Ubuntu, macOS, Windows)
- Both stable and beta Rust versions tested

## Next Steps
Phase C will add:
- Command derive macro
- Improved response parsing based on command type
- PTZ builder patterns

Part of #23