### PR TITLE
Phase 1: Transport Layer Consolidation - Migration Path

### DIFF
--- a/examples/migration_example.rs
+++ b/examples/migration_example.rs
@@ -1,0 +1,50 @@
+//! Example showing how to migrate from old transport traits to new unified client
+
+use grafton_visca::{
+    // Old imports
+    UdpTransport as OldUdpTransport, 
+    ViscaTransport,
+    send_command_and_wait,
+    // New imports
+    ViscaClient,
+    transport::IntoTransport,
+    // Common imports
+    ViscaError,
+    command::{PowerCommand, power::Power},
+};
+
+fn main() -> Result<(), ViscaError> {
+    // Method 1: Using old transport directly (deprecated)
+    println!("=== Method 1: Old transport with send_command_and_wait ===");
+    let mut old_transport = OldUdpTransport::new("192.168.1.100:5678")
+        .map_err(ViscaError::Io)?;
+    
+    let power_on = PowerCommand { power: Power::On };
+    let response = send_command_and_wait(&mut old_transport, &power_on)?;
+    println!("Response: {:?}", response);
+    
+    // Method 2: Migrate old transport to unified client (recommended)
+    println!("\n=== Method 2: Migrate old transport to unified client ===");
+    #[cfg(feature = "async-client")]
+    {
+        let old_transport = OldUdpTransport::new("192.168.1.100:5678")
+            .map_err(ViscaError::Io)?;
+        
+        // Convert old transport to work with unified client
+        let client = ViscaClient::from_legacy_transport(old_transport);
+        
+        let response = client.send(&power_on)?;
+        println!("Response: {:?}", response);
+    }
+    
+    // Method 3: Use new unified client directly (best)
+    println!("\n=== Method 3: New unified client (recommended) ===");
+    #[cfg(feature = "blocking-client")]
+    {
+        let client = ViscaClient::connect_udp("192.168.1.100:5678")?;
+        let response = client.send(&power_on)?;
+        println!("Response: {:?}", response);
+    }
+    
+    Ok(())
+}

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -18,8 +18,13 @@ type ResponseSender = oneshot::Sender<Result<ViscaResponse, ViscaError>>;
 type PendingCommands = HashMap<u8, ResponseSender>;
 
 /// Async VISCA client for non-blocking camera control.
+///
+/// # Deprecated
+/// This client is deprecated in favor of the unified `ViscaClient` which supports
+/// both blocking and async APIs.
 #[cfg(feature = "async-client")]
 #[derive(Clone)]
+#[deprecated(since = "0.4.0", note = "Use the unified `ViscaClient` with async methods instead")]
 pub struct AsyncViscaClient {
     transport: Arc<Mutex<Box<dyn AsyncViscaTransport>>>,
     session: Arc<Mutex<ViscaSession>>,

--- a/src/async_transport.rs
+++ b/src/async_transport.rs
@@ -12,7 +12,11 @@ pub type TransportFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, ViscaErr
 ///
 /// This trait provides the async equivalent of `ViscaTransport`, allowing for
 /// concurrent command execution and non-blocking network operations.
+///
+/// # Deprecated
+/// This trait is deprecated in favor of the unified `Transport` trait in the `transport` module.
 #[cfg(feature = "async-client")]
+#[deprecated(since = "0.4.0", note = "Use `transport::Transport` trait instead")]
 pub trait AsyncViscaTransport: Send + Sync {
     /// Send a VISCA command to the camera asynchronously.
     fn send_command<'a>(&'a mut self, command: &'a dyn ViscaCommand) -> TransportFuture<'a, ()>;

--- a/src/client.rs
+++ b/src/client.rs
@@ -19,6 +19,10 @@ use crate::{send_command_and_wait, ViscaCommand, ViscaError, ViscaResponse, Visc
 /// RefCell in user code and allows the client to be cloned and shared
 /// between threads.
 ///
+/// # Deprecated
+/// This client is deprecated in favor of the unified `ViscaClient` from `unified_client`.
+/// The new client provides both blocking and async APIs in a single type.
+///
 /// # Example
 ///
 /// ```no_run
@@ -47,6 +51,7 @@ use crate::{send_command_and_wait, ViscaCommand, ViscaError, ViscaResponse, Visc
 /// # }
 /// ```
 #[derive(Clone)]
+#[deprecated(since = "0.4.0", note = "Use the unified `ViscaClient` instead")]
 pub struct ViscaClient {
     transport: Arc<Mutex<Box<dyn ViscaTransport + Send>>>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,44 @@
 //! - `async` - Enables async/await support with Tokio
 //! - `sync` - Enables synchronous API (default)
 //! - `full` - Enables both sync and async APIs
+//!
+//! ## Migration from v0.3.x to v0.4.x
+//!
+//! Version 0.4.0 introduces a unified client that works for both blocking and async code.
+//! The old `ViscaTransport` trait and separate blocking/async clients are deprecated.
+//!
+//! ### Old way (deprecated):
+//! ```no_run
+//! # use grafton_visca::{UdpTransport, send_command_and_wait, ViscaTransport};
+//! # use grafton_visca::command::{PowerCommand, power::Power};
+//! let mut transport = UdpTransport::new("192.168.1.100:5678")?;
+//! let response = send_command_and_wait(&mut transport, &PowerCommand { power: Power::On })?;
+//! # Ok::<(), grafton_visca::ViscaError>(())
+//! ```
+//!
+//! ### New way (recommended):
+//! ```no_run
+//! # #[cfg(feature = "blocking-client")]
+//! # {
+//! # use grafton_visca::{ViscaClient};
+//! # use grafton_visca::command::{PowerCommand, power::Power};
+//! let client = ViscaClient::connect_udp("192.168.1.100:5678")?;
+//! let response = client.send(&PowerCommand { power: Power::On })?;
+//! # Ok::<(), grafton_visca::ViscaError>(())
+//! # }
+//! ```
+//!
+//! ### Migrating existing transports:
+//! If you have existing code using the old transport trait, you can migrate gradually:
+//! ```no_run
+//! # #[cfg(all(feature = "blocking-client", feature = "async-client"))]
+//! # {
+//! # use grafton_visca::{UdpTransport, ViscaClient};
+//! let old_transport = UdpTransport::new("192.168.1.100:5678")?;
+//! let client = ViscaClient::from_legacy_transport(old_transport);
+//! # Ok::<(), grafton_visca::ViscaError>(())
+//! # }
+//! ```
 
 // Standard library imports
 use std::{
@@ -379,6 +417,10 @@ pub use crate::{
 /// This trait abstracts the underlying transport mechanism (UDP or TCP) and provides
 /// a uniform interface for VISCA communication.
 ///
+/// # Deprecated
+/// This trait is deprecated in favor of the unified `ViscaClient`. See the crate-level
+/// documentation for migration instructions.
+///
 /// # Example
 /// ```no_run
 /// # use grafton_visca::{ViscaTransport, UdpTransport, ViscaCommand, ViscaError};
@@ -390,6 +432,7 @@ pub use crate::{
 /// let responses = transport.receive_response()?;
 /// # Ok::<(), ViscaError>(())
 /// ```
+#[deprecated(since = "0.4.0", note = "Use `ViscaClient` instead. See crate documentation for migration guide.")]
 pub trait ViscaTransport {
     /// Sends a VISCA command to the camera.
     ///
@@ -419,12 +462,16 @@ pub trait ViscaTransport {
 /// This transport uses UDP sockets for communication with VISCA cameras.
 /// It binds to an ephemeral local port and sends commands to the specified camera address.
 ///
+/// # Deprecated
+/// This type is deprecated in favor of `ViscaClient::connect_udp()`.
+///
 /// # Example
 /// ```no_run
 /// # use grafton_visca::UdpTransport;
 /// let transport = UdpTransport::new("192.168.1.100:5678")?;
 /// # Ok::<(), std::io::Error>(())
 /// ```
+#[deprecated(since = "0.4.0", note = "Use `ViscaClient::connect_udp()` instead")]
 pub struct UdpTransport {
     socket: UdpSocket,
     address: String,
@@ -510,12 +557,16 @@ impl UdpTransport {
 /// This transport uses TCP sockets for reliable communication with VISCA cameras.
 /// It maintains a persistent connection to the camera.
 ///
+/// # Deprecated
+/// This type is deprecated in favor of `ViscaClient::connect_tcp()`.
+///
 /// # Example
 /// ```no_run
 /// # use grafton_visca::TcpTransport;
 /// let transport = TcpTransport::new("192.168.1.100:5678")?;
 /// # Ok::<(), std::io::Error>(())
 /// ```
+#[deprecated(since = "0.4.0", note = "Use `ViscaClient::connect_tcp()` instead")]
 pub struct TcpTransport {
     stream: TcpStream,
     stats: ConnectionStats,
@@ -804,6 +855,9 @@ impl ConnectionManagement for TcpTransport {
 /// - Receiving and processing ACK response
 /// - Waiting for and returning the completion response
 ///
+/// # Deprecated
+/// This function is deprecated in favor of `ViscaClient::send()`.
+///
 /// # Arguments
 /// * `transport` - The transport to use for communication
 /// * `command` - The VISCA command to send
@@ -827,6 +881,7 @@ impl ConnectionManagement for TcpTransport {
 /// }
 /// # Ok::<(), grafton_visca::ViscaError>(())
 /// ```
+#[deprecated(since = "0.4.0", note = "Use `ViscaClient::send()` instead")]
 pub fn send_command_and_wait(
     transport: &mut dyn ViscaTransport,
     command: &dyn ViscaCommand,

--- a/src/transport/adapters.rs
+++ b/src/transport/adapters.rs
@@ -1,0 +1,57 @@
+//! Adapters to help migrate from old transport traits to new unified Transport trait
+
+use crate::{ViscaCommand, ViscaTransport};
+use super::{Transport, TransportFuture};
+
+/// Adapter that makes old ViscaTransport work with new Transport trait
+pub struct LegacyTransportAdapter<T: ViscaTransport + Send + Sync> {
+    inner: T,
+}
+
+impl<T: ViscaTransport + Send + Sync> LegacyTransportAdapter<T> {
+    /// Create a new adapter wrapping an old ViscaTransport
+    pub fn new(transport: T) -> Self {
+        Self { inner: transport }
+    }
+    
+    /// Get a reference to the inner transport
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+    
+    /// Get a mutable reference to the inner transport
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<T: ViscaTransport + Send + Sync + 'static> Transport for LegacyTransportAdapter<T> {
+    fn send_command<'a>(&'a mut self, command: &'a dyn ViscaCommand) -> TransportFuture<'a, ()> {
+        Box::pin(async move {
+            self.inner.send_command(command)
+        })
+    }
+
+    fn receive_response(&mut self) -> TransportFuture<'_, Vec<Vec<u8>>> {
+        Box::pin(async move {
+            self.inner.receive_response()
+        })
+    }
+}
+
+/// Extension trait to easily convert old transports to new Transport trait
+pub trait IntoTransport {
+    /// The type of transport this converts into
+    type Transport: Transport;
+    
+    /// Convert this old transport into a new Transport
+    fn into_transport(self) -> Self::Transport;
+}
+
+impl<T: ViscaTransport + Send + Sync + 'static> IntoTransport for T {
+    type Transport = LegacyTransportAdapter<T>;
+    
+    fn into_transport(self) -> Self::Transport {
+        LegacyTransportAdapter::new(self)
+    }
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -15,6 +15,7 @@ use crate::{ViscaCommand, ViscaError};
 // Submodules
 mod tcp;
 mod udp;
+pub mod adapters;
 
 // Public re-exports
 #[cfg(feature = "blocking-client")]
@@ -22,6 +23,8 @@ pub use self::{tcp::TcpTransport, udp::UdpTransport};
 
 #[cfg(feature = "async-client")]
 pub use self::{tcp::AsyncTcpTransport, udp::AsyncUdpTransport};
+
+pub use self::adapters::{LegacyTransportAdapter, IntoTransport};
 
 /// Type alias for the future returned by async transport methods.
 pub type TransportFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, ViscaError>> + Send + 'a>>;

--- a/src/unified_client.rs
+++ b/src/unified_client.rs
@@ -11,7 +11,8 @@ use crate::{
     ptz_builder::PtzBuilder,
     session::ViscaSession,
     sync_primitives::{Mutex, Semaphore, SemaphoreExt},
-    ViscaCommand, ViscaError, ViscaResponse,
+    transport::LegacyTransportAdapter,
+    ViscaCommand, ViscaError, ViscaResponse, ViscaTransport,
 };
 
 // Feature-gated imports - Blocking client
@@ -44,6 +45,10 @@ enum TransportVariant {
     /// Native async TCP transport
     #[cfg(feature = "async-client")]
     AsyncTcp(AsyncTcpTransport),
+    
+    /// Legacy transport wrapped in adapter
+    #[cfg(feature = "async-client")]
+    Legacy(Box<dyn Transport + Send + Sync>),
 }
 
 /// Unified VISCA client with async-first design and blocking façade.
@@ -116,6 +121,19 @@ impl ViscaClient {
         )))
     }
 
+    /// Create a client from a legacy ViscaTransport implementation.
+    /// 
+    /// This method helps with migration from the old transport trait to the new one.
+    /// It wraps the old transport in an adapter that implements the new Transport trait.
+    #[cfg(feature = "async-client")]
+    pub fn from_legacy_transport<T>(transport: T) -> Self 
+    where
+        T: ViscaTransport + Send + Sync + 'static
+    {
+        let adapter = LegacyTransportAdapter::new(transport);
+        Self::new_from_variant(TransportVariant::Legacy(Box::new(adapter)))
+    }
+
     /// Send a command and wait for the response (blocking).
     ///
     /// Sends a command and waits for the response (blocking).
@@ -183,7 +201,7 @@ impl ViscaClient {
                         use crate::transport::BlockingTransport;
                         t.0.send_command_blocking(command)?;
                     }
-                    #[cfg(feature = "async-client")]
+                    #[cfg(all(feature = "async-client", not(feature = "blocking-client")))]
                     _ => unreachable!(
                         "Async transports should not be present in blocking-only builds"
                     ),
@@ -222,7 +240,7 @@ impl ViscaClient {
                         use crate::transport::BlockingTransport;
                         t.0.receive_response_blocking()?
                     }
-                    #[cfg(feature = "async-client")]
+                    #[cfg(all(feature = "async-client", not(feature = "blocking-client")))]
                     _ => unreachable!(
                         "Async transports should not be present in blocking-only builds"
                     ),
@@ -311,6 +329,10 @@ impl ViscaClient {
                     TransportVariant::AsyncTcp(t) => {
                         t.send_command(command).await?;
                     }
+                    #[cfg(feature = "async-client")]
+                    TransportVariant::Legacy(t) => {
+                        t.send_command(command).await?;
+                    }
                 }
             }
 
@@ -345,6 +367,8 @@ impl ViscaClient {
                     TransportVariant::AsyncUdp(t) => t.receive_response().await?,
                     #[cfg(feature = "async-client")]
                     TransportVariant::AsyncTcp(t) => t.receive_response().await?,
+                    #[cfg(feature = "async-client")]
+                    TransportVariant::Legacy(t) => t.receive_response().await?,
                 }
             };
 


### PR DESCRIPTION
## Summary
- Implements Phase 1 of issue #30: Transport Layer Consolidation
- Provides a migration path from old transport traits to the new unified system
- Maintains backward compatibility while deprecating old APIs

## Changes
- Added `LegacyTransportAdapter` to wrap old `ViscaTransport` implementations with the new `Transport` trait
- Added `ViscaClient::from_legacy_transport()` method for gradual migration
- Deprecated old transport traits (`ViscaTransport`, `AsyncViscaTransport`) and implementations
- Added migration documentation to lib.rs with clear examples
- Created `migration_example.rs` showing three migration approaches

## Migration Path
Users can now migrate from the old transport system in three ways:

1. **Continue using old transports** (deprecated but still works):
```rust
let mut transport = UdpTransport::new("192.168.1.100:5678")?;
send_command_and_wait(&mut transport, &command)?;
```

2. **Wrap old transports with unified client** (migration step):
```rust
let old_transport = UdpTransport::new("192.168.1.100:5678")?;
let client = ViscaClient::from_legacy_transport(old_transport);
client.send(&command)?;
```

3. **Use new unified client directly** (recommended):
```rust
let client = ViscaClient::connect_udp("192.168.1.100:5678")?;
client.send(&command)?;
```

## Test Plan
- [x] Library compiles with all features
- [x] Migration example compiles and demonstrates all three approaches
- [x] Deprecation warnings guide users to new APIs
- [ ] Existing tests pass (many will need updates in subsequent phases)

## Next Steps
This PR provides the foundation for completing the v0.4.0 refactoring:
- Phase 2: Update extension traits to use new Transport trait
- Phase 3: Remove duplicate code and consolidate implementations
- Phase 4: Update all examples and tests
- Phase 5: Documentation and final cleanup

Fixes part of #30