### PR TITLE
feat: Add deprecation warnings for old type names (Phase 3)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,3 +394,43 @@ pub trait Transport {
     /// or if communication with the camera fails.
     fn execute_command(&mut self, command: &dyn Command) -> Result<Response, Error>;
 }
+
+// ============================================================================================
+// Backward Compatibility Type Aliases (Deprecated)
+// ============================================================================================
+//
+// These type aliases are provided for backward compatibility with v0.4.x and earlier.
+// They will be removed in v1.0. Please migrate to the new names.
+
+/// Type alias for backward compatibility. Use `Client` instead.
+#[deprecated(
+    since = "0.5.0",
+    note = "Use `grafton_visca::Client` instead. The `Visca` prefix is redundant in the crate namespace."
+)]
+#[cfg(any(feature = "blocking-client", feature = "async-client"))]
+pub type ViscaClient = Client;
+
+/// Type alias for backward compatibility. Use `Error` instead.
+#[deprecated(
+    since = "0.5.0",
+    note = "Use `grafton_visca::Error` instead. The `Visca` prefix is redundant in the crate namespace."
+)]
+pub type ViscaError = Error;
+
+/// Type alias for backward compatibility. Use `Session` instead.
+#[deprecated(
+    since = "0.5.0",
+    note = "Use `grafton_visca::Session` instead. The `Visca` prefix is redundant in the crate namespace."
+)]
+pub type ViscaSession = Session;
+
+/// Type alias for backward compatibility. Use `Response` instead.
+#[deprecated(
+    since = "0.5.0",
+    note = "Use `grafton_visca::Response` instead. The `Visca` prefix is redundant in the crate namespace."
+)]
+pub type ViscaResponse = Response;
+
+// Note: ViscaCommand and ViscaTransport cannot be provided as type aliases because
+// Command and Transport are traits, not types. Users should directly use the
+// `grafton_visca::Command` and `grafton_visca::Transport` traits.


### PR DESCRIPTION
## Summary
- Implements Phase 3 of issue #50 by adding backward compatibility type aliases with deprecation warnings
- Helps users migrate from old \Visca\ prefixed names to cleaner v0.5.0 names

## Changes
- Add deprecated type aliases for:
  -  → 
  -  → 
  -  → 
  -  → 
- Note:  and  cannot be aliased since they are traits, not types

## Migration Notes
Users will see deprecation warnings when using old names:
\\grafton_visca::ViscaClient\grafton_visca::Client\Visca\\

These aliases will be removed in v1.0.

## Test Plan
- [x] All tests pass (493 tests)
- [x] Code compiles with deprecation warnings when using old names
- [x] No clippy warnings
- [x] Code properly formatted

Closes #50