### PR TITLE
feat: Implement CameraBuilder API (closes #185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] - Unreleased
+## [0.5.0] - Unreleased
+
+### Breaking Changes
+
+#### 🔥 New CameraBuilder API (Issue #185)
+- **BREAKING**: Removed all `connect_*` functions (`connect_tcp`, `connect_udp`, `connect_tokio_tcp`, `connect_tokio_udp`)
+- **NEW**: Introduced `CameraBuilder` for a cleaner, more idiomatic API:
+  ```rust
+  // Before (removed):
+  let camera = Camera::<PTZOpticsG2, _>::connect_tcp("192.168.1.100:52381")?;
+  
+  // After (new):
+  let camera = CameraBuilder::tcp("192.168.1.100:52381")
+      .profile::<PTZOpticsG2>()
+      .build()?;
+  ```
+- Benefits of the new API:
+  - Runtime parameters (address, protocol) come first
+  - Compile-time profile selection comes second
+  - Single entry point (`CameraBuilder`) for all transport types
+  - More extensible for future transport options
+
+### Changed
+- Updated all examples to use the new `CameraBuilder` API
+- Updated README and documentation with new builder pattern examples
+
+## [0.4.0] - 2024-12-27
 
 This release represents a major evolution of the library from a low-level VISCA protocol implementation to a high-level camera control solution with a unified, ergonomic API.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "grafton-visca-macros"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Grant Sparks <grant@grafton.ai>"]
 license = "Apache-2.0"
 repository = "https://github.com/GrantSparks/grafton-visca"
@@ -34,7 +34,7 @@ tokio = ["async", "dep:tokio"]
 async-trait = "0.1"
 bytes = "1.5"
 futures = "0.3"
-grafton-visca-macros = { version = "0.5.0", path = "grafton-visca-macros" }
+grafton-visca-macros = { version = "0.6.0", path = "grafton-visca-macros" }
 log = "0.4.22"
 env_logger = "0.11.5"
 nom = "7.1.3"
@@ -52,6 +52,7 @@ tokio = { version = "1.38", features = [
 
 [dev-dependencies]
 tokio = { version = "1.38", features = ["full", "test-util"] }
+trybuild = "1.0"
 
 [[example]]
 name = "async_concurrent"
@@ -168,4 +169,11 @@ required-features = ["tokio"]
 
 [[example]]
 name = "simplified_async_demo"
+required-features = ["tokio"]
+
+[[example]]
+name = "builder_blocking"
+
+[[example]]
+name = "builder_async"
 required-features = ["tokio"]

--- a/README.md
+++ b/README.md
@@ -35,14 +35,16 @@ All command encoders/decoders compile and have unit / property tests, but **the 
 use grafton_visca::{
     blocking::prelude::*,
     camera::profiles::PTZOpticsG2,
-    Camera,
+    CameraBuilder,
 };
 
 fn main() -> grafton_visca::Result<()> {
     env_logger::init();
 
-    // Ergonomic helper: creates a TCP transport and the camera object
-    let cam = Camera::<PTZOpticsG2, _>::connect_tcp("192.168.1.100:52381")?;
+    // Create camera using the builder pattern
+    let cam = CameraBuilder::tcp("192.168.1.100:52381")
+        .profile::<PTZOpticsG2>()
+        .build()?;
 
     cam.power_on()?;            // turns the camera on
     cam.pan_tilt_home()?;       // move to home
@@ -57,12 +59,15 @@ fn main() -> grafton_visca::Result<()> {
 use grafton_visca::{
     r#async::prelude::*,
     camera::profiles::PTZOpticsG2,
-    Camera,
+    CameraBuilder,
 };
 
 #[tokio::main]
 async fn main() -> grafton_visca::Result<()> {
-    let cam = Camera::<PTZOpticsG2, _>::connect_tokio_tcp("192.168.1.100:52381").await?;
+    let cam = CameraBuilder::tokio_tcp("192.168.1.100:52381")
+        .profile::<PTZOpticsG2>()
+        .build()
+        .await?;
     cam.power_on().await?;
     cam.zoom_in().await?;
     cam.zoom_stop().await?;
@@ -112,9 +117,13 @@ Each profile implements capability traits (`HasZoom`, `HasNDFilter`, …).
 If a capability is absent the corresponding extension trait is **not** in scope, so unsupported calls fail at compile time. Example:
 
 ```rust,ignore
-let cam = Camera::<SonyFR7, _>::connect_tcp("...")?;
+let cam = CameraBuilder::tcp("192.168.1.100:52381")
+    .profile::<SonyFR7>()
+    .build()?;
 // cam.set_nd_filter_mode(NDFilterMode::Variable)?;  // ✅ FR7 supports this
-let b = Camera::<PTZOpticsG2, _>::connect_tcp("...")?;
+let b = CameraBuilder::tcp("192.168.1.101:52381")
+    .profile::<PTZOpticsG2>()
+    .build()?;
 // b.set_nd_filter_mode(NDFilterMode::Variable)?;     // ❌ compile‑error
 ```
 

--- a/examples/builder_async.rs
+++ b/examples/builder_async.rs
@@ -1,0 +1,114 @@
+//! Example demonstrating the CameraBuilder API for async transports with tokio
+//!
+//! This example shows how to use the builder pattern to create cameras
+//! with different profiles and transports in async mode using tokio.
+
+use grafton_visca::{
+    camera::profiles::{GenericVisca, PTZOpticsG2, SonyBRC300},
+    CameraBuilder, Result,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::init();
+
+    // Example 1: Creating an async TCP camera with PTZOpticsG2 profile
+    println!("=== Example 1: Async TCP with PTZOpticsG2 profile ===");
+    let tcp_camera = CameraBuilder::tokio_tcp("192.168.1.100:52381")
+        .profile::<PTZOpticsG2>()
+        .build()
+        .await;
+
+    match tcp_camera {
+        Ok(_camera) => {
+            println!("Successfully created async TCP camera with PTZOpticsG2 profile");
+            // You can now use the camera with async methods
+            // For example: camera.pan_tilt_home().await?;
+        }
+        Err(e) => {
+            println!("Failed to create async TCP camera: {}", e);
+        }
+    }
+
+    // Example 2: Creating an async UDP camera with GenericVisca profile
+    println!("\n=== Example 2: Async UDP with GenericVisca profile ===");
+    let udp_camera = CameraBuilder::tokio_udp("239.0.0.1:52381")
+        .profile::<GenericVisca>()
+        .build()
+        .await;
+
+    match udp_camera {
+        Ok(_camera) => {
+            println!("Successfully created async UDP camera with GenericVisca profile");
+            // All camera methods are async when using tokio transports
+        }
+        Err(e) => {
+            println!("Failed to create async UDP camera: {}", e);
+        }
+    }
+
+    // Example 3: Using different camera profiles
+    println!("\n=== Example 3: Different Camera Profiles ===");
+
+    // The builder supports any type that implements the Profile trait
+    let sony_camera = CameraBuilder::tokio_tcp("192.168.1.101:52381")
+        .profile::<SonyBRC300>()
+        .build()
+        .await;
+
+    match sony_camera {
+        Ok(_camera) => {
+            println!("Successfully created camera with SonyBRC300 profile");
+            // The SonyBRC300 profile provides Sony-specific capabilities
+        }
+        Err(e) => {
+            println!("Failed to create Sony camera: {}", e);
+        }
+    }
+
+    // Example 4: Concurrent camera creation
+    println!("\n=== Example 4: Concurrent Camera Creation ===");
+
+    use tokio::join;
+
+    // Create multiple cameras concurrently
+    let (cam1_result, cam2_result, cam3_result) = join!(
+        CameraBuilder::tokio_tcp("192.168.1.100:52381")
+            .profile::<PTZOpticsG2>()
+            .build(),
+        CameraBuilder::tokio_tcp("192.168.1.101:52381")
+            .profile::<PTZOpticsG2>()
+            .build(),
+        CameraBuilder::tokio_tcp("192.168.1.102:52381")
+            .profile::<PTZOpticsG2>()
+            .build()
+    );
+
+    let created_count = [&cam1_result, &cam2_result, &cam3_result]
+        .iter()
+        .filter(|r| r.is_ok())
+        .count();
+
+    println!(
+        "Successfully created {} out of 3 cameras concurrently",
+        created_count
+    );
+
+    // Example 5: Type safety with async builders
+    println!("\n=== Example 5: Type Safety in Async Context ===");
+
+    // The same compile-time guarantees apply to async builders:
+    // 1. Must call .profile() before .build()
+    // 2. Cannot call .profile() twice
+    // 3. Profile type must implement the Profile trait
+
+    // Additionally, .build() returns a Future that must be awaited
+    // This would not compile without .await:
+    // let camera = CameraBuilder::tokio_tcp("192.168.1.100:52381")
+    //     .profile::<PTZOpticsG2>()
+    //     .build();  // Error: unused implementer of `Future`
+
+    println!("Async builders maintain the same type safety guarantees!");
+
+    Ok(())
+}

--- a/examples/builder_async.rs
+++ b/examples/builder_async.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
             // For example: camera.pan_tilt_home().await?;
         }
         Err(e) => {
-            println!("Failed to create async TCP camera: {}", e);
+            println!("Failed to create async TCP camera: {e}");
         }
     }
 
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
             // All camera methods are async when using tokio transports
         }
         Err(e) => {
-            println!("Failed to create async UDP camera: {}", e);
+            println!("Failed to create async UDP camera: {e}");
         }
     }
 
@@ -62,7 +62,7 @@ async fn main() -> Result<()> {
             // The SonyBRC300 profile provides Sony-specific capabilities
         }
         Err(e) => {
-            println!("Failed to create Sony camera: {}", e);
+            println!("Failed to create Sony camera: {e}");
         }
     }
 
@@ -89,10 +89,7 @@ async fn main() -> Result<()> {
         .filter(|r| r.is_ok())
         .count();
 
-    println!(
-        "Successfully created {} out of 3 cameras concurrently",
-        created_count
-    );
+    println!("Successfully created {created_count} out of 3 cameras concurrently");
 
     // Example 5: Type safety with async builders
     println!("\n=== Example 5: Type Safety in Async Context ===");

--- a/examples/builder_blocking.rs
+++ b/examples/builder_blocking.rs
@@ -24,7 +24,7 @@ fn main() -> Result<()> {
             // For example: camera.pan_tilt_home()?;
         }
         Err(e) => {
-            println!("Failed to create TCP camera: {}", e);
+            println!("Failed to create TCP camera: {e}");
         }
     }
 
@@ -40,7 +40,7 @@ fn main() -> Result<()> {
             // The GenericVisca profile supports a wide range of VISCA commands
         }
         Err(e) => {
-            println!("Failed to create UDP camera: {}", e);
+            println!("Failed to create UDP camera: {e}");
         }
     }
 
@@ -72,7 +72,7 @@ fn main() -> Result<()> {
         .build();
 
     if let Err(e) = result {
-        println!("Expected error for invalid address: {}", e);
+        println!("Expected error for invalid address: {e}");
     }
 
     Ok(())

--- a/examples/builder_blocking.rs
+++ b/examples/builder_blocking.rs
@@ -1,0 +1,79 @@
+//! Example demonstrating the CameraBuilder API for blocking transports
+//!
+//! This example shows how to use the builder pattern to create cameras
+//! with different profiles and transports in blocking mode.
+
+use grafton_visca::{
+    camera::profiles::{GenericVisca, PTZOpticsG2},
+    CameraBuilder, Result,
+};
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    // Example 1: Creating a TCP camera with PTZOpticsG2 profile
+    println!("=== Example 1: TCP with PTZOpticsG2 profile ===");
+    let tcp_camera = CameraBuilder::tcp("192.168.1.100:52381")
+        .profile::<PTZOpticsG2>()
+        .build();
+
+    match tcp_camera {
+        Ok(_camera) => {
+            println!("Successfully created TCP camera with PTZOpticsG2 profile");
+            // You can now use the camera to send commands
+            // For example: camera.pan_tilt_home()?;
+        }
+        Err(e) => {
+            println!("Failed to create TCP camera: {}", e);
+        }
+    }
+
+    // Example 2: Creating a UDP camera with GenericVisca profile
+    println!("\n=== Example 2: UDP with GenericVisca profile ===");
+    let udp_camera = CameraBuilder::udp("239.0.0.1:52381")
+        .profile::<GenericVisca>()
+        .build();
+
+    match udp_camera {
+        Ok(_camera) => {
+            println!("Successfully created UDP camera with GenericVisca profile");
+            // The GenericVisca profile supports a wide range of VISCA commands
+        }
+        Err(e) => {
+            println!("Failed to create UDP camera: {}", e);
+        }
+    }
+
+    // Example 3: Demonstrating compile-time type safety
+    println!("\n=== Example 3: Type Safety ===");
+
+    // The builder pattern ensures type safety at compile time:
+    // 1. You must call .profile() before .build()
+    // 2. You cannot call .profile() twice
+    // 3. The profile type must implement the Profile trait
+
+    // This would not compile:
+    // let camera = CameraBuilder::tcp("192.168.1.100:52381").build();
+    //              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    //              Error: no method named `build` found
+
+    // This would also not compile:
+    // let camera = CameraBuilder::tcp("192.168.1.100:52381")
+    //     .profile::<PTZOpticsG2>()
+    //     .profile::<GenericVisca>()  // Error: no method named `profile`
+    //     .build();
+
+    println!("The builder API enforces correct usage at compile time!");
+
+    // Example 4: Handling connection errors gracefully
+    println!("\n=== Example 4: Error Handling ===");
+    let result = CameraBuilder::tcp("invalid-address:not-a-port")
+        .profile::<PTZOpticsG2>()
+        .build();
+
+    if let Err(e) = result {
+        println!("Expected error for invalid address: {}", e);
+    }
+
+    Ok(())
+}

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -7,8 +7,7 @@
 //! - Blocking: cargo run --example hello_world <camera_ip:port>
 //! - Async: cargo run --example hello_world --features tokio <camera_ip:port>
 
-use grafton_visca::camera::{profiles::PTZOpticsG2, Camera};
-use grafton_visca::Result;
+use grafton_visca::{camera::profiles::PTZOpticsG2, CameraBuilder, Result};
 use std::env;
 
 // Import operation traits for blocking operations
@@ -31,8 +30,10 @@ fn main() -> Result<()> {
 
     println!("Connecting to camera at {camera_addr} (blocking mode)");
 
-    // Create camera using the new profile-centric connection helper
-    let camera = Camera::<PTZOpticsG2, _>::connect_tcp(&camera_addr)?;
+    // Create camera using the new builder pattern
+    let camera = CameraBuilder::tcp(&camera_addr)
+        .profile::<PTZOpticsG2>()
+        .build()?;
 
     // Power on the camera
     println!("Powering on camera...");
@@ -63,8 +64,11 @@ async fn main() -> Result<()> {
 
     println!("Connecting to camera at {camera_addr} (async mode)");
 
-    // Create camera using the new profile-centric async connection helper
-    let camera = Camera::<PTZOpticsG2, _>::connect_tokio_tcp(&camera_addr).await?;
+    // Create camera using the new builder pattern
+    let camera = CameraBuilder::tokio_tcp(&camera_addr)
+        .profile::<PTZOpticsG2>()
+        .build()
+        .await?;
 
     // Power on the camera
     println!("Powering on camera...");

--- a/examples/profile_connection_demo.rs
+++ b/examples/profile_connection_demo.rs
@@ -9,7 +9,7 @@
 //! - Async TCP: cargo run --example profile_connection_demo --features tokio async-tcp <camera_ip:port>
 //! - Async UDP: cargo run --example profile_connection_demo --features tokio async-udp <camera_ip:port>
 
-use grafton_visca::camera::Camera;
+use grafton_visca::CameraBuilder;
 
 #[cfg(not(feature = "tokio"))]
 use grafton_visca::camera::profiles::{GenericVisca, PTZOpticsG2};
@@ -43,7 +43,9 @@ fn main() -> Result<()> {
     match transport_type.as_str() {
         "tcp" => {
             println!("Connecting to PTZOptics G2 camera via TCP at {camera_addr}");
-            let camera = Camera::<PTZOpticsG2, _>::connect_tcp(camera_addr)?;
+            let camera = CameraBuilder::tcp(camera_addr)
+                .profile::<PTZOpticsG2>()
+                .build()?;
 
             println!("Model: {}", camera.model_name());
             println!("Power on...");
@@ -57,7 +59,9 @@ fn main() -> Result<()> {
         }
         "udp" => {
             println!("Connecting to Generic VISCA camera via UDP at {camera_addr}");
-            let camera = Camera::<GenericVisca, _>::connect_udp(camera_addr)?;
+            let camera = CameraBuilder::udp(camera_addr)
+                .profile::<GenericVisca>()
+                .build()?;
 
             println!("Model: {}", camera.model_name());
             println!("Power on...");
@@ -92,7 +96,10 @@ async fn main() -> Result<()> {
     match transport_type.as_str() {
         "async-tcp" => {
             println!("Connecting to Sony FR7 camera via async TCP at {camera_addr}");
-            let camera = Camera::<SonyFR7, _>::connect_tokio_tcp(camera_addr).await?;
+            let camera = CameraBuilder::tokio_tcp(camera_addr)
+                .profile::<SonyFR7>()
+                .build()
+                .await?;
 
             println!("Model: {}", camera.model_name());
             println!("This camera supports ND filters!");
@@ -108,7 +115,10 @@ async fn main() -> Result<()> {
         }
         "async-udp" => {
             println!("Connecting to PTZOptics G2 camera via async UDP at {camera_addr}");
-            let camera = Camera::<PTZOpticsG2, _>::connect_tokio_udp(camera_addr).await?;
+            let camera = CameraBuilder::tokio_udp(camera_addr)
+                .profile::<PTZOpticsG2>()
+                .build()
+                .await?;
 
             println!("Model: {}", camera.model_name());
             println!("Max pan speed: {}", camera.max_pan_speed());

--- a/src/camera/builder.rs
+++ b/src/camera/builder.rs
@@ -1,0 +1,281 @@
+//! Camera builder for runtime configuration and profile selection.
+//!
+//! Provides a fluent API for creating cameras with different transports and profiles.
+
+use std::marker::PhantomData;
+
+use crate::{capabilities::Profile, error::Error};
+
+use super::Camera;
+
+/// Builder for creating camera instances with runtime parameters first.
+///
+/// This builder allows you to specify the transport type and address first,
+/// then apply the compile-time profile type, and finally build the camera.
+///
+/// # Examples
+///
+/// ```ignore
+/// use grafton_visca::{CameraBuilder, camera::profiles::PTZOpticsG2};
+///
+/// # fn example() -> grafton_visca::Result<()> {
+/// // Blocking TCP
+/// let camera = CameraBuilder::tcp("192.168.1.100:52381")
+///     .profile::<PTZOpticsG2>()
+///     .build()?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct CameraBuilder<'a> {
+    _lifetime: PhantomData<&'a ()>,
+}
+
+impl<'a> CameraBuilder<'a> {
+    /// Create a builder for a blocking TCP transport.
+    pub fn tcp(addr: &'a str) -> TcpBuilder<'a> {
+        TcpBuilder { addr }
+    }
+
+    /// Create a builder for a blocking UDP transport.
+    pub fn udp(addr: &'a str) -> UdpBuilder<'a> {
+        UdpBuilder { addr }
+    }
+
+    /// Create a builder for an async TCP transport (tokio).
+    #[cfg(feature = "tokio")]
+    pub fn tokio_tcp(addr: &'a str) -> TokioTcpBuilder<'a> {
+        TokioTcpBuilder { addr }
+    }
+
+    /// Create a builder for an async UDP transport (tokio).
+    #[cfg(feature = "tokio")]
+    pub fn tokio_udp(addr: &'a str) -> TokioUdpBuilder<'a> {
+        TokioUdpBuilder { addr }
+    }
+}
+
+/// Builder for blocking TCP transport.
+#[derive(Debug)]
+pub struct TcpBuilder<'a> {
+    addr: &'a str,
+}
+
+impl<'a> TcpBuilder<'a> {
+    /// Lock in the compile-time profile and return a typed builder.
+    pub fn profile<P>(self) -> TypedTcpBuilder<'a, P>
+    where
+        P: Profile,
+    {
+        TypedTcpBuilder {
+            addr: self.addr,
+            _p: PhantomData,
+        }
+    }
+}
+
+/// Builder for blocking UDP transport.
+#[derive(Debug)]
+pub struct UdpBuilder<'a> {
+    addr: &'a str,
+}
+
+impl<'a> UdpBuilder<'a> {
+    /// Lock in the compile-time profile and return a typed builder.
+    pub fn profile<P>(self) -> TypedUdpBuilder<'a, P>
+    where
+        P: Profile,
+    {
+        TypedUdpBuilder {
+            addr: self.addr,
+            _p: PhantomData,
+        }
+    }
+}
+
+/// Builder for tokio TCP transport.
+#[derive(Debug)]
+#[cfg(feature = "tokio")]
+pub struct TokioTcpBuilder<'a> {
+    addr: &'a str,
+}
+
+#[cfg(feature = "tokio")]
+impl<'a> TokioTcpBuilder<'a> {
+    /// Lock in the compile-time profile and return a typed builder.
+    pub fn profile<P>(self) -> TypedTokioTcpBuilder<'a, P>
+    where
+        P: Profile,
+    {
+        TypedTokioTcpBuilder {
+            addr: self.addr,
+            _p: PhantomData,
+        }
+    }
+}
+
+/// Builder for tokio UDP transport.
+#[derive(Debug)]
+#[cfg(feature = "tokio")]
+pub struct TokioUdpBuilder<'a> {
+    addr: &'a str,
+}
+
+#[cfg(feature = "tokio")]
+impl<'a> TokioUdpBuilder<'a> {
+    /// Lock in the compile-time profile and return a typed builder.
+    pub fn profile<P>(self) -> TypedTokioUdpBuilder<'a, P>
+    where
+        P: Profile,
+    {
+        TypedTokioUdpBuilder {
+            addr: self.addr,
+            _p: PhantomData,
+        }
+    }
+}
+
+/// Typed builder for blocking TCP.
+#[derive(Debug)]
+pub struct TypedTcpBuilder<'a, P> {
+    addr: &'a str,
+    _p: PhantomData<P>,
+}
+
+impl<P: Profile> TypedTcpBuilder<'_, P> {
+    /// Build the camera with blocking TCP transport.
+    pub fn build(self) -> Result<Camera<P, crate::transport::blocking::Tcp>, Error> {
+        let transport = crate::transport::blocking::Tcp::connect(self.addr)?;
+        Ok(Camera::from_transport(transport))
+    }
+}
+
+/// Typed builder for blocking UDP.
+#[derive(Debug)]
+pub struct TypedUdpBuilder<'a, P> {
+    addr: &'a str,
+    _p: PhantomData<P>,
+}
+
+impl<P: Profile> TypedUdpBuilder<'_, P> {
+    /// Build the camera with blocking UDP transport.
+    pub fn build(self) -> Result<Camera<P, crate::transport::blocking::Udp>, Error> {
+        let transport = crate::transport::blocking::Udp::connect(self.addr)?;
+        Ok(Camera::from_transport(transport))
+    }
+}
+
+/// Typed builder for tokio TCP.
+#[derive(Debug)]
+#[cfg(feature = "tokio")]
+pub struct TypedTokioTcpBuilder<'a, P> {
+    addr: &'a str,
+    _p: PhantomData<P>,
+}
+
+#[cfg(feature = "tokio")]
+impl<P: Profile> TypedTokioTcpBuilder<'_, P> {
+    /// Build the camera with tokio TCP transport.
+    pub async fn build(self) -> Result<Camera<P, crate::transport::tokio::Tcp>, Error> {
+        let transport = crate::transport::tokio::Tcp::connect(self.addr).await?;
+        Ok(Camera::from_transport(transport))
+    }
+}
+
+/// Typed builder for tokio UDP.
+#[derive(Debug)]
+#[cfg(feature = "tokio")]
+pub struct TypedTokioUdpBuilder<'a, P> {
+    addr: &'a str,
+    _p: PhantomData<P>,
+}
+
+#[cfg(feature = "tokio")]
+impl<P: Profile> TypedTokioUdpBuilder<'_, P> {
+    /// Build the camera with tokio UDP transport.
+    pub async fn build(self) -> Result<Camera<P, crate::transport::tokio::Udp>, Error> {
+        let transport = crate::transport::tokio::Udp::connect(self.addr).await?;
+        Ok(Camera::from_transport(transport))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::camera::profiles::{GenericVisca, PTZOpticsG2};
+
+    #[test]
+    fn test_builder_type_inference() {
+        // This should compile - testing that the builder API works
+        let _builder = CameraBuilder::tcp("127.0.0.1:1234").profile::<GenericVisca>();
+    }
+
+    #[test]
+    fn test_tcp_builder_creation() {
+        let builder = CameraBuilder::tcp("192.168.1.100:52381");
+        // Should create a TcpBuilder
+        let typed = builder.profile::<PTZOpticsG2>();
+        // Verify the address is preserved
+        assert_eq!(typed.addr, "192.168.1.100:52381");
+    }
+
+    #[test]
+    fn test_udp_builder_creation() {
+        let builder = CameraBuilder::udp("239.0.0.1:52381");
+        // Should create a UdpBuilder
+        let typed = builder.profile::<GenericVisca>();
+        // Verify the address is preserved
+        assert_eq!(typed.addr, "239.0.0.1:52381");
+    }
+
+    #[cfg(feature = "tokio")]
+    #[test]
+    fn test_tokio_tcp_builder_creation() {
+        let builder = CameraBuilder::tokio_tcp("192.168.1.100:52381");
+        // Should create a TokioTcpBuilder
+        let typed = builder.profile::<PTZOpticsG2>();
+        // Verify the address is preserved
+        assert_eq!(typed.addr, "192.168.1.100:52381");
+    }
+
+    #[cfg(feature = "tokio")]
+    #[test]
+    fn test_tokio_udp_builder_creation() {
+        let builder = CameraBuilder::tokio_udp("239.0.0.1:52381");
+        // Should create a TokioUdpBuilder
+        let typed = builder.profile::<GenericVisca>();
+        // Verify the address is preserved
+        assert_eq!(typed.addr, "239.0.0.1:52381");
+    }
+
+    // Test that the builder is Send and Sync
+    #[test]
+    fn test_builder_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send_sync::<CameraBuilder>();
+        assert_send_sync::<TcpBuilder>();
+        assert_send_sync::<UdpBuilder>();
+        assert_send_sync::<TypedTcpBuilder<GenericVisca>>();
+        assert_send_sync::<TypedUdpBuilder<PTZOpticsG2>>();
+
+        #[cfg(feature = "tokio")]
+        {
+            assert_send_sync::<TokioTcpBuilder>();
+            assert_send_sync::<TokioUdpBuilder>();
+            assert_send_sync::<TypedTokioTcpBuilder<GenericVisca>>();
+            assert_send_sync::<TypedTokioUdpBuilder<PTZOpticsG2>>();
+        }
+    }
+
+    // Test that invalid addresses are handled properly
+    #[test]
+    fn test_invalid_address_handling() {
+        // The error will happen during build(), not during builder creation
+        let typed = CameraBuilder::tcp("invalid:address:format").profile::<GenericVisca>();
+
+        // This should fail when we try to connect
+        let result = typed.build();
+        assert!(result.is_err());
+    }
+}

--- a/src/camera/generic.rs
+++ b/src/camera/generic.rs
@@ -38,17 +38,17 @@ use crate::runtime::RuntimeSpawner;
 /// # Examples
 ///
 /// ```ignore
-/// use grafton_visca::camera::generic::Camera;
-/// use grafton_visca::camera::profiles::PTZOpticsG2;
-/// use grafton_visca::transport::blocking::Tcp;
+/// use grafton_visca::{CameraBuilder, camera::profiles::PTZOpticsG2};
 ///
-/// // Create a camera with explicit profile type
+/// // Create a camera using the builder pattern
+/// let camera = CameraBuilder::tcp("192.168.1.100:52381")
+///     .profile::<PTZOpticsG2>()
+///     .build()?;
+///
+/// // Or create directly with a transport
+/// use grafton_visca::transport::blocking::Tcp;
 /// let transport = Tcp::connect("192.168.1.100:52381")?;
 /// let camera = Camera::<PTZOpticsG2, _>::new(transport);
-///
-/// // Or use the type alias
-/// use grafton_visca::prelude::PTZOpticsG2Cam;
-/// let camera = PTZOpticsG2Cam::new(transport);
 /// ```
 pub struct Camera<P, T>
 where
@@ -631,95 +631,6 @@ where
     }
 }
 
-// Connection factory methods for specific transport types
-impl<P> Camera<P, crate::transport::blocking::Tcp>
-where
-    P: Profile,
-{
-    /// Connect to a camera via blocking TCP.
-    ///
-    /// # Examples
-    /// ```no_run
-    /// # use grafton_visca::camera::{Camera, profiles::PTZOpticsG2};
-    /// # use grafton_visca::Result;
-    /// # fn example() -> Result<()> {
-    /// let camera = Camera::<PTZOpticsG2, _>::connect_tcp("192.168.1.100:52381")?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn connect_tcp(addr: &str) -> Result<Self, Error> {
-        let transport = crate::transport::blocking::Tcp::connect(addr)?;
-        Ok(Self::from_transport(transport))
-    }
-}
-
-impl<P> Camera<P, crate::transport::blocking::Udp>
-where
-    P: Profile,
-{
-    /// Connect to a camera via blocking UDP.
-    ///
-    /// # Examples
-    /// ```no_run
-    /// # use grafton_visca::camera::{Camera, profiles::PTZOpticsG2};
-    /// # use grafton_visca::Result;
-    /// # fn example() -> Result<()> {
-    /// let camera = Camera::<PTZOpticsG2, _>::connect_udp("192.168.1.100:52381")?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn connect_udp(addr: &str) -> Result<Self, Error> {
-        let transport = crate::transport::blocking::Udp::connect(addr)?;
-        Ok(Self::from_transport(transport))
-    }
-}
-
-#[cfg(feature = "tokio")]
-impl<P> Camera<P, crate::transport::tokio::Tcp>
-where
-    P: Profile,
-{
-    /// Connect to a camera via async TCP (tokio).
-    ///
-    /// # Examples
-    /// ```no_run
-    /// # use grafton_visca::camera::{Camera, profiles::PTZOpticsG2};
-    /// # use grafton_visca::Result;
-    /// # #[tokio::main]
-    /// # async fn example() -> Result<()> {
-    /// let camera = Camera::<PTZOpticsG2, _>::connect_tokio_tcp("192.168.1.100:52381").await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn connect_tokio_tcp(addr: &str) -> Result<Self, Error> {
-        let transport = crate::transport::tokio::Tcp::connect(addr).await?;
-        Ok(Self::from_transport(transport))
-    }
-}
-
-#[cfg(feature = "tokio")]
-impl<P> Camera<P, crate::transport::tokio::Udp>
-where
-    P: Profile,
-{
-    /// Connect to a camera via async UDP (tokio).
-    ///
-    /// # Examples
-    /// ```no_run
-    /// # use grafton_visca::camera::{Camera, profiles::PTZOpticsG2};
-    /// # use grafton_visca::Result;
-    /// # #[tokio::main]
-    /// # async fn example() -> Result<()> {
-    /// let camera = Camera::<PTZOpticsG2, _>::connect_tokio_udp("192.168.1.100:52381").await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn connect_tokio_udp(addr: &str) -> Result<Self, Error> {
-        let transport = crate::transport::tokio::Udp::connect(addr).await?;
-        Ok(Self::from_transport(transport))
-    }
-}
-
 // Generic constructor for custom transports
 impl<P, T> Camera<P, T>
 where
@@ -728,11 +639,11 @@ where
 {
     /// Create a new camera with a custom transport.
     ///
-    /// For standard TCP/UDP transports, prefer using the connection factory methods:
-    /// - `connect_tcp()` for blocking TCP
-    /// - `connect_udp()` for blocking UDP
-    /// - `connect_tokio_tcp()` for async TCP with tokio
-    /// - `connect_tokio_udp()` for async UDP with tokio
+    /// For standard TCP/UDP transports, prefer using the CameraBuilder:
+    /// - `CameraBuilder::tcp()` for blocking TCP
+    /// - `CameraBuilder::udp()` for blocking UDP
+    /// - `CameraBuilder::tokio_tcp()` for async TCP with tokio
+    /// - `CameraBuilder::tokio_udp()` for async UDP with tokio
     pub fn new(transport: T) -> Self {
         Self::from_transport(transport)
     }

--- a/src/camera/mod.rs
+++ b/src/camera/mod.rs
@@ -8,6 +8,7 @@
 //! - `SonyFR7Cam<T>` for Sony FR7 cameras
 //! - etc.
 
+pub mod builder;
 pub mod generic;
 pub mod generic_methods;
 pub mod methods;
@@ -15,3 +16,12 @@ pub mod profiles;
 
 // Re-export the generic Camera as the primary Camera type
 pub use generic::Camera;
+
+// Re-export builder types
+pub use builder::CameraBuilder;
+
+#[cfg(not(feature = "async"))]
+pub use builder::{TcpBuilder, TypedTcpBuilder, TypedUdpBuilder, UdpBuilder};
+
+#[cfg(feature = "tokio")]
+pub use builder::{TokioTcpBuilder, TokioUdpBuilder, TypedTokioTcpBuilder, TypedTokioUdpBuilder};

--- a/src/camera/profiles.rs
+++ b/src/camera/profiles.rs
@@ -1082,5 +1082,5 @@ mod tests {
     }
 }
 
-// Connection helpers are now provided directly on the Camera struct.
-// Use Camera::<Profile, _>::connect_tcp() etc.
+// Connection helpers are now provided via CameraBuilder.
+// Use CameraBuilder::tcp() etc.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,17 +42,13 @@
 //!
 //! ### Camera - No Generics Required!
 //! ```ignore
-//! use grafton_visca::{Error, prelude::*};
-//! use grafton_visca::transport::blocking::Tcp;
+//! use grafton_visca::{CameraBuilder, Error, prelude::*};
 //!
 //! fn main() -> Result<(), Error> {
-//!     // Create camera with default profile (GenericVisca)
-//!     let transport = Tcp::connect("192.168.1.100:52381")?;
-//!     let camera = GenericViscaCam::new(transport);
-//!
-//!     // Or create a specific camera model
-//!     let transport = Tcp::connect("192.168.1.100:52381")?;
-//!     let camera = PTZOpticsG2Cam::new(transport);
+//!     // Create camera using the builder pattern
+//!     let camera = CameraBuilder::tcp("192.168.1.100:52381")
+//!         .profile::<PTZOpticsG2>()
+//!         .build()?;
 //!
 //!     // Camera model is known at compile time
 //!     println!("Using PTZOptics G2 camera");
@@ -67,14 +63,15 @@
 //!
 //! ### Async Example
 //! ```ignore
-//! use grafton_visca::{Error, r#async::prelude::*};
-//! use grafton_visca::transport::tokio::Tcp;
+//! use grafton_visca::{CameraBuilder, Error, r#async::prelude::*};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Error> {
-//!     // Create camera with specific profile
-//!     let transport = Tcp::connect("192.168.1.100:52381").await?;
-//!     let camera = PTZOpticsG2Cam::new(transport);
+//!     // Create camera using the builder pattern
+//!     let camera = CameraBuilder::tokio_tcp("192.168.1.100:52381")
+//!         .profile::<PTZOpticsG2>()
+//!         .build()
+//!         .await?;
 //!
 //!     // Same API, just with .await
 //!     camera.power_on().await?;
@@ -322,7 +319,7 @@ pub mod blocking;
 pub mod r#async;
 
 pub mod prelude;
-pub use camera::Camera;
+pub use camera::{Camera, CameraBuilder};
 pub use camera_id::CameraId;
 
 pub use types::{ExposureCompensationLevel, FStop, IntoIrisLevel, NDIQuality};

--- a/tests/builder_compile_fail_tests.rs
+++ b/tests/builder_compile_fail_tests.rs
@@ -1,0 +1,20 @@
+//! Compile-fail tests for the CameraBuilder API to ensure type safety.
+//!
+//! These tests ensure that the builder API prevents misuse at compile time:
+//! - Cannot call `.build()` before `.profile()`
+//! - Cannot call `.profile()` twice
+//! - Cannot use types that don't implement `Profile`
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+
+    // Test that build() cannot be called before profile()
+    t.compile_fail("tests/ui/builder_build_without_profile.rs");
+
+    // Test that profile() cannot be called twice
+    t.compile_fail("tests/ui/builder_double_profile.rs");
+
+    // Test that non-Profile types cannot be used
+    t.compile_fail("tests/ui/builder_non_profile_type.rs");
+}

--- a/tests/ui/builder_build_without_profile.rs
+++ b/tests/ui/builder_build_without_profile.rs
@@ -1,0 +1,9 @@
+//! This test should fail to compile because we're trying to call .build() before .profile()
+
+use grafton_visca::CameraBuilder;
+
+fn main() {
+    // This should fail: cannot call build() directly on CameraBuilder
+    let _camera = CameraBuilder::tcp("192.168.1.100:52381")
+        .build(); // Error: no method named `build` found
+}

--- a/tests/ui/builder_build_without_profile.stderr
+++ b/tests/ui/builder_build_without_profile.stderr
@@ -1,0 +1,9 @@
+error[E0599]: no method named `build` found for struct `TcpBuilder` in the current scope
+ --> tests/ui/builder_build_without_profile.rs:8:10
+  |
+7 |       let _camera = CameraBuilder::tcp("192.168.1.100:52381")
+  |  ___________________-
+8 | |         .build(); // Error: no method named `build` found
+  | |         -^^^^^ method not found in `TcpBuilder<'_>`
+  | |_________|
+  |

--- a/tests/ui/builder_double_profile.rs
+++ b/tests/ui/builder_double_profile.rs
@@ -1,0 +1,11 @@
+//! This test should fail to compile because we're trying to call .profile() twice
+
+use grafton_visca::{CameraBuilder, camera::profiles::{PTZOpticsG2, GenericVisca}};
+
+fn main() {
+    // This should fail: cannot call profile() twice
+    let _camera = CameraBuilder::tcp("192.168.1.100:52381")
+        .profile::<PTZOpticsG2>()
+        .profile::<GenericVisca>() // Error: no method named `profile` found
+        .build();
+}

--- a/tests/ui/builder_double_profile.stderr
+++ b/tests/ui/builder_double_profile.stderr
@@ -1,0 +1,13 @@
+error[E0599]: no method named `profile` found for struct `TypedTcpBuilder` in the current scope
+ --> tests/ui/builder_double_profile.rs:9:10
+  |
+7 |       let _camera = CameraBuilder::tcp("192.168.1.100:52381")
+  |                     -----------------------------------------
+  |                     |
+  |  ___________________method `profile` is available on `TcpBuilder<'_>`
+  | |
+8 | |         .profile::<PTZOpticsG2>()
+9 | |         .profile::<GenericVisca>() // Error: no method named `profile` found
+  | |         -^^^^^^^ method not found in `TypedTcpBuilder<'_, PTZOpticsG2>`
+  | |_________|
+  |

--- a/tests/ui/builder_non_profile_type.rs
+++ b/tests/ui/builder_non_profile_type.rs
@@ -1,0 +1,13 @@
+//! This test should fail to compile because we're using a type that doesn't implement Profile
+
+use grafton_visca::CameraBuilder;
+
+// A type that doesn't implement Profile
+struct NotAProfile;
+
+fn main() {
+    // This should fail: NotAProfile doesn't implement Profile
+    let _camera = CameraBuilder::tcp("192.168.1.100:52381")
+        .profile::<NotAProfile>() // Error: the trait bound `NotAProfile: Profile` is not satisfied
+        .build();
+}

--- a/tests/ui/builder_non_profile_type.stderr
+++ b/tests/ui/builder_non_profile_type.stderr
@@ -1,0 +1,365 @@
+error[E0277]: the trait bound `NotAProfile: Profile` is not satisfied
+  --> tests/ui/builder_non_profile_type.rs:11:20
+   |
+11 |         .profile::<NotAProfile>() // Error: the trait bound `NotAProfile: Profile` is not satisfied
+   |          -------   ^^^^^^^^^^^ the trait `ProfileMetadata` is not implemented for `NotAProfile`
+   |          |
+   |          required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `ProfileMetadata`:
+             GenericVisca
+             NearusBRC300
+             PTZOptics30X
+             PTZOpticsG2
+             PTZOpticsG3
+             SonyBRC300
+             SonyBRCH900
+             SonyEVIH100
+             SonyFR7
+   = note: required for `NotAProfile` to implement `Profile`
+note: required by a bound in `TcpBuilder::<'a>::profile`
+  --> src/camera/builder.rs
+   |
+   |     pub fn profile<P>(self) -> TypedTcpBuilder<'a, P>
+   |            ------- required by a bound in this associated function
+   |     where
+   |         P: Profile,
+   |            ^^^^^^^ required by this bound in `TcpBuilder::<'a>::profile`
+
+error[E0277]: the trait bound `NotAProfile: Profile` is not satisfied
+  --> tests/ui/builder_non_profile_type.rs:11:20
+   |
+11 |         .profile::<NotAProfile>() // Error: the trait bound `NotAProfile: Profile` is not satisfied
+   |          -------   ^^^^^^^^^^^ the trait `grafton_visca::capabilities::PanTilt` is not implemented for `NotAProfile`
+   |          |
+   |          required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `grafton_visca::capabilities::PanTilt`:
+             GenericVisca
+             NearusBRC300
+             PTZOptics30X
+             PTZOpticsG2
+             PTZOpticsG3
+             SonyBRC300
+             SonyBRCH900
+             SonyEVIH100
+             SonyFR7
+   = note: required for `NotAProfile` to implement `Profile`
+note: required by a bound in `TcpBuilder::<'a>::profile`
+  --> src/camera/builder.rs
+   |
+   |     pub fn profile<P>(self) -> TypedTcpBuilder<'a, P>
+   |            ------- required by a bound in this associated function
+   |     where
+   |         P: Profile,
+   |            ^^^^^^^ required by this bound in `TcpBuilder::<'a>::profile`
+
+error[E0277]: the trait bound `NotAProfile: Profile` is not satisfied
+  --> tests/ui/builder_non_profile_type.rs:11:20
+   |
+11 |         .profile::<NotAProfile>() // Error: the trait bound `NotAProfile: Profile` is not satisfied
+   |          -------   ^^^^^^^^^^^ the trait `grafton_visca::capabilities::Zoom` is not implemented for `NotAProfile`
+   |          |
+   |          required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `grafton_visca::capabilities::Zoom`:
+             GenericVisca
+             NearusBRC300
+             PTZOptics30X
+             PTZOpticsG2
+             PTZOpticsG3
+             SonyBRC300
+             SonyBRCH900
+             SonyEVIH100
+             SonyFR7
+   = note: required for `NotAProfile` to implement `Profile`
+note: required by a bound in `TcpBuilder::<'a>::profile`
+  --> src/camera/builder.rs
+   |
+   |     pub fn profile<P>(self) -> TypedTcpBuilder<'a, P>
+   |            ------- required by a bound in this associated function
+   |     where
+   |         P: Profile,
+   |            ^^^^^^^ required by this bound in `TcpBuilder::<'a>::profile`
+
+error[E0277]: the trait bound `NotAProfile: Profile` is not satisfied
+  --> tests/ui/builder_non_profile_type.rs:11:20
+   |
+11 |         .profile::<NotAProfile>() // Error: the trait bound `NotAProfile: Profile` is not satisfied
+   |          -------   ^^^^^^^^^^^ the trait `grafton_visca::capabilities::Focus` is not implemented for `NotAProfile`
+   |          |
+   |          required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `grafton_visca::capabilities::Focus`:
+             GenericVisca
+             NearusBRC300
+             PTZOptics30X
+             PTZOpticsG2
+             PTZOpticsG3
+             SonyBRC300
+             SonyBRCH900
+             SonyEVIH100
+             SonyFR7
+   = note: required for `NotAProfile` to implement `Profile`
+note: required by a bound in `TcpBuilder::<'a>::profile`
+  --> src/camera/builder.rs
+   |
+   |     pub fn profile<P>(self) -> TypedTcpBuilder<'a, P>
+   |            ------- required by a bound in this associated function
+   |     where
+   |         P: Profile,
+   |            ^^^^^^^ required by this bound in `TcpBuilder::<'a>::profile`
+
+error[E0277]: the trait bound `NotAProfile: Profile` is not satisfied
+  --> tests/ui/builder_non_profile_type.rs:11:20
+   |
+11 |         .profile::<NotAProfile>() // Error: the trait bound `NotAProfile: Profile` is not satisfied
+   |          -------   ^^^^^^^^^^^ the trait `grafton_visca::capabilities::Exposure` is not implemented for `NotAProfile`
+   |          |
+   |          required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `grafton_visca::capabilities::Exposure`:
+             GenericVisca
+             NearusBRC300
+             PTZOptics30X
+             PTZOpticsG2
+             PTZOpticsG3
+             SonyBRC300
+             SonyBRCH900
+             SonyEVIH100
+             SonyFR7
+   = note: required for `NotAProfile` to implement `Profile`
+note: required by a bound in `TcpBuilder::<'a>::profile`
+  --> src/camera/builder.rs
+   |
+   |     pub fn profile<P>(self) -> TypedTcpBuilder<'a, P>
+   |            ------- required by a bound in this associated function
+   |     where
+   |         P: Profile,
+   |            ^^^^^^^ required by this bound in `TcpBuilder::<'a>::profile`
+
+error[E0277]: the trait bound `NotAProfile: Profile` is not satisfied
+  --> tests/ui/builder_non_profile_type.rs:11:20
+   |
+11 |         .profile::<NotAProfile>() // Error: the trait bound `NotAProfile: Profile` is not satisfied
+   |          -------   ^^^^^^^^^^^ the trait `grafton_visca::capabilities::WhiteBalance` is not implemented for `NotAProfile`
+   |          |
+   |          required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `grafton_visca::capabilities::WhiteBalance`:
+             GenericVisca
+             NearusBRC300
+             PTZOptics30X
+             PTZOpticsG2
+             PTZOpticsG3
+             SonyBRC300
+             SonyBRCH900
+             SonyEVIH100
+             SonyFR7
+   = note: required for `NotAProfile` to implement `Profile`
+note: required by a bound in `TcpBuilder::<'a>::profile`
+  --> src/camera/builder.rs
+   |
+   |     pub fn profile<P>(self) -> TypedTcpBuilder<'a, P>
+   |            ------- required by a bound in this associated function
+   |     where
+   |         P: Profile,
+   |            ^^^^^^^ required by this bound in `TcpBuilder::<'a>::profile`
+
+error[E0277]: the trait bound `NotAProfile: Profile` is not satisfied
+  --> tests/ui/builder_non_profile_type.rs:11:20
+   |
+11 |         .profile::<NotAProfile>() // Error: the trait bound `NotAProfile: Profile` is not satisfied
+   |          -------   ^^^^^^^^^^^ the trait `grafton_visca::capabilities::ImageProcessing` is not implemented for `NotAProfile`
+   |          |
+   |          required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `grafton_visca::capabilities::ImageProcessing`:
+             GenericVisca
+             NearusBRC300
+             PTZOptics30X
+             PTZOpticsG2
+             PTZOpticsG3
+             SonyBRC300
+             SonyBRCH900
+             SonyEVIH100
+             SonyFR7
+   = note: required for `NotAProfile` to implement `Profile`
+note: required by a bound in `TcpBuilder::<'a>::profile`
+  --> src/camera/builder.rs
+   |
+   |     pub fn profile<P>(self) -> TypedTcpBuilder<'a, P>
+   |            ------- required by a bound in this associated function
+   |     where
+   |         P: Profile,
+   |            ^^^^^^^ required by this bound in `TcpBuilder::<'a>::profile`
+
+error[E0277]: the trait bound `NotAProfile: Profile` is not satisfied
+  --> tests/ui/builder_non_profile_type.rs:11:20
+   |
+11 |         .profile::<NotAProfile>() // Error: the trait bound `NotAProfile: Profile` is not satisfied
+   |          -------   ^^^^^^^^^^^ the trait `grafton_visca::capabilities::Presets` is not implemented for `NotAProfile`
+   |          |
+   |          required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `grafton_visca::capabilities::Presets`:
+             GenericVisca
+             NearusBRC300
+             PTZOptics30X
+             PTZOpticsG2
+             PTZOpticsG3
+             SonyBRC300
+             SonyBRCH900
+             SonyEVIH100
+             SonyFR7
+   = note: required for `NotAProfile` to implement `Profile`
+note: required by a bound in `TcpBuilder::<'a>::profile`
+  --> src/camera/builder.rs
+   |
+   |     pub fn profile<P>(self) -> TypedTcpBuilder<'a, P>
+   |            ------- required by a bound in this associated function
+   |     where
+   |         P: Profile,
+   |            ^^^^^^^ required by this bound in `TcpBuilder::<'a>::profile`
+
+error[E0277]: the trait bound `NotAProfile: Profile` is not satisfied
+  --> tests/ui/builder_non_profile_type.rs:11:20
+   |
+11 |         .profile::<NotAProfile>() // Error: the trait bound `NotAProfile: Profile` is not satisfied
+   |          -------   ^^^^^^^^^^^ the trait `grafton_visca::capabilities::Power` is not implemented for `NotAProfile`
+   |          |
+   |          required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `grafton_visca::capabilities::Power`:
+             GenericVisca
+             NearusBRC300
+             PTZOptics30X
+             PTZOpticsG2
+             PTZOpticsG3
+             SonyBRC300
+             SonyBRCH900
+             SonyEVIH100
+             SonyFR7
+   = note: required for `NotAProfile` to implement `Profile`
+note: required by a bound in `TcpBuilder::<'a>::profile`
+  --> src/camera/builder.rs
+   |
+   |     pub fn profile<P>(self) -> TypedTcpBuilder<'a, P>
+   |            ------- required by a bound in this associated function
+   |     where
+   |         P: Profile,
+   |            ^^^^^^^ required by this bound in `TcpBuilder::<'a>::profile`
+
+error[E0277]: the trait bound `NotAProfile: Profile` is not satisfied
+  --> tests/ui/builder_non_profile_type.rs:11:20
+   |
+11 |         .profile::<NotAProfile>() // Error: the trait bound `NotAProfile: Profile` is not satisfied
+   |          -------   ^^^^^^^^^^^ the trait `grafton_visca::capabilities::MenuControl` is not implemented for `NotAProfile`
+   |          |
+   |          required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `grafton_visca::capabilities::MenuControl`:
+             GenericVisca
+             NearusBRC300
+             PTZOptics30X
+             PTZOpticsG2
+             PTZOpticsG3
+             SonyBRC300
+             SonyBRCH900
+             SonyEVIH100
+             SonyFR7
+   = note: required for `NotAProfile` to implement `Profile`
+note: required by a bound in `TcpBuilder::<'a>::profile`
+  --> src/camera/builder.rs
+   |
+   |     pub fn profile<P>(self) -> TypedTcpBuilder<'a, P>
+   |            ------- required by a bound in this associated function
+   |     where
+   |         P: Profile,
+   |            ^^^^^^^ required by this bound in `TcpBuilder::<'a>::profile`
+
+error[E0599]: the method `build` exists for struct `TypedTcpBuilder<'_, NotAProfile>`, but its trait bounds were not satisfied
+  --> tests/ui/builder_non_profile_type.rs:12:10
+   |
+6  |   struct NotAProfile;
+   |   ------------------ doesn't satisfy 11 bounds
+...
+10 |       let _camera = CameraBuilder::tcp("192.168.1.100:52381")
+   |  ___________________-
+11 | |         .profile::<NotAProfile>() // Error: the trait bound `NotAProfile: Profile` is not satisfied
+12 | |         .build();
+   | |         -^^^^^ method cannot be called on `TypedTcpBuilder<'_, NotAProfile>` due to unsatisfied trait bounds
+   | |_________|
+   |
+   |
+   = note: the following trait bounds were not satisfied:
+           `NotAProfile: ProfileMetadata`
+           which is required by `NotAProfile: Profile`
+           `NotAProfile: grafton_visca::capabilities::PanTilt`
+           which is required by `NotAProfile: Profile`
+           `NotAProfile: grafton_visca::capabilities::Zoom`
+           which is required by `NotAProfile: Profile`
+           `NotAProfile: grafton_visca::capabilities::Focus`
+           which is required by `NotAProfile: Profile`
+           `NotAProfile: grafton_visca::capabilities::Exposure`
+           which is required by `NotAProfile: Profile`
+           `NotAProfile: grafton_visca::capabilities::WhiteBalance`
+           which is required by `NotAProfile: Profile`
+           `NotAProfile: grafton_visca::capabilities::ImageProcessing`
+           which is required by `NotAProfile: Profile`
+           `NotAProfile: grafton_visca::capabilities::Presets`
+           which is required by `NotAProfile: Profile`
+           `NotAProfile: grafton_visca::capabilities::Power`
+           which is required by `NotAProfile: Profile`
+           `NotAProfile: grafton_visca::capabilities::MenuControl`
+           which is required by `NotAProfile: Profile`
+note: the traits `ProfileMetadata`, `grafton_visca::capabilities::Exposure`, `grafton_visca::capabilities::Focus`, `grafton_visca::capabilities::ImageProcessing`, `grafton_visca::capabilities::MenuControl`, `grafton_visca::capabilities::PanTilt`, `grafton_visca::capabilities::Power`, `grafton_visca::capabilities::Presets`, `grafton_visca::capabilities::WhiteBalance`,  and `grafton_visca::capabilities::Zoom` must be implemented
+  --> src/capabilities/profile_metadata.rs
+   |
+   | pub trait ProfileMetadata {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+  ::: src/capabilities/zoom.rs
+   |
+   | pub trait Zoom {
+   | ^^^^^^^^^^^^^^
+   |
+  ::: src/capabilities/white_balance.rs
+   |
+   | pub trait WhiteBalance {
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+  ::: src/capabilities/presets.rs
+   |
+   | pub trait Presets {
+   | ^^^^^^^^^^^^^^^^^
+   |
+  ::: src/capabilities/power.rs
+   |
+   | pub trait Power {
+   | ^^^^^^^^^^^^^^^
+   |
+  ::: src/capabilities/pan_tilt.rs
+   |
+   | pub trait PanTilt {
+   | ^^^^^^^^^^^^^^^^^
+   |
+  ::: src/capabilities/menu_control.rs
+   |
+   | pub trait MenuControl {
+   | ^^^^^^^^^^^^^^^^^^^^^
+   |
+  ::: src/capabilities/image_processing.rs
+   |
+   | pub trait ImageProcessing {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+  ::: src/capabilities/focus.rs
+   |
+   | pub trait Focus {
+   | ^^^^^^^^^^^^^^^
+   |
+  ::: src/capabilities/exposure.rs
+   |
+   | pub trait Exposure {
+   | ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
This PR implements the CameraBuilder API as specified in issue #185, providing a cleaner and more idiomatic way to create camera instances.

## Changes
- Added `CameraBuilder` with methods: `tcp()`, `udp()`, `tokio_tcp()`, `tokio_udp()`
- Implemented type-safe builder pattern with `.profile::<P>()` method
- Removed all legacy `connect_*` methods from `Camera` struct
- Updated examples to use new builder pattern
- Added new examples: `builder_blocking.rs` and `builder_async.rs`
- Added compile-fail tests using trybuild to ensure type safety
- Updated README and CHANGELOG documentation

## Breaking Changes
This is a breaking change that removes all `connect_*` methods. Users must migrate to the new builder API:

```rust
// Before (removed):
let camera = Camera::<PTZOpticsG2, _>::connect_tcp("192.168.1.100:52381")?;

// After (new):
let camera = CameraBuilder::tcp("192.168.1.100:52381")
    .profile::<PTZOpticsG2>()
    .build()?;
```

## Test Plan
- [x] All unit tests pass with `cargo test --all-features`
- [x] Compile-fail tests verify type safety
- [x] No clippy warnings
- [x] Code properly formatted
- [x] Examples compile and demonstrate the new API

Closes #185

🤖 Generated with [Claude Code](https://claude.ai/code)