### PR TITLE
Gate optional vendor controls by profile support (#518)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,19 +47,26 @@ jobs:
         with:
           components: rustfmt
         continue-on-error: true
-        id: nightly-toolchain
 
-      # Fallback: retry with rustup directly if the action fails
-      - name: Retry nightly toolchain installation
-        if: steps.nightly-toolchain.outcome == 'failure'
+      # macOS runners have intermittently left `cargo` resolving to
+      # `rustup-init` after the install action reported success, so verify the
+      # toolchain is actually usable and fall back to a direct rustup install.
+      - name: Ensure nightly toolchain is usable
+        shell: bash
         run: |
+          if rustup component list --toolchain nightly --installed 2>/dev/null | grep -q '^rustfmt' \
+            && cargo +nightly --version >/dev/null 2>&1; then
+            cargo +nightly --version
+            exit 0
+          fi
           for i in {1..3}; do
             echo "Attempt $i of 3..."
             rustup toolchain install nightly --component rustfmt --profile minimal && break
             sleep 30
           done
+          cargo +nightly --version
 
-      - run: cargo fmt --all -- --check
+      - run: cargo +nightly fmt --all -- --check
 
   # Test on minimal platform for feature branches (uses reusable workflow)
   test-minimal:
@@ -99,17 +106,26 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
         continue-on-error: true
-        id: matrix-toolchain
 
-      # Fallback: retry with rustup directly if the action fails
-      - name: Retry ${{ matrix.rust }} toolchain installation
-        if: steps.matrix-toolchain.outcome == 'failure'
+      # macOS runners have intermittently left `cargo` resolving to
+      # `rustup-init` after the install action reported success, so verify the
+      # toolchain is actually usable and fall back to a direct rustup install.
+      - name: Ensure ${{ matrix.rust }} toolchain is usable
+        shell: bash
         run: |
+          if rustup show active-toolchain 2>/dev/null | grep -q "${{ matrix.rust }}" \
+            && cargo +${{ matrix.rust }} --version >/dev/null 2>&1; then
+            cargo +${{ matrix.rust }} --version
+            exit 0
+          fi
           for i in {1..3}; do
             echo "Attempt $i of 3..."
-            rustup toolchain install ${{ matrix.rust }} --profile minimal && break
+            rustup toolchain install ${{ matrix.rust }} --profile minimal \
+              && rustup default ${{ matrix.rust }} \
+              && break
             sleep 30
           done
+          cargo +${{ matrix.rust }} --version
 
       # Setup sccache for compiler caching (gracefully handle service outages)
       - name: Setup sccache
@@ -156,17 +172,25 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
         continue-on-error: true
-        id: matrix-toolchain
 
-      # Fallback: retry with rustup directly if the action fails
-      - name: Retry ${{ matrix.rust }} toolchain installation
-        if: steps.matrix-toolchain.outcome == 'failure'
+      # Mirror the Unix job's verify-and-fallback so a silently-unusable
+      # toolchain reinstalls before tests run.
+      - name: Ensure ${{ matrix.rust }} toolchain is usable
+        shell: bash
         run: |
+          if rustup show active-toolchain 2>/dev/null | grep -q "${{ matrix.rust }}" \
+            && cargo +${{ matrix.rust }} --version >/dev/null 2>&1; then
+            cargo +${{ matrix.rust }} --version
+            exit 0
+          fi
           for i in {1..3}; do
             echo "Attempt $i of 3..."
-            rustup toolchain install ${{ matrix.rust }} --profile minimal && break
+            rustup toolchain install ${{ matrix.rust }} --profile minimal \
+              && rustup default ${{ matrix.rust }} \
+              && break
             sleep 30
           done
+          cargo +${{ matrix.rust }} --version
 
       # Setup sccache for compiler caching (gracefully handle service outages)
       - name: Setup sccache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: The unused `MotionGuard` helper and low-level `runtime_demo_lowlevel` example were removed; use explicit camera accessors such as `camera.zoom().stop()` and the high-level `runtime_demo` example instead
 - **BREAKING**: The direct blocking `nd_filter()` inquiry method was removed to reserve `camera.nd_filter()` for the camera-first ND filter accessor; use `camera.nd_filter().position()?`
 
+#### Optional Vendor Control Capability Gates (#518)
+- **BREAKING**: Optional vendor feature traits were split into runtime metadata traits (`NdFilterMetadata`, `MotionSyncMetadata`, `VariableSpeedMetadata`) and explicit typed API support markers (`HasNdFilter`, `HasMotionSync`, `HasVariableSpeed`)
+- **BREAKING**: Unsupported typed vendor controls no longer compile for profiles that only carry unsupported metadata defaults; for example, `PtzOpticsG2.nd_filter()`, `PtzOpticsG2.motion_sync()`, `GenericVisca.motion_sync()`, and `SonyFR7.motion_sync()` are no longer available
+- **BREAKING**: ND filter inquiries were removed from broad all-profile inquiry paths and are now gated with the ND filter support marker through `NdFilterInquiryControl`
+- `Profile` still requires optional-feature metadata so `Capabilities::from_profile::<P>()` can report `has_nd_filter`, `has_motion_sync`, `has_variable_speed`, `nd_filter_type`, and `max_motion_sync_speed` for every built-in profile
+- Built-in typed support markers now follow the documented model capabilities: `SonyFR7` supports typed ND filter and variable speed controls; built-in PTZOptics profiles remain unmarked for typed Motion Sync because the current model capability specs do not establish that support; `GenericVisca` and other built-ins remain unmarked for these optional vendor controls
+- Built-in profiles now report generic `SUPPORTS_ONE_PUSH_FOCUS = false` unless the reference docs establish that exact capability; FR7 still exposes its separate Push AF support through `HasPushAutoFocus`
+- Added contributor guidance for source-backed camera profile capability changes, including metadata/support-marker decisions and required test coverage
+- Raw/custom VISCA command extension APIs remain profile-agnostic escape hatches for advanced integrations
+
 #### Granular Iris Capability Modelling
 - **BREAKING**: `Exposure::IRIS_RANGE` changed from `Range<u16>` to `Option<Range<u16>>`; downstream `impl Exposure` blocks must wrap their range in `Some(...)` or use `None` for cameras that lack iris control
 - **BREAKING**: `Capabilities::iris_range` changed from `RangeInclusive<u16>` to `Option<RangeInclusive<u16>>`
@@ -55,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### 1.0 API Contract Tests (#512)
 - Expanded the API stability suite from compile-presence checks into explicit 1.0 contract assertions for public value wrappers, profile capabilities, serialization/schema/type-generation features, and runtime/transport-gated public entry points
 - Added feature-specific compile contracts for async camera-first sessions, blocking serial, Tokio serial, `dyn-api`, and `test-utils` so supported feature surfaces fail loudly when their public API drifts
+- Added compile-fail contracts proving unsupported optional vendor controls and support-marker bounds stay unavailable for unsupported profiles
 
 #### Per-Profile Iris and Exposure-Mode Support
 - New `Exposure::EXPOSURE_MODES` associated constant lets each profile declare which exposure modes the hardware accepts (defaults to all five standard modes)
@@ -82,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compatibility-only feature unions are documented separately from supported contract rows, so CI coverage for dependency-graph combinations does not imply additional public API promises
 - CI feature coverage now includes explicit blocking detection, blocking serial, Tokio serial, serde/schemars/ts-rs, dyn-api, and Tokio/smol runtime coexistence entries
 - `dyn-api` is treated as a first-class 1.0 feature with public API contract coverage plus Tokio and smol runtime integration tests
+- README, crate docs, and examples now document the profile-gated vendor control matrix separately from runtime capability metadata
 
 #### PTZOptics Profiles Disable Iris
 - PTZOptics G2, G3, and 30X profiles now set `IRIS_RANGE: None` and exclude `ExposureMode::Iris` from their supported modes, reflecting hardware behaviour observed on real devices

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Thank you for your interest in contributing to grafton-visca! This guide will he
 - [Code Style](#code-style)
 - [Safety Guidelines](#safety-guidelines)
 - [Command Development](#command-development)
+- [Camera Profile Support](#camera-profile-support)
 - [Testing](#testing)
 - [Documentation](#documentation)
 - [Pull Request Process](#pull-request-process)
@@ -167,6 +168,24 @@ impl ViscaCommand for MyInquiry {
     }
 }
 ```
+
+## Camera Profile Support
+
+Camera profiles are part of the public type-safety contract. Before adding or
+changing a profile capability, follow the
+[Camera Profile Support Guide](docs/camera_profile_support.md).
+
+The short version:
+
+- Checked-in reference docs and specs are the source of truth.
+- Model-specific capability docs take precedence over generic opcode tables.
+- Runtime metadata traits feed `Capabilities::from_profile::<P>()`.
+- Support marker traits such as `HasNdFilter`, `HasMotionSync`, and
+  `HasVariableSpeed` expose typed APIs and must only be implemented when the
+  source docs establish support.
+- Raw VISCA command APIs remain available for experiments and downstream camera
+  variants, but raw opcode availability does not justify marking a built-in
+  profile as supported.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ documented rows they combine.
 | `SonyEVIH100`, `SonyBRC300`, `NearusBRC300` | Raw VISCA | Supported through profile capability gates and protocol tests |
 | `SonyBRCH900`, `SonyFR7` | Sony encapsulation | Supported through Sony encapsulation, profile capability gates, and protocol tests |
 
+### Profile-Gated Vendor Controls
+
+Typed vendor-specific controls are exposed only for profiles whose documented
+model capabilities support them. Runtime capability metadata remains available for
+discovery on every profile, and raw command escape hatches remain available for
+custom integrations.
+
+| Typed control surface | Profiles |
+| --------------------- | -------- |
+| ND filter controls and inquiries | `SonyFR7` |
+| Variable speed mode controls | `SonyFR7` |
+| Motion Sync controls and inquiries | Custom/evidenced profiles that explicitly implement `HasMotionSync`; no built-in profile is marked from the current specs |
+
+Contributors adding or changing profile capabilities should follow the
+[Camera Profile Support Guide](docs/camera_profile_support.md), which explains
+how source documents, runtime metadata, and typed support markers fit together.
+
 ### Optional features
 
 | Feature | 1.0 support |
@@ -215,6 +232,7 @@ Port can be omitted in connection strings; the profile default is used.
 - **[API Reference](https://docs.rs/grafton-visca)** — Complete type and method documentation
 - **[Examples](examples/)** — Maintained examples for common scenarios
 - **[Example Policy](docs/examples.md)** — 1.0 examples contract and maintenance rules
+- **[Camera Profile Support Guide](docs/camera_profile_support.md)** — Source-of-truth and testing rules for adding camera capabilities
 - **[CHANGELOG](CHANGELOG.md)** — Version history and migration guides
 
 ### Examples

--- a/docs/PTZOptics-NDI-HX-Gen2-Specs.md
+++ b/docs/PTZOptics-NDI-HX-Gen2-Specs.md
@@ -55,6 +55,14 @@ This document consolidates (and cross‑checks) the key technical data found in 
 - **Presets:** 255 via serial/IP; IR remote supports 10 presets (0–9)
 - **Preset accuracy:** 0.1°
 
+### Capability boundaries
+
+- The manual/datasheet capability tables do not list camera one-push focus or
+  PTZ Motion Sync as supported Gen-2 model capabilities.
+- The VISCA command-list reference may contain raw opcodes for firmware-specific
+  commands. Treat those as raw command references unless the model capability
+  specs above explicitly establish support.
+
 ### Power and environment
 
 - **Input voltage:** DC 12V (10.8–13.0V) or PoE (802.3af)

--- a/docs/camera_profile_support.md
+++ b/docs/camera_profile_support.md
@@ -1,0 +1,96 @@
+# Camera Profile Support Guide
+
+This guide is for contributors adding or changing camera profiles and optional
+camera capabilities. The goal is that a selected profile means something
+concrete: protocol framing, numeric limits, runtime capability metadata, and
+typed control surfaces all match the checked-in source documents.
+
+## Source Of Truth
+
+Profile support must start from evidence in `docs/` or from a new source
+document added with the change.
+
+Use this order when sources disagree:
+
+1. Model-specific manuals, datasheets, and capability tables.
+2. Manufacturer VISCA command lists for the same model and firmware family.
+3. Hardware validation logs or reproducible tests with model and firmware noted.
+4. Generic VISCA references and command tables.
+
+A command-list opcode proves that an opcode exists in some command reference. It
+does not, by itself, prove that a built-in profile should expose a typed API for
+that feature. If model capability docs do not establish support, keep the profile
+conservative and document the ambiguity.
+
+## Metadata Versus Typed Support
+
+Optional vendor features use two layers:
+
+| Layer | Meaning | Example |
+| ----- | ------- | ------- |
+| Metadata traits | Runtime discovery facts for `Capabilities::from_profile::<P>()`; unsupported defaults are valid. | `NdFilterMetadata`, `MotionSyncMetadata`, `VariableSpeedMetadata` |
+| Support markers | Compile-time permission for typed control/accessor/inquiry APIs. | `HasNdFilter`, `HasMotionSync`, `HasVariableSpeed` |
+
+`Profile` requires metadata traits so discovery can report the same fields for
+every profile. Do not treat those metadata traits as proof of support. Implement
+support markers only when the camera profile's source documents establish that
+the feature exists and the crate has a typed implementation for it.
+
+Raw/custom VISCA command APIs are different. They remain available as escape
+hatches for experiments, unsupported firmware variants, and downstream
+integrations. Raw command availability must not be used to justify a built-in
+typed support marker.
+
+## Adding Or Updating A Profile
+
+1. Add or update the source documents in `docs/`.
+2. Record any model/firmware limitations near the relevant capability section.
+3. Implement profile constants in `src/camera/profiles.rs` from those sources.
+4. Use `false`, `None`, or conservative ranges when the docs do not establish support.
+5. Implement optional metadata with supported values only when runtime discovery should report support.
+6. Implement optional support markers only when typed APIs are intentionally supported for that profile.
+7. Add pass API-contract fixtures for newly supported typed surfaces.
+8. Add compile-fail fixtures proving unsupported profiles cannot call those typed surfaces.
+9. Add or update `Capabilities::from_profile` tests for every affected built-in profile.
+10. Update README, examples docs, crate docs, and the Unreleased changelog entry.
+
+## Common Decisions
+
+| Situation | Profile metadata | Support marker | Notes |
+| --------- | ---------------- | -------------- | ----- |
+| Model docs say the feature exists and typed APIs exist | Supported value | Implement marker | Add pass and runtime discovery tests. |
+| Model docs say the feature does not exist | Unsupported default | No marker | Add compile-fail coverage if the typed API could be accidentally exposed. |
+| Command list has an opcode but model capability docs do not list support | Unsupported default | No marker | Document the ambiguity; raw commands remain available. |
+| Hardware testing proves support not shown in a manual | Supported value if reproducible | Implement marker only if typed API is intentional | Add model, firmware, test setup, and protocol evidence to docs. |
+| Feature exists but the crate lacks a typed control surface | Supported metadata may be OK | No marker yet | Open or reference follow-up work for typed support. |
+
+## Test Expectations
+
+Profile support changes should include focused tests before relying on the full
+feature matrix:
+
+```sh
+cargo test --test api_stability_test --no-default-features
+cargo test --test api_stability_test --no-default-features --features mode-async
+cargo test --no-default-features --lib capabilities::discovery
+cargo test --no-default-features --test feature_detection_tests --test camera_profile_tests --test simple_compile_test
+cargo test --no-default-features --features test-utils --test compile_time_safety_test
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Before merging 1.0 contract work, run the declared matrix:
+
+```sh
+bash .github/scripts/test-all-features.sh
+```
+
+If a matrix failure is unrelated or flaky, note the exact failing command and
+test in the PR so reviewers know what remains unresolved.
+
+## Documentation Checklist
+
+- README support matrix reflects the implemented typed API surface.
+- `docs/visca_unified_reference.md` and model-specific docs explain capability boundaries.
+- `examples/type_safe_commands.rs` demonstrates metadata and marker bounds without using unsupported built-in profiles.
+- `CHANGELOG.md` describes breaking changes and migration guidance.
+- Any source conflict is documented near the relevant capability, not only in the PR discussion.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -33,6 +33,15 @@ The maintained examples in `examples/` fall into these categories:
   and keep examples runnable.
 - Keep examples focused. A single example should demonstrate one API path or one
   operational pattern, not a broad hardware tour.
+- When examples demonstrate optional vendor features, use the support-marker
+  bounds for typed controls (`HasNdFilter`, `HasMotionSync`,
+  `HasVariableSpeed`) and metadata traits only for runtime discovery. The
+  maintained typed support matrix is: `SonyFR7` for ND filter and variable
+  speed controls. Built-in PTZOptics profiles are not marked for typed Motion
+  Sync because the current model capability specs do not establish that support.
+- When an example or fixture adds support for a new camera profile capability,
+  follow the [Camera Profile Support Guide](camera_profile_support.md) so the
+  example matches the source-of-truth docs and typed support markers.
 
 ## Release Checks
 

--- a/docs/visca_unified_reference.md
+++ b/docs/visca_unified_reference.md
@@ -239,7 +239,7 @@ Different camera models vary in capabilities even though they share the VISCA pr
 | **Preset slots**            | **127** G2 / **255** G3 / **10** (IR remote)    | 100 (0–99)                              | 16 (0–15)                               | 6 (0–5)                    | 6 (0–5)                   |
 | **Pan speed steps**         | 1–24 (std. VISCA range)                         | **1–50** (supports “Fine” mode)         | 1–24                                    | 1–24                       | 1–24                      |
 | **Focus Lock command**      | ✔ (`81 0A 04 68 02/03 FF`)                      | ✖ (no separate lock; uses AF/MF toggle) | ✖                                       | ✖                          | ✖                         |
-| **“Snap” Focus (One-push)** | ✔ (`81 01 04 38 04 FF` triggers one-shot focus) | ✔ (Push AF commands)                    | ✖                                       | ✖ (older models lack this) | ✖                         |
+| **“Snap” Focus (One-push)** | ✖ (not listed in Gen-2 model specs)             | ✔ (Push AF commands)                    | ✖                                       | ✖ (older models lack this) | ✖                         |
 | **ND Filter control**       | ✖ (no ND filter)                                | ✔ (Elec. ND 2–7 stops, 1/4 to 1/128)    | ✖ (no ND; uses optical only)            | ✖                          | ✖                         |
 | **Dual Tally lamps**        | Single (one lamp: On/Off/Flash)                 | **Two** (Red & Green, independent)      | Single (red, Hi/Lo brightness)          | ✖ (no tally)               | ✖                         |
 | **“Bright” AE mode**        | ✔ (Bright mode available)                       | ✖ (not supported on FR7)                | ✔ (Bright mode supported)               | ✔ (Bright mode supported)  | ✔ (Bright mode supported) |
@@ -249,7 +249,7 @@ Different camera models vary in capabilities even though they share the VISCA pr
 
 \* Sony BRC‑H900 IP control requires the BRBK-IP10 option; without it, only RS-232/422 control is available.
 
-As seen above, the newer FR7 introduces unique features like a variable electronic ND filter and dual tally lights, not found on older models. PTZOptics has some custom commands (like Focus Lock and Snap Focus) not present on Sony cameras. The number of preset memory slots varies widely: from 6 on entry-level models up to 100+ on newer cameras. PTZOptics NDI|HX Gen‑2 documentation lists **127 presets** (0–127) available via **serial/IP control**, while Gen‑3 models support **255 presets**; the included **IR remote supports 10 presets (0–9)**. When developing a controller, use the profile's `MAX_PRESETS` value and adjust the UI accordingly – for example, disable ND controls for models without ND filters, limit the preset index range offered to the user, or hide options like ATW or dual tally unless the camera supports them.
+As seen above, the newer FR7 introduces unique features like a variable electronic ND filter and dual tally lights, not found on older models. PTZOptics has some custom commands (like Focus Lock) not present on Sony cameras. The number of preset memory slots varies widely: from 6 on entry-level models up to 100+ on newer cameras. PTZOptics NDI|HX Gen‑2 documentation lists **127 presets** (0–127) available via **serial/IP control**, while Gen‑3 models support **255 presets**; the included **IR remote supports 10 presets (0–9)**. When developing a controller, use the profile's `MAX_PRESETS` value and adjust the UI accordingly – for example, disable ND controls for models without ND filters, limit the preset index range offered to the user, or hide options like ATW or dual tally unless the camera supports them. In the Rust API, runtime metadata remains available through `Capabilities::from_profile::<P>()`, while typed optional vendor controls are compile-gated by support markers. From the current model capability specs, `SonyFR7` exposes typed ND filter and variable speed controls; built-in PTZOptics profiles are not marked for typed Motion Sync.
 
 *(Note: The Sony BRC-X1000 4K camera (2017) is similar to FR7 in many respects and supports up to 100 presets. The older Sony BRC-300 had only 6 presets accessible via remote/serial. Always check model specs.)*
 
@@ -331,14 +331,14 @@ Many cameras implement additional VISCA commands beyond the baseline set, often 
 PTZOptics cameras largely follow the standard VISCA command set (their firmware is VISCA-based). However, they added a few extensions:
 
 * **Focus Lock:** `81 0A 04 68 02 FF` (Lock focus) / `81 0A 04 68 03 FF` (Unlock focus). When focus lock is on, the camera’s focus mechanism is held at its current position and any autofocus or manual focus commands are ignored. If you attempt a focus move while locked, the camera will return a `41 FF` *Not Executable* error (because it refuses to change focus). This is useful to temporarily prevent any focus changes.
-* **Snap Focus (One-Push AF in Manual):** `81 01 04 38 04 FF`. This command, sometimes called “One Push Trigger” for focus, will trigger an autofocus operation once, even if the camera is in manual focus mode. After the focus operation completes (or times out), the camera remains in Manual focus mode. Essentially, it’s a way to quickly autofocus at a target, then remain in manual (so it won’t continue hunting). On the PTZOptics Move series, this is documented as “Snap Focus”.
+* **Snap Focus / One-Push Focus:** The current PTZOptics Gen-2 model specs used by this repository do not list one-push focus as a supported camera capability. Keep any raw opcode experiments outside the typed built-in profile contract unless profile-specific evidence is added.
 * **Image Flip/Mirror:** PTZOptics provides a combined flip command. `81 01 04 A4 0p FF` controls mirroring/orientation. p = 0 (Off, normal), 1 (Horizontal Flip), 2 (Vertical Flip), 3 (Both H+V Flip). This single command replaces the separate Sony commands (`61` and `66` opcodes) used on some other models. Use this when mounting the camera inverted (ceiling) or if you need a mirror image.
 
   **Important:** PTZOptics G2/G3/30X cameras require using the combined flip command (0xA4) rather than legacy separate commands (0x61/0x66). The legacy commands may be accepted but not actually applied. The library automatically routes flip operations (`enable_flip`, `disable_flip`, etc.) through the combined command for PTZOptics profiles. To persist flip settings across power cycles, call `save_settings()` after changing flip settings.
 * **Auto WB Sensitivity:** `81 01 04 A9 00 FF` (High), `... A9 01 FF` (Normal), `... A9 02 FF` (Low). This adjusts how aggressively the Auto White Balance reacts to scene changes. In some PTZOptics models, “High” makes WB change more rapidly (useful for fast lighting changes), while “Low” dampens the response for stability.
 * **Multicast Streaming On/Off:** `81 0B 01 23 01 FF` (Enable multicast), `81 0B 01 23 02 FF` (Disable) – specific to NDI models. This toggles the camera’s multicast video stream output. (Not a VISCA camera control per se, but implemented via the VISCA-over-IP interface on PTZOptics NDI cameras).
 * **NDI|HX Mode Quality:** `81 0B 01 01 0p FF` – on NDI cameras, sets the NDI stream bandwidth/quality (p=1 High, 2 Medium, 3 Low, 4 Off). Again, not standard VISCA, but PTZOptics extends VISCA commands for some IP configuration settings.
-* **Motion Sync Feature:** Some newer PTZOptics (e.g., firmware 1.1.6+ on certain models) have “PTZ Motion Sync”, which coordinates pan, tilt, and zoom to start and stop simultaneously for preset recalls. Commands like `81 0A 11 13 02 FF` (MotionSync On) / `... 13 03 FF` (Off) and `81 0A 11 14 pp FF` (set MotionSync max speed, pp = 0x01–0x18 for speeds 1–24) configure this. When MotionSync is on, recalling a preset will adjust the pan/tilt speeds so that zoom and pan/tilt movements complete at the same time, yielding a more synchronized and smooth arrival on the preset.
+* **Motion Sync Feature:** Some newer PTZOptics firmware or models document “PTZ Motion Sync” opcodes, which coordinate pan, tilt, and zoom to start and stop simultaneously for preset recalls. The current Gen-2 model capability specs in this repository do not establish Motion Sync as a built-in profile capability, so typed Motion Sync support is left to custom/evidenced profiles while raw command escape hatches remain available for experiments.
 
 * **Image Processing:** PTZOptics G2/G3/30X cameras support a full set of image processing controls (see Section 8.4): Luminance (`0xA1`, range 0–14), Contrast (`0xA2`, range 0–14), Sharpness (`0x42`, range 0–11), Saturation (range 0–14), Hue (range 0–14), and 2D/3D Noise Reduction. Gamma curve control (`0x5B`, values 0–4) is also supported despite not being listed in the official PTZOptics VISCA command reference — hardware testing confirms both gamma inquiry and set commands work correctly.
 
@@ -484,7 +484,7 @@ Focus,Focus Near Var,81 01 04 08 3p FF,6,Yes,Yes,Yes,p = 0–7
 Focus,Focus Direct,81 01 04 48 0p 0q 0r 0s FF,10,Yes,Yes,Yes,
 Focus,Auto Focus On,81 01 04 38 02 FF,6,Yes,Yes,Yes,
 Focus,Auto Focus Off (Manual),81 01 04 38 03 FF,6,Yes,Yes,Yes,
-Focus,Focus One Push (Snap),81 01 04 38 04 FF,6,No,Yes,Yes,PTZOptics Snap Focus, FR7 Push AF (diff opcode)
+Focus,Focus One Push (Snap),81 01 04 38 04 FF,6,No,No,No,FR7 Push AF uses separate commands below
 Focus,Auto/Manual Toggle,81 01 04 38 10 FF,6,No,Yes,No,PTZOptics specific toggle
 Focus,Focus Mode Inq,81 09 04 38 FF,5,Yes,Yes,Yes,Reply 90 50 02/03 (Auto/Man)
 Focus,Focus Pos Inq,81 09 04 48 FF,5,Yes,Yes,Yes,Reply 90 50 0p0q0r0s FF
@@ -586,9 +586,9 @@ System,V-Flip On (legacy),81 01 04 66 02 FF,6,Yes,Yes,No,
 System,V-Flip Off (legacy),81 01 04 66 03 FF,6,Yes,Yes,No,
 System,Flip (Combined PTZOptics),81 01 04 A4 0p FF,6,No,Yes,No,p=0/1/2/3 Off/H/V/HV
 System,Settings Save (PTZOptics),81 01 04 A5 10 FF,6,No,Yes,No,Save current config
-System,PTZ MotionSync On (PTZOptics),81 0A 11 13 02 FF,6,No,Yes,No,
-System,PTZ MotionSync Off (PTZOptics),81 0A 11 13 03 FF,6,No,Yes,No,
-System,PTZ MotionSync Speed,81 0A 11 14 pp FF,6,No,Yes,No,pp = 01–18 (speed 1–24)
+System,PTZ MotionSync On (PTZOptics),81 0A 11 13 02 FF,6,No,No*,No,Listed in command references for some PTZOptics firmware; not a built-in Gen-2 profile capability
+System,PTZ MotionSync Off (PTZOptics),81 0A 11 13 03 FF,6,No,No*,No,Listed in command references for some PTZOptics firmware; not a built-in Gen-2 profile capability
+System,PTZ MotionSync Speed,81 0A 11 14 pp FF,6,No,No*,No,pp = 01–18; listed in command references for some PTZOptics firmware, not a built-in Gen-2 profile capability
 System,FR7 Speed Mode 24,81 01 7E 04 1B 01 FF,7,No,No,Yes,
 System,FR7 Speed Mode 50,81 01 7E 04 1B 02 FF,7,No,No,Yes,
 System,Menu Display On,81 01 06 06 02 FF,6,Yes,Yes,Yes,
@@ -607,7 +607,7 @@ Streaming,Multicast Off (PTZOptics),81 0B 01 23 02 FF,6,No,Yes,No,
 Streaming,NDI Quality Set (PTZOptics),81 0B 01 01 0p FF,6,No,Yes,No,p=1–4 (Hi,Med,Low,Off)
 ```
 
-> *"Bytes" column indicates total bytes including the terminator `FF`. "Yes/No" in model columns denote whether that model/family supports the command (to the best of current knowledge).*
+> *"Bytes" column indicates total bytes including the terminator `FF`. "Yes/No" in model columns denote whether that model/family supports the command (to the best of current knowledge). `No*` means an opcode appears in command references, but the current model capability specs do not establish it as a built-in profile capability.*
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -130,7 +130,9 @@ The examples use different camera profiles to demonstrate compile-time type safe
 - `SonyBRC300` - Sony BRC-300 standard PTZ cameras
 - `GenericVisca` - Basic VISCA profile for unknown cameras
 
-Profiles enable compile-time validation of camera capabilities. Commands not supported by a profile won't compile, preventing runtime errors.
+Profiles enable compile-time validation of camera capabilities. Commands not supported by a profile won't compile, preventing runtime errors. Optional vendor-specific typed controls are intentionally narrower than runtime metadata: `SonyFR7` exposes ND filter and variable speed controls; built-in PTZOptics profiles are not marked for typed Motion Sync from the current model capability specs.
+
+Profile capability contributions should follow the [Camera Profile Support Guide](../docs/camera_profile_support.md), which defines how source docs, metadata traits, and typed support markers fit together.
 
 ## Current API Shape
 

--- a/examples/type_safe_commands.rs
+++ b/examples/type_safe_commands.rs
@@ -14,8 +14,9 @@
 use grafton_visca::{
     camera::profiles::{GenericVisca, PtzOpticsG2, SonyFR7},
     capabilities::{
-        nd_filter::NdFilterExt, zoom::ZoomExt, Exposure, HasExposureCompensation, HasFocusLock,
-        HasPushAutoFocus, NdFilter, PanTilt, Presets, ProfileMetadata, WhiteBalance, Zoom,
+        nd_filter::NdFilterMetadataExt, zoom::ZoomExt, Exposure, HasExposureCompensation,
+        HasFocusLock, HasNdFilter, HasPushAutoFocus, HasVariableSpeed, NdFilterMetadata, PanTilt,
+        Presets, ProfileMetadata, WhiteBalance, Zoom,
     },
 };
 
@@ -30,7 +31,14 @@ fn main() {
 
 fn print_profile<P>()
 where
-    P: ProfileMetadata + PanTilt + Zoom + Exposure + WhiteBalance + Presets + NdFilter + Default,
+    P: ProfileMetadata
+        + PanTilt
+        + Zoom
+        + Exposure
+        + WhiteBalance
+        + Presets
+        + NdFilterMetadata
+        + Default,
 {
     let profile = P::default();
 
@@ -84,10 +92,14 @@ fn demonstrate_optional_capability_bounds() {
 
     requires_focus_lock::<PtzOpticsG2>();
     requires_push_af::<SonyFR7>();
+    requires_nd_filter::<SonyFR7>();
+    requires_variable_speed::<SonyFR7>();
     requires_exposure_compensation::<PtzOpticsG2>();
     requires_exposure_compensation::<SonyFR7>();
 
     // These lines intentionally do not compile if uncommented:
+    // requires_nd_filter::<PtzOpticsG2>();
+    // requires_variable_speed::<PtzOpticsG2>();
     // requires_push_af::<PtzOpticsG2>();
     // requires_focus_lock::<SonyFR7>();
 }
@@ -97,6 +109,20 @@ where
     P: ProfileMetadata + HasFocusLock,
 {
     println!("  {} supports focus lock", P::MODEL_NAME);
+}
+
+fn requires_nd_filter<P>()
+where
+    P: ProfileMetadata + HasNdFilter,
+{
+    println!("  {} supports typed ND filter control", P::MODEL_NAME);
+}
+
+fn requires_variable_speed<P>()
+where
+    P: ProfileMetadata + HasVariableSpeed,
+{
+    println!("  {} supports variable speed mode", P::MODEL_NAME);
 }
 
 fn requires_push_af<P>()

--- a/src/camera/accessors.rs
+++ b/src/camera/accessors.rs
@@ -11,8 +11,9 @@ use crate::{
             color::ColorControl,
             exposure::ExposureControl,
             focus::{FocusControl, FocusLockControl, PushAFControl},
-            inquiry::{InquiryControl, PanTiltInquiryControl},
+            inquiry::{InquiryControl, NdFilterInquiryControl, PanTiltInquiryControl},
             menu::MenuControl,
+            motion_sync::MotionSyncControl,
             nd_filter::NdFilterControl,
             pan_tilt::PanTiltControl,
             power::PowerControl,
@@ -543,7 +544,7 @@ where
         self.camera.set_focus_near_limit(position)
     }
 
-    /// Trigger one-push auto focus.
+    /// Trigger one-push auto focus when supported by the profile.
     ///
     /// Performs a single auto-focus operation then returns to the previous focus mode.
     pub fn one_push(&self) -> M::Fut<'_, Result<(), Error>>
@@ -1355,7 +1356,7 @@ where
 impl<'a, M, P, Tr, Exec> NdFilterAccessor<'a, M, P, Tr, Exec>
 where
     M: Mode,
-    P: Profile,
+    P: Profile + crate::capabilities::HasNdFilter,
     Exec: Executor,
 {
     #[cfg(feature = "mode-async")]
@@ -1366,7 +1367,7 @@ where
     /// Get the current ND filter position.
     pub fn position(&self) -> M::Fut<'_, Result<crate::command::NdFilterPosition, Error>>
     where
-        Camera<M, P, Tr, Exec>: InquiryControl<Mode = M>,
+        Camera<M, P, Tr, Exec>: NdFilterInquiryControl<Mode = M>,
     {
         self.camera.nd_filter_position()
     }
@@ -1374,7 +1375,7 @@ where
     /// Get the ND filter preset setting.
     pub fn preset(&self) -> M::Fut<'_, Result<crate::types::NdFilterPreset, Error>>
     where
-        Camera<M, P, Tr, Exec>: InquiryControl<Mode = M>,
+        Camera<M, P, Tr, Exec>: NdFilterInquiryControl<Mode = M>,
     {
         self.camera.nd_filter_preset()
     }
@@ -1434,7 +1435,7 @@ where
 impl<'a, M, P, Tr, Exec> MotionSyncAccessor<'a, M, P, Tr, Exec>
 where
     M: Mode,
-    P: Profile,
+    P: Profile + crate::capabilities::HasMotionSync,
     Exec: Executor,
 {
     #[cfg(feature = "mode-async")]
@@ -1445,7 +1446,7 @@ where
     /// Get the motion sync mode setting.
     pub fn mode(&self) -> M::Fut<'_, Result<crate::command::MotionSyncMode, Error>>
     where
-        Camera<M, P, Tr, Exec>: InquiryControl<Mode = M>,
+        Camera<M, P, Tr, Exec>: MotionSyncControl<Mode = M>,
     {
         self.camera.motion_sync_mode()
     }

--- a/src/camera/blocking_api.rs
+++ b/src/camera/blocking_api.rs
@@ -13,7 +13,7 @@ use crate::{
             exposure::{ExposureCompensationControl, ExposureControl},
             focus::{FocusControl, FocusLockControl, PushAFControl},
             image_processing::ImageProcessingControl,
-            inquiry::{InquiryControl, PanTiltInquiryControl},
+            inquiry::{InquiryControl, NdFilterInquiryControl, PanTiltInquiryControl},
             menu::{DirectMenuControl, MenuControl},
             motion_sync::MotionSyncControl,
             nd_filter::NdFilterControl,
@@ -323,12 +323,18 @@ where
     }
 
     /// Access ND filter controls and inquiries.
-    pub fn nd_filter(&self) -> BlockingNdFilterAccessor<'_, P, Tr> {
+    pub fn nd_filter(&self) -> BlockingNdFilterAccessor<'_, P, Tr>
+    where
+        P: crate::capabilities::HasNdFilter,
+    {
         BlockingNdFilterAccessor::new(self)
     }
 
     /// Access motion sync controls and inquiries.
-    pub fn motion_sync(&self) -> BlockingMotionSyncAccessor<'_, P, Tr> {
+    pub fn motion_sync(&self) -> BlockingMotionSyncAccessor<'_, P, Tr>
+    where
+        P: crate::capabilities::HasMotionSync,
+    {
         BlockingMotionSyncAccessor::new(self)
     }
 
@@ -693,7 +699,7 @@ where
         self.camera.set_focus_near_limit(position)
     }
 
-    /// Trigger one-push auto focus.
+    /// Trigger one-push auto focus when supported by the profile.
     pub fn one_push(&self) -> Result<(), Error> {
         self.camera.focus_one_push()
     }
@@ -1294,8 +1300,9 @@ define_blocking_accessor!(
 
 impl<P, Tr> BlockingNdFilterAccessor<'_, P, Tr>
 where
-    P: crate::capabilities::Profile + Default + crate::capabilities::nd_filter::NdFilter,
-    Camera<Blocking, P, Tr, ()>: NdFilterControl<Mode = Blocking> + InquiryControl<Mode = Blocking>,
+    P: crate::capabilities::Profile + Default + crate::capabilities::HasNdFilter,
+    Camera<Blocking, P, Tr, ()>:
+        NdFilterControl<Mode = Blocking> + NdFilterInquiryControl<Mode = Blocking>,
 {
     /// Get the current ND filter position.
     pub fn position(&self) -> Result<crate::command::NdFilterPosition, Error> {
@@ -1340,7 +1347,7 @@ define_blocking_accessor!(
 
 impl<P, Tr> BlockingMotionSyncAccessor<'_, P, Tr>
 where
-    P: crate::capabilities::Profile + Default + crate::capabilities::motion_sync::MotionSync,
+    P: crate::capabilities::Profile + Default + crate::capabilities::HasMotionSync,
     Camera<Blocking, P, Tr, ()>: MotionSyncControl<Mode = Blocking>,
 {
     /// Get the motion sync mode.
@@ -1544,7 +1551,7 @@ where
         /// Stop focus movement.
         fn focus_stop() -> ();
 
-        /// Trigger one-push auto focus.
+        /// Trigger one-push auto focus when supported by the profile.
         fn focus_one_push() -> ();
 
         /// Set focus position.
@@ -2103,7 +2110,7 @@ where
 impl<P, Tr> BlockingClient<P, Tr>
 where
     Camera<Blocking, P, Tr, ()>: VariableSpeedControl<Mode = Blocking>,
-    P: crate::capabilities::Profile + Default + crate::capabilities::variable_speed::VariableSpeed,
+    P: crate::capabilities::Profile + Default + crate::capabilities::HasVariableSpeed,
 {
     impl_blocking_methods! {
         /// Set variable speed mode.
@@ -2118,7 +2125,7 @@ where
 impl<P, Tr> BlockingClient<P, Tr>
 where
     Camera<Blocking, P, Tr, ()>: MotionSyncControl<Mode = Blocking>,
-    P: crate::capabilities::Profile + Default + crate::capabilities::motion_sync::MotionSync,
+    P: crate::capabilities::Profile + Default + crate::capabilities::HasMotionSync,
 {
     impl_blocking_methods! {
         /// Set motion sync mode.
@@ -2145,7 +2152,7 @@ where
 impl<P, Tr> BlockingClient<P, Tr>
 where
     Camera<Blocking, P, Tr, ()>: NdFilterControl<Mode = Blocking>,
-    P: crate::capabilities::Profile + Default + crate::capabilities::nd_filter::NdFilter,
+    P: crate::capabilities::Profile + Default + crate::capabilities::HasNdFilter,
 {
     impl_blocking_methods! {
         /// Set ND filter mode.
@@ -2260,9 +2267,6 @@ where
         /// Get picture effect.
         fn picture_effect() -> crate::command::PictureEffectMode;
 
-        /// Get ND filter position.
-        fn nd_filter_position() -> crate::command::NdFilterPosition;
-
         /// Get camera version information.
         fn version() -> crate::command::VersionInfo;
 
@@ -2332,14 +2336,29 @@ where
         /// Get two-tone mode enabled status.
         fn two_tone_mode_enabled() -> bool;
 
-        /// Get ND filter preset.
-        fn nd_filter_preset() -> crate::types::NdFilterPreset;
-
         /// Get digital mode enabled status.
         fn digital_mode_enabled() -> bool;
 
         /// Get tally auto adjust enabled status.
         fn tally_auto_adjust_enabled() -> bool;
+    }
+}
+
+// ============================================================================
+// NdFilterInquiryControl implementation
+// ============================================================================
+
+impl<P, Tr> BlockingClient<P, Tr>
+where
+    Camera<Blocking, P, Tr, ()>: NdFilterInquiryControl<Mode = Blocking>,
+    P: crate::capabilities::Profile + Default + crate::capabilities::HasNdFilter,
+{
+    impl_blocking_methods! {
+        /// Get ND filter position.
+        fn nd_filter_position() -> crate::command::NdFilterPosition;
+
+        /// Get ND filter preset.
+        fn nd_filter_preset() -> crate::types::NdFilterPreset;
     }
 }
 

--- a/src/camera/capabilities.rs
+++ b/src/camera/capabilities.rs
@@ -5,7 +5,9 @@
 //! optional capability traits. The actual control methods for these capabilities
 //! are provided by their respective trait modules in `src/camera/controls/`.
 
-use crate::capabilities::{MotionSync, NdFilter, NdFilterMode as CapabilityNdFilterMode, Profile};
+use crate::capabilities::{
+    HasMotionSync, HasNdFilter, NdFilterMode as CapabilityNdFilterMode, Profile,
+};
 
 #[cfg(feature = "mode-async")]
 use crate::{camera::Camera, executor::Executor, mode, transport::AsyncTransport};
@@ -16,7 +18,7 @@ use crate::{camera::Camera, mode, transport::BlockingTransport};
 #[cfg(not(feature = "mode-async"))]
 impl<P, Tr> Camera<mode::Blocking, P, Tr, ()>
 where
-    P: Profile + NdFilter,
+    P: Profile + HasNdFilter,
     Tr: BlockingTransport,
 {
     /// Get the ND filter mode from the camera profile.
@@ -35,7 +37,7 @@ where
 #[cfg(not(feature = "mode-async"))]
 impl<P, Tr> Camera<mode::Blocking, P, Tr, ()>
 where
-    P: Profile + MotionSync,
+    P: Profile + HasMotionSync,
     Tr: BlockingTransport,
 {
     /// Check if motion sync is supported.
@@ -55,7 +57,7 @@ where
 #[cfg(feature = "mode-async")]
 impl<P, Tr, Exec> Camera<mode::Async, P, Tr, Exec>
 where
-    P: Profile + NdFilter,
+    P: Profile + HasNdFilter,
     Tr: AsyncTransport,
     Exec: Executor,
 {
@@ -75,7 +77,7 @@ where
 #[cfg(feature = "mode-async")]
 impl<P, Tr, Exec> Camera<mode::Async, P, Tr, Exec>
 where
-    P: Profile + MotionSync,
+    P: Profile + HasMotionSync,
     Tr: AsyncTransport,
     Exec: Executor,
 {
@@ -97,6 +99,6 @@ mod tests {
     #[test]
     fn test_nd_filter_compilation() {
         // This test verifies that ND filter methods are only available for cameras
-        // that implement the NdFilter trait.
+        // that implement the typed ND filter support marker.
     }
 }

--- a/src/camera/controls/focus.rs
+++ b/src/camera/controls/focus.rs
@@ -5,7 +5,7 @@
 //! - Variable speed focus adjustment (near/far)
 //! - Absolute position control and infinity focus
 //! - Focus lock to prevent unwanted changes (vendor-specific: PtzOptics)
-//! - One-push auto focus for quick adjustment
+//! - One-push auto focus for profiles whose metadata reports support
 //! - Push AF for temporary auto focus (vendor-specific: Sony FR7)
 //! - Focus zone configuration for area-specific focusing
 //! - Auto focus sensitivity adjustment
@@ -40,7 +40,8 @@ use crate::{
 ///
 /// - **Auto Focus**: Camera automatically adjusts focus based on scene content
 /// - **Manual Focus**: User has direct control over focus position
-/// - **One-Push AF**: Single auto focus operation then returns to manual
+/// - **One-Push AF**: Single auto focus operation then returns to manual,
+///   when the selected profile reports support
 /// - **Push AF**: Temporary auto focus while button is held
 ///
 /// # Examples
@@ -71,7 +72,8 @@ pub trait FocusControl {
     /// within the configured focus zone.
     ///
     /// # Errors
-    /// Returns an error if the command fails to send or receive a response.
+    /// Returns an error if the selected profile does not report one-push focus
+    /// support, or if the command fails to send or receive a response.
     fn focus_auto(&self) -> <Self::Mode as Mode>::Fut<'_, Result<(), Error>>;
 
     /// Set manual focus mode.
@@ -294,6 +296,11 @@ where
     }
 
     fn focus_one_push(&self) -> M::Fut<'_, Result<(), Error>> {
+        if !P::SUPPORTS_ONE_PUSH_FOCUS {
+            return self.error(Error::FeatureNotSupported {
+                feature: "one-push focus",
+            });
+        }
         self.execute(Focus::OnePushTrigger)
     }
 
@@ -341,6 +348,11 @@ where
     }
 
     fn focus_snap(&self) -> M::Fut<'_, Result<(), Error>> {
+        if !P::SUPPORTS_ONE_PUSH_FOCUS {
+            return self.error(Error::FeatureNotSupported {
+                feature: "snap focus",
+            });
+        }
         self.execute(Focus::Snap)
     }
 }

--- a/src/camera/controls/inquiry.rs
+++ b/src/camera/controls/inquiry.rs
@@ -6,7 +6,7 @@
 //! - Image processing settings (sharpness, saturation, noise reduction)
 //! - System status (power, version, menu state)
 //! - Color settings (gain, tuning, temperature)
-//! - Special features (tally lights, ND filters, motion sync)
+//! - Special features (tally lights, digital PTZ, defog)
 //!
 //! Inquiry operations allow you to read the current state of various camera
 //! parameters without changing them. This is essential for building user
@@ -18,8 +18,8 @@
 use crate::{
     camera::ViscaClient,
     command::{
-        focus::AutoFocusSensitivity, system::MotionSyncMode, ExposureMode, FocusMode, FocusZone,
-        SharpnessMode, WhiteBalanceMode,
+        focus::AutoFocusSensitivity, ExposureMode, FocusMode, FocusZone, SharpnessMode,
+        WhiteBalanceMode,
     },
     mode::Mode,
     Error,
@@ -37,7 +37,7 @@ use crate::{
 /// - **Color**: White balance, color temperature, red/blue gain and tuning
 /// - **Image**: Sharpness, saturation, hue, noise reduction, picture effects
 /// - **System**: Power state, version, menu status, tally lights
-/// - **Special**: ND filters, motion sync, digital PTZ, defog
+/// - **Special**: digital PTZ, defog
 ///
 /// # Examples
 ///
@@ -373,17 +373,6 @@ pub trait InquiryControl {
         &self,
     ) -> <Self::Mode as Mode>::Fut<'_, Result<crate::command::PictureEffectMode, Error>>;
 
-    /// Get the current ND filter position.
-    ///
-    /// Returns the position of the neutral density filter.
-    /// Only available on cameras with built-in ND filters (e.g., Sony FR7).
-    ///
-    /// # Errors
-    /// Returns an error if the inquiry fails, times out, or is not supported.
-    fn nd_filter_position(
-        &self,
-    ) -> <Self::Mode as Mode>::Fut<'_, Result<crate::command::NdFilterPosition, Error>>;
-
     /// Get the camera version information.
     ///
     /// Returns detailed version information including model name,
@@ -645,17 +634,6 @@ pub trait InquiryControl {
     /// Returns an error if the inquiry fails or times out.
     fn two_tone_mode_enabled(&self) -> <Self::Mode as Mode>::Fut<'_, Result<bool, Error>>;
 
-    /// Get the ND filter preset setting.
-    ///
-    /// Returns the current ND filter preset number for cameras
-    /// with multiple ND filter configurations.
-    ///
-    /// # Errors
-    /// Returns an error if the inquiry fails or times out.
-    fn nd_filter_preset(
-        &self,
-    ) -> <Self::Mode as Mode>::Fut<'_, Result<crate::types::NdFilterPreset, Error>>;
-
     /// Get the digital mode state.
     ///
     /// Returns whether digital mode is enabled, which may affect
@@ -682,15 +660,6 @@ pub trait InquiryControl {
     /// Returns an error if the inquiry fails or times out.
     fn tally_auto_adjust_enabled(&self) -> <Self::Mode as Mode>::Fut<'_, Result<bool, Error>>;
 
-    /// Get the motion sync mode setting.
-    ///
-    /// Returns the current motion sync mode which affects how
-    /// the camera synchronizes movement with other devices.
-    ///
-    /// # Errors
-    /// Returns an error if the inquiry fails or times out.
-    fn motion_sync_mode(&self) -> <Self::Mode as Mode>::Fut<'_, Result<MotionSyncMode, Error>>;
-
     /// Get the anti-flicker mode setting.
     ///
     /// Returns the current flicker reduction mode (Off, 50Hz, or 60Hz).
@@ -702,6 +671,23 @@ pub trait InquiryControl {
     fn flicker_mode(
         &self,
     ) -> <Self::Mode as Mode>::Fut<'_, Result<crate::command::exposure::AntiFlickerMode, Error>>;
+}
+
+/// ND filter-specific inquiry operations for cameras with typed ND filter support.
+#[grafton_visca_macros::delegate_to_session]
+pub trait NdFilterInquiryControl {
+    /// The mode type for this camera (Async or Blocking).
+    type Mode: Mode;
+
+    /// Get the current ND filter position.
+    fn nd_filter_position(
+        &self,
+    ) -> <Self::Mode as Mode>::Fut<'_, Result<crate::command::NdFilterPosition, Error>>;
+
+    /// Get the ND filter preset setting.
+    fn nd_filter_preset(
+        &self,
+    ) -> <Self::Mode as Mode>::Fut<'_, Result<crate::types::NdFilterPreset, Error>>;
 }
 
 /// Pan/tilt-specific inquiry operations for cameras.
@@ -912,11 +898,6 @@ where
         self.query(PictureEffectInquiry)
     }
 
-    fn nd_filter_position(&self) -> M::Fut<'_, Result<crate::command::NdFilterPosition, Error>> {
-        use crate::command::inquiry_structs::NdFilterInquiry;
-        self.query(NdFilterInquiry)
-    }
-
     fn version(&self) -> M::Fut<'_, Result<crate::command::VersionInfo, Error>> {
         use crate::command::inquiry_structs::VersionInquiry;
         self.query(VersionInquiry)
@@ -1038,11 +1019,6 @@ where
         self.query(TwoToneModeInquiry)
     }
 
-    fn nd_filter_preset(&self) -> M::Fut<'_, Result<crate::types::NdFilterPreset, Error>> {
-        use crate::command::inquiry_structs::NdFilterPresetInquiry;
-        self.query(NdFilterPresetInquiry)
-    }
-
     fn digital_mode_enabled(&self) -> M::Fut<'_, Result<bool, Error>> {
         use crate::command::inquiry_structs::DigitalInquiry;
         self.query(DigitalInquiry)
@@ -1053,14 +1029,29 @@ where
         self.query(TallyAutoAdjustInquiry)
     }
 
-    fn motion_sync_mode(&self) -> M::Fut<'_, Result<MotionSyncMode, Error>> {
-        use crate::command::inquiry_structs::MotionSyncModeInquiry;
-        self.query(MotionSyncModeInquiry)
-    }
-
     fn flicker_mode(&self) -> M::Fut<'_, Result<crate::command::exposure::AntiFlickerMode, Error>> {
         use crate::command::inquiry_structs::FlickerModeInquiry;
         self.query(FlickerModeInquiry)
+    }
+}
+
+impl<M, P, Tr, Exec> NdFilterInquiryControl for crate::camera::Camera<M, P, Tr, Exec>
+where
+    M: Mode,
+    P: crate::capabilities::Profile + Default + crate::capabilities::HasNdFilter,
+    Self: ViscaClient<M>,
+    Exec: crate::executor::Executor,
+{
+    type Mode = M;
+
+    fn nd_filter_position(&self) -> M::Fut<'_, Result<crate::command::NdFilterPosition, Error>> {
+        use crate::command::inquiry_structs::NdFilterInquiry;
+        self.query(NdFilterInquiry)
+    }
+
+    fn nd_filter_preset(&self) -> M::Fut<'_, Result<crate::types::NdFilterPreset, Error>> {
+        use crate::command::inquiry_structs::NdFilterPresetInquiry;
+        self.query(NdFilterPresetInquiry)
     }
 }
 

--- a/src/camera/controls/mod.rs
+++ b/src/camera/controls/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
     exposure::{ExposureCompensationControl, ExposureControl},
     focus::{FocusControl, FocusLockControl, PushAFControl},
     image_processing::ImageProcessingControl,
-    inquiry::{InquiryControl, PanTiltInquiryControl},
+    inquiry::{InquiryControl, NdFilterInquiryControl, PanTiltInquiryControl},
     menu::{DirectMenuControl, MenuControl},
     motion::MotionControl,
     motion_sync::MotionSyncControl,

--- a/src/camera/controls/motion_sync.rs
+++ b/src/camera/controls/motion_sync.rs
@@ -11,8 +11,8 @@
 //! This feature helps eliminate the jarring effect of sequential movements
 //! by synchronizing all axes to complete their movement simultaneously.
 //!
-//! This feature is primarily available on PtzOptics cameras and other
-//! professional PTZ systems that support coordinated movement control.
+//! This feature is available only for profiles that explicitly implement the
+//! `HasMotionSync` support marker.
 //!
 //! The implementation uses the Mode trait to provide both blocking and async APIs
 //! from a single unified codebase.
@@ -69,8 +69,8 @@ pub trait MotionSyncControl {
     /// - `mode`: The motion sync mode to set (On or Off)
     ///
     /// # Note
-    /// This is primarily a PtzOptics-specific feature, though other professional
-    /// cameras may support similar functionality.
+    /// This is a vendor-specific feature and is only available for profiles
+    /// that explicitly implement the typed Motion Sync support marker.
     ///
     /// # Errors
     /// Returns an error if the camera doesn't support motion sync or the command fails.
@@ -133,7 +133,7 @@ pub trait MotionSyncControl {
 impl<M, P, Tr, Exec> MotionSyncControl for crate::camera::Camera<M, P, Tr, Exec>
 where
     M: Mode,
-    P: crate::capabilities::Profile + Default + crate::capabilities::motion_sync::MotionSync,
+    P: crate::capabilities::Profile + Default + crate::capabilities::HasMotionSync,
     Self: ViscaClient<M>,
     Exec: crate::executor::Executor,
 {

--- a/src/camera/controls/nd_filter.rs
+++ b/src/camera/controls/nd_filter.rs
@@ -155,7 +155,7 @@ pub trait NdFilterControl {
 impl<M, P, Tr, Exec> NdFilterControl for crate::camera::Camera<M, P, Tr, Exec>
 where
     M: Mode,
-    P: crate::capabilities::Profile + Default + crate::capabilities::nd_filter::NdFilter,
+    P: crate::capabilities::Profile + Default + crate::capabilities::HasNdFilter,
     Self: ViscaClient<M>,
     Exec: crate::executor::Executor,
 {

--- a/src/camera/controls/variable_speed.rs
+++ b/src/camera/controls/variable_speed.rs
@@ -87,7 +87,7 @@ pub trait VariableSpeedControl {
 impl<M, P, Tr, Exec> VariableSpeedControl for crate::camera::Camera<M, P, Tr, Exec>
 where
     M: Mode,
-    P: crate::capabilities::Profile + Default + crate::capabilities::VariableSpeed,
+    P: crate::capabilities::Profile + Default + crate::capabilities::HasVariableSpeed,
     Self: ViscaClient<M>,
     Exec: crate::executor::Executor,
 {

--- a/src/camera/profiles.rs
+++ b/src/camera/profiles.rs
@@ -7,9 +7,9 @@ use std::{fmt, time::Duration};
 
 use crate::{
     capabilities::{
-        CoordinateSystem, Exposure, Focus, ImageProcessing, MenuCapability, MotionSync, NdFilter,
-        NdFilterMode, PanTilt, Power, Presets, ProfileMetadata, ShutterSpeed, VariableSpeed,
-        WhiteBalance, Zoom,
+        CoordinateSystem, Exposure, Focus, HasNdFilter, HasVariableSpeed, ImageProcessing,
+        MenuCapability, MotionSyncMetadata, NdFilterMetadata, NdFilterMode, PanTilt, Power,
+        Presets, ProfileMetadata, ShutterSpeed, VariableSpeedMetadata, WhiteBalance, Zoom,
     },
     command::exposure::ExposureMode,
     error::Error,
@@ -216,17 +216,14 @@ impl Power for PtzOpticsG2 {
     const SUPPORTS_STANDBY: bool = true;
 }
 
-impl MotionSync for PtzOpticsG2 {
-    const SUPPORTS_MOTION_SYNC: bool = true;
-    const MAX_MOTION_SYNC_SPEED: u8 = 24;
-}
+impl MotionSyncMetadata for PtzOpticsG2 {}
 impl MenuCapability for PtzOpticsG2 {}
 impl crate::capabilities::Tally for PtzOpticsG2 {}
 
 impl crate::capabilities::HasExposureCompensation for PtzOpticsG2 {}
 impl crate::capabilities::HasFocusLock for PtzOpticsG2 {}
-impl NdFilter for PtzOpticsG2 {}
-impl VariableSpeed for PtzOpticsG2 {}
+impl NdFilterMetadata for PtzOpticsG2 {}
+impl VariableSpeedMetadata for PtzOpticsG2 {}
 
 /// Generic VISCA camera profile.
 ///
@@ -319,9 +316,9 @@ impl Presets for GenericVisca {
 }
 
 impl crate::capabilities::Tally for GenericVisca {}
-impl MotionSync for GenericVisca {}
-impl NdFilter for GenericVisca {}
-impl VariableSpeed for GenericVisca {}
+impl MotionSyncMetadata for GenericVisca {}
+impl NdFilterMetadata for GenericVisca {}
+impl VariableSpeedMetadata for GenericVisca {}
 
 /// Sony FR7 camera profile (example with ND filter).
 ///
@@ -364,7 +361,7 @@ impl Focus for SonyFR7 {
     const FOCUS_NEAR_LIMIT: u16 = 0x1000;
     const FOCUS_FAR_LIMIT: u16 = 0xF000;
     const SUPPORTS_AUTO_FOCUS: bool = true;
-    const SUPPORTS_ONE_PUSH_FOCUS: bool = true;
+    const SUPPORTS_ONE_PUSH_FOCUS: bool = false;
     const SUPPORTS_FOCUS_ZONE: bool = true;
     const SUPPORTS_AF_SENSITIVITY: bool = true;
 }
@@ -420,17 +417,19 @@ impl Power for SonyFR7 {
     const SUPPORTS_WAKE_ON_LAN: bool = true;
 }
 
-impl NdFilter for SonyFR7 {
+impl NdFilterMetadata for SonyFR7 {
     const ND_MODE: NdFilterMode = NdFilterMode::Variable;
     const ND_STEPS: Option<u8> = None;
 }
+impl HasNdFilter for SonyFR7 {}
 impl MenuCapability for SonyFR7 {
     const SUPPORTS_DIRECT_CONTROL: bool = true;
 }
 
-impl VariableSpeed for SonyFR7 {
+impl VariableSpeedMetadata for SonyFR7 {
     const SUPPORTS_VARIABLE_SPEED: bool = true;
 }
+impl HasVariableSpeed for SonyFR7 {}
 
 impl crate::capabilities::HasExposureCompensation for SonyFR7 {}
 impl crate::capabilities::HasPushAutoFocus for SonyFR7 {}
@@ -438,7 +437,7 @@ impl crate::capabilities::menu_control::HasDirectMenuControl for SonyFR7 {}
 impl crate::capabilities::Tally for SonyFR7 {
     const SUPPORTS_TALLY: bool = true;
 }
-impl MotionSync for SonyFR7 {}
+impl MotionSyncMetadata for SonyFR7 {}
 
 /// Sony BRC-H900 camera profile.
 ///
@@ -480,7 +479,7 @@ impl Focus for SonyBRCH900 {
     const FOCUS_NEAR_LIMIT: u16 = 0x1000;
     const FOCUS_FAR_LIMIT: u16 = 0xF000;
     const SUPPORTS_AUTO_FOCUS: bool = true;
-    const SUPPORTS_ONE_PUSH_FOCUS: bool = true;
+    const SUPPORTS_ONE_PUSH_FOCUS: bool = false;
 }
 
 impl Exposure for SonyBRCH900 {
@@ -527,9 +526,9 @@ impl MenuCapability for SonyBRCH900 {}
 impl crate::capabilities::Tally for SonyBRCH900 {
     const SUPPORTS_TALLY: bool = true;
 }
-impl MotionSync for SonyBRCH900 {}
-impl NdFilter for SonyBRCH900 {}
-impl VariableSpeed for SonyBRCH900 {}
+impl MotionSyncMetadata for SonyBRCH900 {}
+impl NdFilterMetadata for SonyBRCH900 {}
+impl VariableSpeedMetadata for SonyBRCH900 {}
 
 /// Sony EVI-H100 camera profile.
 ///
@@ -569,7 +568,7 @@ impl Focus for SonyEVIH100 {
     const FOCUS_NEAR_LIMIT: u16 = 0x1000;
     const FOCUS_FAR_LIMIT: u16 = 0xF000;
     const SUPPORTS_AUTO_FOCUS: bool = true;
-    const SUPPORTS_ONE_PUSH_FOCUS: bool = true;
+    const SUPPORTS_ONE_PUSH_FOCUS: bool = false;
 }
 
 impl Exposure for SonyEVIH100 {
@@ -614,9 +613,9 @@ impl ImageProcessing for SonyEVIH100 {
 
 impl MenuCapability for SonyEVIH100 {}
 impl crate::capabilities::Tally for SonyEVIH100 {}
-impl MotionSync for SonyEVIH100 {}
-impl NdFilter for SonyEVIH100 {}
-impl VariableSpeed for SonyEVIH100 {}
+impl MotionSyncMetadata for SonyEVIH100 {}
+impl NdFilterMetadata for SonyEVIH100 {}
+impl VariableSpeedMetadata for SonyEVIH100 {}
 
 /// Sony BRC-300 camera profile.
 ///
@@ -700,9 +699,9 @@ impl ImageProcessing for SonyBRC300 {
 
 impl MenuCapability for SonyBRC300 {}
 impl crate::capabilities::Tally for SonyBRC300 {}
-impl MotionSync for SonyBRC300 {}
-impl NdFilter for SonyBRC300 {}
-impl VariableSpeed for SonyBRC300 {}
+impl MotionSyncMetadata for SonyBRC300 {}
+impl NdFilterMetadata for SonyBRC300 {}
+impl VariableSpeedMetadata for SonyBRC300 {}
 
 /// Nearus BRC-300 camera profile.
 ///
@@ -784,9 +783,9 @@ impl ImageProcessing for NearusBRC300 {
 
 impl MenuCapability for NearusBRC300 {}
 impl crate::capabilities::Tally for NearusBRC300 {}
-impl MotionSync for NearusBRC300 {}
-impl NdFilter for NearusBRC300 {}
-impl VariableSpeed for NearusBRC300 {}
+impl MotionSyncMetadata for NearusBRC300 {}
+impl NdFilterMetadata for NearusBRC300 {}
+impl VariableSpeedMetadata for NearusBRC300 {}
 
 /// PtzOptics G3 camera profile.
 ///
@@ -831,7 +830,7 @@ impl Focus for PtzOpticsG3 {
     const FOCUS_NEAR_LIMIT: u16 = 0x1000;
     const FOCUS_FAR_LIMIT: u16 = 0xF000;
     const SUPPORTS_AUTO_FOCUS: bool = true;
-    const SUPPORTS_ONE_PUSH_FOCUS: bool = true;
+    const SUPPORTS_ONE_PUSH_FOCUS: bool = false;
 }
 
 impl Exposure for PtzOpticsG3 {
@@ -889,12 +888,9 @@ impl crate::capabilities::Tally for PtzOpticsG3 {}
 impl crate::capabilities::HasExposureCompensation for PtzOpticsG3 {}
 impl crate::capabilities::HasFocusLock for PtzOpticsG3 {}
 
-impl MotionSync for PtzOpticsG3 {
-    const SUPPORTS_MOTION_SYNC: bool = true;
-    const MAX_MOTION_SYNC_SPEED: u8 = 24;
-}
-impl NdFilter for PtzOpticsG3 {}
-impl VariableSpeed for PtzOpticsG3 {}
+impl MotionSyncMetadata for PtzOpticsG3 {}
+impl NdFilterMetadata for PtzOpticsG3 {}
+impl VariableSpeedMetadata for PtzOpticsG3 {}
 
 /// PtzOptics 30X camera profile.
 ///
@@ -939,7 +935,7 @@ impl Focus for PtzOptics30X {
     const FOCUS_NEAR_LIMIT: u16 = 0x1000;
     const FOCUS_FAR_LIMIT: u16 = 0xF000;
     const SUPPORTS_AUTO_FOCUS: bool = true;
-    const SUPPORTS_ONE_PUSH_FOCUS: bool = true;
+    const SUPPORTS_ONE_PUSH_FOCUS: bool = false;
 }
 
 impl Exposure for PtzOptics30X {
@@ -997,12 +993,9 @@ impl crate::capabilities::Tally for PtzOptics30X {}
 impl crate::capabilities::HasExposureCompensation for PtzOptics30X {}
 impl crate::capabilities::HasFocusLock for PtzOptics30X {}
 
-impl MotionSync for PtzOptics30X {
-    const SUPPORTS_MOTION_SYNC: bool = true;
-    const MAX_MOTION_SYNC_SPEED: u8 = 24;
-}
-impl NdFilter for PtzOptics30X {}
-impl VariableSpeed for PtzOptics30X {}
+impl MotionSyncMetadata for PtzOptics30X {}
+impl NdFilterMetadata for PtzOptics30X {}
+impl VariableSpeedMetadata for PtzOptics30X {}
 
 /// Preset ID for PtzOptics G2 cameras (0-127).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1694,7 +1687,7 @@ impl fmt::Display for G2Gain {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::capabilities::nd_filter::NdFilterExt;
+    use crate::capabilities::nd_filter::NdFilterMetadataExt;
     use crate::capabilities::pan_tilt::PanTiltExt;
 
     #[test]

--- a/src/camera/session.rs
+++ b/src/camera/session.rs
@@ -779,12 +779,18 @@ where
     }
 
     /// Access ND filter controls and inquiries.
-    pub fn nd_filter(&self) -> crate::camera::accessors::NdFilterAccessor<'_, M, P, Tr, Exec> {
+    pub fn nd_filter(&self) -> crate::camera::accessors::NdFilterAccessor<'_, M, P, Tr, Exec>
+    where
+        P: crate::capabilities::HasNdFilter,
+    {
         crate::camera::accessors::NdFilterAccessor::new(&self.camera)
     }
 
     /// Access motion sync controls and inquiries.
-    pub fn motion_sync(&self) -> crate::camera::accessors::MotionSyncAccessor<'_, M, P, Tr, Exec> {
+    pub fn motion_sync(&self) -> crate::camera::accessors::MotionSyncAccessor<'_, M, P, Tr, Exec>
+    where
+        P: crate::capabilities::HasMotionSync,
+    {
         crate::camera::accessors::MotionSyncAccessor::new(&self.camera)
     }
 

--- a/src/capabilities/discovery.rs
+++ b/src/capabilities/discovery.rs
@@ -330,25 +330,37 @@ impl Capabilities {
         let exposure_modes = P::EXPOSURE_MODES.to_vec();
         let iris_range = P::IRIS_RANGE
             .as_ref()
-            .map(|range| range.start..=(range.end - 1));
-        let gain_range = P::GAIN_RANGE.start..=(P::GAIN_RANGE.end - 1);
+            .map(|range| range.start..=range.end.saturating_sub(1));
+        let gain_range = P::GAIN_RANGE.start..=P::GAIN_RANGE.end.saturating_sub(1);
 
         // Extract white balance capabilities
-        let color_temp_range = P::COLOR_TEMP_RANGE.as_ref().map(|r| r.start..=(r.end - 1));
-        let rg_tuning_range = P::RG_TUNING_RANGE.as_ref().map(|r| r.start..=(r.end - 1));
-        let bg_tuning_range = P::BG_TUNING_RANGE.as_ref().map(|r| r.start..=(r.end - 1));
+        let color_temp_range = P::COLOR_TEMP_RANGE
+            .as_ref()
+            .map(|r| r.start..=r.end.saturating_sub(1));
+        let rg_tuning_range = P::RG_TUNING_RANGE
+            .as_ref()
+            .map(|r| r.start..=r.end.saturating_sub(1));
+        let bg_tuning_range = P::BG_TUNING_RANGE
+            .as_ref()
+            .map(|r| r.start..=r.end.saturating_sub(1));
 
         // Extract image processing capabilities
-        let brightness_range = P::BRIGHTNESS_RANGE.start..=(P::BRIGHTNESS_RANGE.end - 1);
-        let contrast_range = P::CONTRAST_RANGE.start..=(P::CONTRAST_RANGE.end - 1);
-        let sharpness_range = P::SHARPNESS_RANGE.start..=(P::SHARPNESS_RANGE.end - 1);
-        let saturation_range = P::SATURATION_RANGE.as_ref().map(|r| r.start..=(r.end - 1));
-        let hue_range = P::HUE_RANGE.as_ref().map(|r| r.start..=(r.end - 1));
+        let brightness_range =
+            P::BRIGHTNESS_RANGE.start..=P::BRIGHTNESS_RANGE.end.saturating_sub(1);
+        let contrast_range = P::CONTRAST_RANGE.start..=P::CONTRAST_RANGE.end.saturating_sub(1);
+        let sharpness_range = P::SHARPNESS_RANGE.start..=P::SHARPNESS_RANGE.end.saturating_sub(1);
+        let saturation_range = P::SATURATION_RANGE
+            .as_ref()
+            .map(|r| r.start..=r.end.saturating_sub(1));
+        let hue_range = P::HUE_RANGE
+            .as_ref()
+            .map(|r| r.start..=r.end.saturating_sub(1));
 
         // Extract preset capabilities
-        let preset_speed_range = P::PRESET_SPEED_RANGE.start..=(P::PRESET_SPEED_RANGE.end - 1);
+        let preset_speed_range =
+            P::PRESET_SPEED_RANGE.start..=P::PRESET_SPEED_RANGE.end.saturating_sub(1);
 
-        // Extract ND filter capabilities from the NdFilter trait
+        // Extract ND filter capabilities from profile metadata.
         let has_nd_filter = !matches!(P::ND_MODE, crate::capabilities::NdFilterMode::None);
         let nd_filter_type = match P::ND_MODE {
             crate::capabilities::NdFilterMode::None => None,
@@ -357,7 +369,7 @@ impl Capabilities {
             crate::capabilities::NdFilterMode::Variable => Some("Variable ND filter".to_string()),
         };
 
-        // Extract motion sync capabilities from the MotionSync trait
+        // Extract Motion Sync capabilities from profile metadata.
         let has_motion_sync = P::SUPPORTS_MOTION_SYNC;
         let max_motion_sync_speed = if has_motion_sync {
             Some(P::MAX_MOTION_SYNC_SPEED)
@@ -636,7 +648,10 @@ impl Capabilities {
 
 #[cfg(test)]
 mod tests {
-    use crate::camera::profiles::{GenericVisca, PtzOpticsG2, SonyFR7};
+    use crate::camera::profiles::{
+        GenericVisca, NearusBRC300, PtzOptics30X, PtzOpticsG2, PtzOpticsG3, SonyBRC300,
+        SonyBRCH900, SonyEVIH100, SonyFR7,
+    };
 
     use super::*;
 
@@ -670,6 +685,10 @@ mod tests {
 
         assert_eq!(caps.max_presets, 127);
         assert!(!caps.supports_preset_tour);
+        assert!(!caps.has_nd_filter);
+        assert!(!caps.has_motion_sync);
+        assert_eq!(caps.max_motion_sync_speed, None);
+        assert!(!caps.has_variable_speed);
 
         assert!(caps.has_basic_features());
     }
@@ -684,10 +703,16 @@ mod tests {
 
         assert_eq!(caps.max_presets, 255);
         assert!(caps.supports_preset_tour);
+        assert!(!caps.has_one_push_focus);
         assert!(caps.has_focus_zone);
         assert!(caps.has_af_sensitivity);
         assert!(caps.has_focus_near_limit_inquiry);
         assert!(caps.has_rgb_gain);
+        assert!(caps.has_nd_filter);
+        assert_eq!(caps.nd_filter_type.as_deref(), Some("Variable ND filter"));
+        assert!(!caps.has_motion_sync);
+        assert_eq!(caps.max_motion_sync_speed, None);
+        assert!(caps.has_variable_speed);
 
         assert!(caps.has_advanced_features());
     }
@@ -706,7 +731,50 @@ mod tests {
         assert!(caps.has_basic_features());
         // GenericVisca has one-push white balance, which counts as an advanced feature
         assert!(caps.has_one_push_wb);
+        assert!(!caps.has_nd_filter);
+        assert!(!caps.has_motion_sync);
+        assert_eq!(caps.max_motion_sync_speed, None);
+        assert!(!caps.has_variable_speed);
         assert!(caps.has_advanced_features());
+    }
+
+    #[test]
+    fn test_optional_vendor_feature_metadata_matrix() {
+        for caps in [
+            Capabilities::from_profile::<PtzOpticsG2>(),
+            Capabilities::from_profile::<PtzOpticsG3>(),
+            Capabilities::from_profile::<PtzOptics30X>(),
+        ] {
+            assert!(!caps.has_one_push_focus);
+            assert!(!caps.has_nd_filter);
+            assert_eq!(caps.nd_filter_type, None);
+            assert!(!caps.has_motion_sync);
+            assert_eq!(caps.max_motion_sync_speed, None);
+            assert!(!caps.has_variable_speed);
+        }
+
+        let fr7 = Capabilities::from_profile::<SonyFR7>();
+        assert!(fr7.has_nd_filter);
+        assert_eq!(fr7.nd_filter_type.as_deref(), Some("Variable ND filter"));
+        assert!(!fr7.has_one_push_focus);
+        assert!(!fr7.has_motion_sync);
+        assert_eq!(fr7.max_motion_sync_speed, None);
+        assert!(fr7.has_variable_speed);
+
+        for caps in [
+            Capabilities::from_profile::<GenericVisca>(),
+            Capabilities::from_profile::<SonyBRCH900>(),
+            Capabilities::from_profile::<SonyEVIH100>(),
+            Capabilities::from_profile::<SonyBRC300>(),
+            Capabilities::from_profile::<NearusBRC300>(),
+        ] {
+            assert!(!caps.has_one_push_focus);
+            assert!(!caps.has_nd_filter);
+            assert_eq!(caps.nd_filter_type, None);
+            assert!(!caps.has_motion_sync);
+            assert_eq!(caps.max_motion_sync_speed, None);
+            assert!(!caps.has_variable_speed);
+        }
     }
 
     #[test]

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -31,13 +31,13 @@ pub use exposure::Exposure;
 pub use focus::Focus;
 pub use image_processing::ImageProcessing;
 pub use menu_control::{HasDirectMenuControl, MenuCapability};
-pub use motion_sync::MotionSync;
-pub use nd_filter::{NdFilter, NdFilterMode};
+pub use motion_sync::MotionSyncMetadata;
+pub use nd_filter::{NdFilterMetadata, NdFilterMetadataExt, NdFilterMode};
 pub use pan_tilt::PanTilt;
 pub use power::Power;
 pub use presets::Presets;
 pub use tally::Tally;
-pub use variable_speed::VariableSpeed;
+pub use variable_speed::VariableSpeedMetadata;
 pub use white_balance::WhiteBalance;
 pub use zoom::Zoom;
 
@@ -56,9 +56,8 @@ pub use discovery::Capabilities;
 /// Super-trait that encompasses all camera capabilities.
 ///
 /// This trait allows a single generic bound to ensure a type has all the
-/// necessary camera capabilities. It combines metadata with all feature traits,
-/// including optional features like motion sync, ND filter, and variable speed
-/// (which default to "not supported" when not overridden).
+/// necessary camera capabilities. It combines metadata with all baseline
+/// feature traits plus optional-feature metadata for runtime discovery.
 ///
 /// # Example
 /// ```ignore
@@ -82,9 +81,9 @@ pub trait Profile:
     + Power
     + MenuCapability
     + Tally
-    + MotionSync
-    + NdFilter
-    + VariableSpeed
+    + MotionSyncMetadata
+    + NdFilterMetadata
+    + VariableSpeedMetadata
     + Sized
     + Send
     + Sync
@@ -105,9 +104,9 @@ impl<T> Profile for T where
         + Power
         + MenuCapability
         + Tally
-        + MotionSync
-        + NdFilter
-        + VariableSpeed
+        + MotionSyncMetadata
+        + NdFilterMetadata
+        + VariableSpeedMetadata
         + Sized
         + Send
         + Sync

--- a/src/capabilities/motion_sync.rs
+++ b/src/capabilities/motion_sync.rs
@@ -1,10 +1,11 @@
-//! Motion sync capability trait for PtzOptics cameras.
+//! Motion sync metadata trait for camera profiles.
 
-/// Trait for cameras that support Motion Sync functionality.
+/// Metadata for a camera profile's Motion Sync capability.
 ///
-/// Motion Sync is a PtzOptics-specific feature that coordinates pan, tilt, and zoom
-/// movements for smoother preset recalls.
-pub trait MotionSync {
+/// This trait supplies runtime discovery defaults. It does not mean the typed
+/// Motion Sync control API is available for a profile; use
+/// [`crate::capabilities::HasMotionSync`] for that compile-time support marker.
+pub trait MotionSyncMetadata {
     /// Whether this camera supports motion sync.
     const SUPPORTS_MOTION_SYNC: bool = false;
 

--- a/src/capabilities/nd_filter.rs
+++ b/src/capabilities/nd_filter.rs
@@ -1,14 +1,15 @@
-//! Neutral Density (ND) filter capability trait and associated types.
+//! Neutral Density (ND) filter metadata trait and associated types.
 
 use std::borrow::Cow;
 
 use crate::capabilities::ValidationError;
 
-/// Trait for cameras that support ND filter control.
+/// Metadata for a camera profile's ND filter capability.
 ///
-/// This trait defines the constants and capabilities for ND filter operations.
-/// ND filters reduce the amount of light entering the camera without affecting color.
-pub trait NdFilter {
+/// This trait supplies runtime discovery defaults. It does not mean the typed
+/// ND filter control API is available for a profile; use
+/// [`crate::capabilities::HasNdFilter`] for that compile-time support marker.
+pub trait NdFilterMetadata {
     /// ND filter mode determines how the filter operates.
     ///
     /// Default: [`NdFilterMode::None`] — no ND filter available.
@@ -21,8 +22,8 @@ pub trait NdFilter {
     const ND_STEPS: Option<u8> = None;
 }
 
-/// Extension trait that adds validation methods to cameras with ND filter support.
-pub trait NdFilterExt: NdFilter {
+/// Extension trait that adds validation methods to ND filter metadata.
+pub trait NdFilterMetadataExt: NdFilterMetadata {
     /// Validate an ND filter setting based on the camera's ND mode.
     fn validate_nd_filter(&self, value: u8) -> Result<u8, ValidationError> {
         match Self::ND_MODE {
@@ -83,8 +84,7 @@ pub trait NdFilterExt: NdFilter {
     }
 }
 
-// Automatic implementation for all types that support ND filter
-impl<T: NdFilter> NdFilterExt for T {}
+impl<T: NdFilterMetadata> NdFilterMetadataExt for T {}
 
 /// ND filter operating modes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -107,25 +107,25 @@ mod tests {
     use super::*;
 
     struct NoNdCamera;
-    impl NdFilter for NoNdCamera {
+    impl NdFilterMetadata for NoNdCamera {
         const ND_MODE: NdFilterMode = NdFilterMode::None;
         const ND_STEPS: Option<u8> = None;
     }
 
     struct FixedNdCamera;
-    impl NdFilter for FixedNdCamera {
+    impl NdFilterMetadata for FixedNdCamera {
         const ND_MODE: NdFilterMode = NdFilterMode::Fixed(3);
         const ND_STEPS: Option<u8> = None;
     }
 
     struct SteppedNdCamera;
-    impl NdFilter for SteppedNdCamera {
+    impl NdFilterMetadata for SteppedNdCamera {
         const ND_MODE: NdFilterMode = NdFilterMode::Stepped(3);
         const ND_STEPS: Option<u8> = Some(3);
     }
 
     struct VariableNdCamera;
-    impl NdFilter for VariableNdCamera {
+    impl NdFilterMetadata for VariableNdCamera {
         const ND_MODE: NdFilterMode = NdFilterMode::Variable;
         const ND_STEPS: Option<u8> = None;
     }

--- a/src/capabilities/profile_metadata.rs
+++ b/src/capabilities/profile_metadata.rs
@@ -176,13 +176,13 @@ pub trait HasPower {}
 /// Marker trait indicating support for menu control.
 pub trait HasMenuControl {}
 
-/// Marker trait indicating support for motion sync.
+/// Marker trait indicating typed Motion Sync API support.
 pub trait HasMotionSync {}
 
-/// Marker trait indicating support for variable speed.
+/// Marker trait indicating typed variable speed API support.
 pub trait HasVariableSpeed {}
 
-/// Marker trait indicating support for ND filter.
+/// Marker trait indicating typed ND filter API support.
 pub trait HasNdFilter {}
 
 // Specific feature marker traits
@@ -203,7 +203,7 @@ pub trait HasFocusLock {}
 /// feature primarily supported by Sony cameras.
 pub trait HasPushAutoFocus {}
 
-// Specialized blanket implementations for each marker trait.
+// Specialized blanket implementations for baseline marker traits.
 // These automatically implement the marker trait for any type that implements
 // both ProfileMetadata and the corresponding capability trait.
 
@@ -216,9 +216,6 @@ impl<T: ProfileMetadata + crate::capabilities::ImageProcessing> HasImageProcessi
 impl<T: ProfileMetadata + crate::capabilities::Presets> HasPresets for T {}
 impl<T: ProfileMetadata + crate::capabilities::Power> HasPower for T {}
 impl<T: ProfileMetadata + crate::capabilities::MenuCapability> HasMenuControl for T {}
-impl<T: ProfileMetadata + crate::capabilities::MotionSync> HasMotionSync for T {}
-impl<T: ProfileMetadata + crate::capabilities::VariableSpeed> HasVariableSpeed for T {}
-impl<T: ProfileMetadata + crate::capabilities::NdFilter> HasNdFilter for T {}
 
 #[cfg(test)]
 mod tests {

--- a/src/capabilities/variable_speed.rs
+++ b/src/capabilities/variable_speed.rs
@@ -1,12 +1,14 @@
-//! Variable speed mode capability trait for Sony FR7.
+//! Variable speed mode metadata trait for camera profiles.
 //!
 //! The FR7 supports switching between 24-step and 50-step speed modes.
 
-/// Trait for cameras that support variable speed mode control.
+/// Metadata for a camera profile's variable speed mode capability.
 ///
-/// Only the Sony FR7 currently supports this feature, allowing
-/// switching between 24-step (standard) and 50-step (fine) speed modes.
-pub trait VariableSpeed {
+/// This trait supplies runtime discovery defaults. It does not mean the typed
+/// variable speed control API is available for a profile; use
+/// [`crate::capabilities::HasVariableSpeed`] for that compile-time support
+/// marker.
+pub trait VariableSpeedMetadata {
     /// Whether the camera supports variable speed mode switching.
     ///
     /// Defaults to false. Only Sony FR7 overrides this to true.

--- a/src/command/focus.rs
+++ b/src/command/focus.rs
@@ -119,7 +119,9 @@ pub enum Focus {
     /// Snap focus (one-push AF while in manual mode).
     ///
     /// Triggers a single autofocus operation, then returns to manual focus mode.
-    /// **Vendor-Specific**: PTZOptics "Snap Focus" feature.
+    /// **Vendor-Specific**: Some vendor/firmware command references document
+    /// this opcode, but built-in profiles only expose it when their profile
+    /// metadata reports one-push focus support.
     Snap,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,6 +323,13 @@
 //! // g2.nd_filter().set_mode(NdFilterMode::Clear)?; // Compile error: G2 has no ND filter capability
 //! ```
 //!
+//! Runtime discovery metadata is available for every profile through
+//! `Capabilities::from_profile::<P>()`. Typed optional vendor controls use
+//! separate support markers, so the public API exposes only documented support:
+//! `SonyFR7` has typed ND filter and variable speed controls. Built-in
+//! PTZOptics profiles are not marked for typed Motion Sync from the current
+//! model capability specs.
+//!
 //! ## Transport Implementation
 //!
 //! The library provides transport traits that you can implement for any communication method:
@@ -675,9 +682,10 @@ pub use crate::{
         controls::{
             ColorControl, DirectMenuControl, ExposureCompensationControl, ExposureControl,
             FocusControl, FocusLockControl, ImageProcessingControl, InquiryControl, MenuControl,
-            MotionControl, MotionSyncControl, NdFilterControl, PanTiltControl,
-            PanTiltInquiryControl, PowerControl, PresetsControl, PushAFControl, StreamingControl,
-            SystemControl, TallyControl, VariableSpeedControl, WhiteBalanceControl, ZoomControl,
+            MotionControl, MotionSyncControl, NdFilterControl, NdFilterInquiryControl,
+            PanTiltControl, PanTiltInquiryControl, PowerControl, PresetsControl, PushAFControl,
+            StreamingControl, SystemControl, TallyControl, VariableSpeedControl,
+            WhiteBalanceControl, ZoomControl,
         },
         Camera, CameraBuilder,
     },

--- a/tests/api_contract/fail/generic_optional_accessors_removed.rs
+++ b/tests/api_contract/fail/generic_optional_accessors_removed.rs
@@ -1,0 +1,8 @@
+use grafton_visca::{profiles::GenericVisca, transport::BlockingTransportHandle, BlockingCamera};
+
+fn main() {
+    let camera: Option<BlockingCamera<GenericVisca, BlockingTransportHandle>> = None;
+    let camera = camera.unwrap();
+    let _ = camera.nd_filter();
+    let _ = camera.motion_sync();
+}

--- a/tests/api_contract/fail/ptzoptics_g2_nd_filter_accessor_removed.rs
+++ b/tests/api_contract/fail/ptzoptics_g2_nd_filter_accessor_removed.rs
@@ -1,0 +1,6 @@
+use grafton_visca::{profiles::PtzOpticsG2, transport::BlockingTransportHandle, BlockingCamera};
+
+fn main() {
+    let camera: Option<BlockingCamera<PtzOpticsG2, BlockingTransportHandle>> = None;
+    let _ = camera.unwrap().nd_filter();
+}

--- a/tests/api_contract/fail/ptzoptics_g2_nd_filter_direct_removed.rs
+++ b/tests/api_contract/fail/ptzoptics_g2_nd_filter_direct_removed.rs
@@ -1,0 +1,9 @@
+use grafton_visca::{
+    command::NdFilterMode, profiles::PtzOpticsG2, transport::BlockingTransportHandle,
+    BlockingCamera,
+};
+
+fn main() {
+    let camera: Option<BlockingCamera<PtzOpticsG2, BlockingTransportHandle>> = None;
+    let _ = camera.unwrap().set_nd_filter_mode(NdFilterMode::Variable);
+}

--- a/tests/api_contract/fail/ptzoptics_g2_variable_speed_removed.rs
+++ b/tests/api_contract/fail/ptzoptics_g2_variable_speed_removed.rs
@@ -1,0 +1,11 @@
+use grafton_visca::{
+    command::VariableSpeedMode, profiles::PtzOpticsG2, transport::BlockingTransportHandle,
+    BlockingCamera,
+};
+
+fn main() {
+    let camera: Option<BlockingCamera<PtzOpticsG2, BlockingTransportHandle>> = None;
+    let _ = camera
+        .unwrap()
+        .set_variable_speed_mode(VariableSpeedMode::Fine50);
+}

--- a/tests/api_contract/fail/ptzoptics_motion_sync_accessor_removed.rs
+++ b/tests/api_contract/fail/ptzoptics_motion_sync_accessor_removed.rs
@@ -1,0 +1,15 @@
+use grafton_visca::{
+    profiles::{PtzOptics30X, PtzOpticsG2, PtzOpticsG3},
+    transport::BlockingTransportHandle,
+    BlockingCamera,
+};
+
+fn main() {
+    let g2: Option<BlockingCamera<PtzOpticsG2, BlockingTransportHandle>> = None;
+    let g3: Option<BlockingCamera<PtzOpticsG3, BlockingTransportHandle>> = None;
+    let thirty_x: Option<BlockingCamera<PtzOptics30X, BlockingTransportHandle>> = None;
+
+    let _ = g2.unwrap().motion_sync();
+    let _ = g3.unwrap().motion_sync();
+    let _ = thirty_x.unwrap().motion_sync();
+}

--- a/tests/api_contract/fail/ptzoptics_motion_sync_direct_removed.rs
+++ b/tests/api_contract/fail/ptzoptics_motion_sync_direct_removed.rs
@@ -1,0 +1,9 @@
+use grafton_visca::{
+    command::MotionSyncMode, profiles::PtzOpticsG2, transport::BlockingTransportHandle,
+    BlockingCamera,
+};
+
+fn main() {
+    let camera: Option<BlockingCamera<PtzOpticsG2, BlockingTransportHandle>> = None;
+    let _ = camera.unwrap().set_motion_sync_mode(MotionSyncMode::On);
+}

--- a/tests/api_contract/fail/sony_fr7_motion_sync_removed.rs
+++ b/tests/api_contract/fail/sony_fr7_motion_sync_removed.rs
@@ -1,0 +1,6 @@
+use grafton_visca::{profiles::SonyFR7, transport::BlockingTransportHandle, BlockingCamera};
+
+fn main() {
+    let camera: Option<BlockingCamera<SonyFR7, BlockingTransportHandle>> = None;
+    let _ = camera.unwrap().motion_sync();
+}

--- a/tests/api_contract/fail/unsupported_optional_inquiries_removed.rs
+++ b/tests/api_contract/fail/unsupported_optional_inquiries_removed.rs
@@ -1,0 +1,12 @@
+use grafton_visca::{
+    profiles::{GenericVisca, PtzOpticsG2},
+    transport::BlockingTransportHandle,
+    BlockingCamera,
+};
+
+fn main() {
+    let g2: Option<BlockingCamera<PtzOpticsG2, BlockingTransportHandle>> = None;
+    let generic: Option<BlockingCamera<GenericVisca, BlockingTransportHandle>> = None;
+    let _ = g2.unwrap().nd_filter_position();
+    let _ = generic.unwrap().nd_filter_preset();
+}

--- a/tests/api_contract/fail/unsupported_optional_support_markers.rs
+++ b/tests/api_contract/fail/unsupported_optional_support_markers.rs
@@ -1,0 +1,20 @@
+use grafton_visca::{
+    capabilities::{HasMotionSync, HasNdFilter, HasVariableSpeed},
+    profiles::{GenericVisca, PtzOptics30X, PtzOpticsG2, PtzOpticsG3, SonyFR7},
+};
+
+fn requires_nd<P: HasNdFilter>() {}
+fn requires_motion_sync<P: HasMotionSync>() {}
+fn requires_variable_speed<P: HasVariableSpeed>() {}
+
+fn main() {
+    requires_nd::<PtzOpticsG2>();
+    requires_nd::<GenericVisca>();
+    requires_variable_speed::<PtzOpticsG2>();
+    requires_variable_speed::<GenericVisca>();
+    requires_motion_sync::<PtzOpticsG2>();
+    requires_motion_sync::<PtzOpticsG3>();
+    requires_motion_sync::<PtzOptics30X>();
+    requires_motion_sync::<GenericVisca>();
+    requires_motion_sync::<SonyFR7>();
+}

--- a/tests/api_contract/fail_async/async_optional_accessors_removed.rs
+++ b/tests/api_contract/fail_async/async_optional_accessors_removed.rs
@@ -1,0 +1,30 @@
+use grafton_visca::{
+    camera::CameraSession,
+    mode::Async,
+    profiles::{GenericVisca, PtzOpticsG2, SonyFR7},
+    Executor,
+};
+
+fn ptzoptics_g2_session<Tr, Exec>(session: &CameraSession<Async, PtzOpticsG2, Tr, Exec>)
+where
+    Exec: Executor,
+{
+    let _ = session.nd_filter();
+    let _ = session.motion_sync();
+}
+
+fn generic_session<Tr, Exec>(session: &CameraSession<Async, GenericVisca, Tr, Exec>)
+where
+    Exec: Executor,
+{
+    let _ = session.motion_sync();
+}
+
+fn sony_fr7_session<Tr, Exec>(session: &CameraSession<Async, SonyFR7, Tr, Exec>)
+where
+    Exec: Executor,
+{
+    let _ = session.motion_sync();
+}
+
+fn main() {}

--- a/tests/api_contract/pass/public_root_control_traits.rs
+++ b/tests/api_contract/pass/public_root_control_traits.rs
@@ -1,9 +1,9 @@
 use grafton_visca::{
     ColorControl, DirectMenuControl, ExposureCompensationControl, ExposureControl, FocusControl,
     FocusLockControl, ImageProcessingControl, InquiryControl, MenuControl, MotionControl,
-    MotionSyncControl, NdFilterControl, PanTiltControl, PanTiltInquiryControl, PowerControl,
-    PresetsControl, PushAFControl, StreamingControl, SystemControl, TallyControl,
-    VariableSpeedControl, WhiteBalanceControl, ZoomControl,
+    MotionSyncControl, NdFilterControl, NdFilterInquiryControl, PanTiltControl,
+    PanTiltInquiryControl, PowerControl, PresetsControl, PushAFControl, StreamingControl,
+    SystemControl, TallyControl, VariableSpeedControl, WhiteBalanceControl, ZoomControl,
 };
 
 use core::marker::PhantomData;
@@ -30,6 +30,7 @@ impl<T> RootControlBounds<T> where
         + MotionControl
         + MotionSyncControl
         + NdFilterControl
+        + NdFilterInquiryControl
         + PushAFControl
         + StreamingControl
         + SystemControl

--- a/tests/api_contract/pass_async/async_camera_first_accessors.rs
+++ b/tests/api_contract/pass_async/async_camera_first_accessors.rs
@@ -3,7 +3,7 @@
 use grafton_visca::{
     camera::{CameraConfig, CameraSession, Connect},
     mode::Async,
-    profiles::PtzOpticsG2,
+    profiles::{PtzOpticsG2, SonyFR7},
     runtime::Runtime,
     transport::TransportConfig,
     Error, Executor,
@@ -22,11 +22,16 @@ where
     let _ = session.image();
     let _ = session.presets();
     let _ = session.tally();
-    let _ = session.nd_filter();
-    let _ = session.motion_sync();
     let _ = session.menu();
     let _ = session.system();
     let _ = session.advanced();
+}
+
+fn async_fr7_optional_accessors<Tr, Exec>(session: &CameraSession<Async, SonyFR7, Tr, Exec>)
+where
+    Exec: Executor,
+{
+    let _ = session.nd_filter();
 }
 
 async fn async_connect_contract<R>(runtime: R) -> Result<(), Error>

--- a/tests/api_contract/pass_blocking/blocking_camera_accessors.rs
+++ b/tests/api_contract/pass_blocking/blocking_camera_accessors.rs
@@ -1,6 +1,6 @@
 use grafton_visca::{
-    command::{NdFilterMode, NdFilterStep},
-    profiles::PtzOpticsG2,
+    command::{NdFilterMode, NdFilterStep, VariableSpeedMode},
+    profiles::{PtzOpticsG2, SonyFR7},
     transport::BlockingTransportHandle,
     units::{Degrees, Normalized},
     BlockingCamera, Error, SpeedLevel,
@@ -21,15 +21,23 @@ fn use_blocking_camera(
     camera.tally().bright_hi()?;
     camera.tally().flash()?;
     camera.tally().off()?;
+    camera.system().interface_clear()?;
+    Ok(())
+}
+
+fn use_sony_fr7_nd_filter(
+    camera: BlockingCamera<SonyFR7, BlockingTransportHandle>,
+) -> Result<(), Error> {
     camera.nd_filter().set_mode(NdFilterMode::Variable)?;
     camera.nd_filter().set_value(4)?;
     camera.nd_filter().set_stops(3.0)?;
     camera.nd_filter().step(NdFilterStep::Up)?;
     camera.nd_filter().set_auto(false)?;
-    camera.system().interface_clear()?;
+    camera.set_variable_speed_mode(VariableSpeedMode::Fine50)?;
     Ok(())
 }
 
 fn main() {
     let _ = use_blocking_camera;
+    let _ = use_sony_fr7_nd_filter;
 }

--- a/tests/api_stability_test.rs
+++ b/tests/api_stability_test.rs
@@ -315,8 +315,8 @@ fn test_core_types_stability() {
 fn test_capability_traits_stability() {
     use grafton_visca::camera::profiles::{GenericVisca, PtzOpticsG2, SonyFR7};
     use grafton_visca::capabilities::{
-        Capabilities, Exposure, Focus, ImageProcessing, InquirySupport, NdFilter, PanTilt, Power,
-        Profile, ProfileMetadata, WhiteBalance, Zoom,
+        Capabilities, Exposure, Focus, HasNdFilter, ImageProcessing, InquirySupport, PanTilt,
+        Power, Profile, ProfileMetadata, WhiteBalance, Zoom,
     };
 
     // Test that capability traits can be used as bounds
@@ -334,7 +334,7 @@ fn test_capability_traits_stability() {
 
     fn test_specialized_bounds<P>()
     where
-        P: Profile + NdFilter, // Only NdFilter since not all profiles have MotionSync
+        P: Profile + HasNdFilter,
     {
     }
 
@@ -347,7 +347,7 @@ fn test_capability_traits_stability() {
     test_advanced_bounds::<SonyFR7>();
     test_advanced_bounds::<GenericVisca>();
 
-    // Only test NdFilter specialization for SonyFR7 which supports it
+    // Only test typed ND filter support for SonyFR7.
     test_specialized_bounds::<SonyFR7>();
 
     assert_eq!(PtzOpticsG2::MODEL_NAME, "PtzOptics G2");
@@ -363,8 +363,8 @@ fn test_capability_traits_stability() {
     assert!(g2_caps.has_basic_features());
     assert!(g2_caps.has_full_inquiry_support());
     assert_eq!(g2_caps.inquiry_support, InquirySupport::Full);
-    assert!(g2_caps.has_motion_sync);
-    assert_eq!(g2_caps.max_motion_sync_speed, Some(24));
+    assert!(!g2_caps.has_motion_sync);
+    assert_eq!(g2_caps.max_motion_sync_speed, None);
     assert!(!g2_caps.has_nd_filter);
     assert!(!g2_caps.has_iris_control);
 

--- a/tests/camera_profile_tests.rs
+++ b/tests/camera_profile_tests.rs
@@ -107,7 +107,7 @@ fn test_profile_capabilities_are_compile_time() {
         // This function can only accept async cameras with ND filter support
         fn _requires_nd_filter_async<P, T, E>(_camera: &AsyncCamera<P, T, E>) -> bool
         where
-            P: Profile + NdFilter,
+            P: Profile + HasNdFilter,
             T: AsyncTransport + Send + Sync + 'static,
             E: Executor + Send + Sync + 'static,
         {
@@ -132,7 +132,7 @@ fn test_profile_capabilities_are_compile_time() {
         // This function can only accept blocking cameras with ND filter support
         fn _requires_nd_filter_blocking<P, T>(_camera: &BlockingCamera<P, T>) -> bool
         where
-            P: Profile + NdFilter,
+            P: Profile + HasNdFilter,
             T: BlockingTransport + Send + Sync + 'static,
         {
             // At compile time, we know this camera supports ND filter
@@ -151,8 +151,8 @@ fn test_profile_capabilities_are_compile_time() {
     }
 
     // These demonstrate compile-time checking:
-    // - SonyFR7 has NdFilter, so it can use requires_nd_filter
-    // - GenericVisca doesn't have NdFilter, so it cannot
+    // - SonyFR7 has typed ND filter support, so it can use requires_nd_filter
+    // - GenericVisca doesn't have typed ND filter support, so it cannot
     // - Both can use requires_only_basic
 }
 
@@ -197,22 +197,22 @@ fn test_profile_traits_composition() {
 #[test]
 fn test_optional_capabilities() {
     // Test which profiles have optional capabilities
-    fn has_nd_filter<T: NdFilter>() {}
-    fn has_motion_sync<T: MotionSync>() {}
-    fn has_variable_speed<T: VariableSpeed>() {}
+    fn has_nd_filter<T: HasNdFilter>() {}
+    fn has_variable_speed<T: HasVariableSpeed>() {}
 
     // These compile:
     has_nd_filter::<grafton_visca::camera::profiles::SonyFR7>();
-    has_motion_sync::<grafton_visca::camera::profiles::PtzOpticsG2>();
-    // Note: SonyFR7 doesn't have MotionSync in the current implementation
+    // Note: SonyFR7 doesn't have typed Motion Sync support.
     has_variable_speed::<grafton_visca::camera::profiles::SonyFR7>();
 
     // These would NOT compile (commented out to keep test passing):
     // has_nd_filter::<grafton_visca::camera::profiles::PtzOpticsG2>();
     // has_nd_filter::<grafton_visca::camera::profiles::GenericVisca>();
-    // has_motion_sync::<grafton_visca::camera::profiles::GenericVisca>();
     // has_variable_speed::<grafton_visca::camera::profiles::PtzOpticsG2>();
     // has_variable_speed::<grafton_visca::camera::profiles::GenericVisca>();
+    //
+    // The API contract compile-fail fixtures cover unsupported Motion Sync
+    // markers for built-in PTZOptics profiles, GenericVisca, and SonyFR7.
 }
 
 #[test]

--- a/tests/common/compile_fail.rs
+++ b/tests/common/compile_fail.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-const EXPECTED_INACCESSIBLE_ERROR_CODES: &[&str] = &["E0432", "E0433", "E0599", "E0603"];
+const EXPECTED_INACCESSIBLE_ERROR_CODES: &[&str] = &["E0277", "E0432", "E0433", "E0599", "E0603"];
 
 pub fn active_grafton_visca_features() -> Vec<&'static str> {
     let mut features = Vec::new();

--- a/tests/compile_time_safety_test.rs
+++ b/tests/compile_time_safety_test.rs
@@ -55,7 +55,7 @@ fn test_sony_fr7_has_nd_filter() -> Result<(), Error> {
 fn test_compile_time_capability_checking() {
     fn adjust_nd_filter<P, T>(_camera: &grafton_visca::BlockingCamera<P, T>) -> Result<(), Error>
     where
-        P: Profile + NdFilter,
+        P: Profile + HasNdFilter,
         T: grafton_visca::transport::BlockingTransport + Send + Sync + 'static,
     {
         Ok(())
@@ -88,15 +88,6 @@ fn test_generic_functions_with_trait_bounds() {
         Ok(())
     }
 
-    fn motion_sync_control<P>(
-        _camera: &grafton_visca::BlockingCamera<P, ScriptedBlockingTransport>,
-    ) -> Result<(), Error>
-    where
-        P: Profile + MotionSync + Default,
-    {
-        Ok(())
-    }
-
     let g2_transport = ScriptedBlockingTransport::new(vec![
         helpers::auto_respond_step(),
         helpers::auto_respond_step(),
@@ -108,9 +99,6 @@ fn test_generic_functions_with_trait_bounds() {
         (),
     >::new_blocking(g2_transport)
     .unwrap();
-
-    let g2_transport_wrapper = ScriptedBlockingTransport::new(vec![helpers::auto_respond_step()]);
-    let g2_wrapper = PtzOpticsG2Cam::new(g2_transport_wrapper).unwrap();
 
     let fr7_transport = ScriptedBlockingTransport::new(vec![
         helpers::sony_auto_respond_step(),
@@ -142,6 +130,4 @@ fn test_generic_functions_with_trait_bounds() {
     assert!(fr7_result.is_ok());
 
     assert!(basic_control(&mut generic_camera).is_ok());
-
-    assert!(motion_sync_control(&g2_wrapper).is_ok());
 }

--- a/tests/feature_detection_tests.rs
+++ b/tests/feature_detection_tests.rs
@@ -10,7 +10,7 @@ use grafton_visca::{camera::AsyncCamera, transport::AsyncTransport, Executor};
 use grafton_visca::{transport::BlockingTransportHandle, BlockingClient};
 
 use grafton_visca::{
-    capabilities::{MotionSync, NdFilter, Profile, VariableSpeed},
+    capabilities::{HasMotionSync, HasNdFilter, HasVariableSpeed, Profile},
     NdFilterPosition,
 };
 
@@ -22,12 +22,12 @@ fn test_nd_filter_compile_time_safety() {
     #[cfg(feature = "mode-async")]
     fn _set_nd_filter_async<P, T, E>(_camera: &AsyncCamera<P, T, E>, _position: NdFilterPosition)
     where
-        P: Profile + NdFilter,
+        P: Profile + HasNdFilter,
         T: AsyncTransport + Send + Sync + 'static,
         E: Executor,
     {
         // This function can only be called with cameras that have ND filter
-        // The trait bound P: NdFilter enforces this at compile time
+        // The trait bound P: HasNdFilter enforces this at compile time
     }
 
     // Blocking version - functions that require ND filter support
@@ -36,10 +36,10 @@ fn test_nd_filter_compile_time_safety() {
         _camera: &BlockingClient<P, BlockingTransportHandle>,
         _position: NdFilterPosition,
     ) where
-        P: Profile + NdFilter,
+        P: Profile + HasNdFilter,
     {
         // This function can only be called with cameras that have ND filter
-        // The trait bound P: NdFilter enforces this at compile time
+        // The trait bound P: HasNdFilter enforces this at compile time
     }
 
     // Test passes if compilation succeeds
@@ -53,11 +53,11 @@ fn test_motion_sync_compile_time_safety() {
         _camera: &AsyncCamera<P, T, E>,
         _mode: grafton_visca::command::MotionSyncMode,
     ) where
-        P: Profile + MotionSync,
+        P: Profile + HasMotionSync,
         T: AsyncTransport + Send + Sync + 'static,
         E: Executor,
     {
-        // Only cameras with MotionSync can compile this function
+        // Only cameras with typed Motion Sync support can compile this function
     }
 
     // Blocking version - functions that require motion sync support
@@ -66,9 +66,9 @@ fn test_motion_sync_compile_time_safety() {
         _camera: &BlockingClient<P, BlockingTransportHandle>,
         _mode: grafton_visca::command::MotionSyncMode,
     ) where
-        P: Profile + MotionSync,
+        P: Profile + HasMotionSync,
     {
-        // Only cameras with MotionSync can compile this function
+        // Only cameras with typed Motion Sync support can compile this function
     }
 
     // Test passes if compilation succeeds
@@ -82,11 +82,11 @@ fn test_variable_speed_compile_time_safety() {
         _camera: &AsyncCamera<P, T, E>,
         _mode: grafton_visca::command::VariableSpeedMode,
     ) where
-        P: Profile + VariableSpeed,
+        P: Profile + HasVariableSpeed,
         T: AsyncTransport + Send + Sync + 'static,
         E: Executor,
     {
-        // Only cameras with VariableSpeed can compile this function
+        // Only cameras with typed variable speed support can compile this function
     }
 
     // Blocking version - functions that require variable speed support
@@ -95,9 +95,9 @@ fn test_variable_speed_compile_time_safety() {
         _camera: &BlockingClient<P, BlockingTransportHandle>,
         _mode: grafton_visca::command::VariableSpeedMode,
     ) where
-        P: Profile + VariableSpeed,
+        P: Profile + HasVariableSpeed,
     {
-        // Only cameras with VariableSpeed can compile this function
+        // Only cameras with typed variable speed support can compile this function
     }
 
     // Test passes if compilation succeeds
@@ -139,36 +139,24 @@ fn test_basic_features_available_to_all() {
 
 #[test]
 fn test_profile_specific_compile_time_checks() {
-    use grafton_visca::camera::profiles::{GenericVisca, PtzOpticsG2, SonyFR7};
+    use grafton_visca::camera::profiles::{GenericVisca, SonyFR7};
 
     // Functions that demonstrate profile-specific capabilities
 
     #[cfg(feature = "mode-async")]
     {
-        // SonyFR7 has NdFilter and VariableSpeed
+        // SonyFR7 has typed ND filter and variable speed support
         fn _sony_fr7_features_async<T, E>(_camera: &AsyncCamera<SonyFR7, T, E>)
         where
             T: AsyncTransport + Send + Sync + 'static,
             E: Executor,
         {
-            // This compiles because SonyFR7 implements NdFilter and VariableSpeed
-            fn requires_nd<P: NdFilter>() {}
-            fn requires_var_speed<P: VariableSpeed>() {}
+            // This compiles because SonyFR7 implements the support markers.
+            fn requires_nd<P: HasNdFilter>() {}
+            fn requires_var_speed<P: HasVariableSpeed>() {}
 
             requires_nd::<SonyFR7>();
             requires_var_speed::<SonyFR7>();
-        }
-
-        // PtzOpticsG2 has MotionSync
-        fn _ptzoptics_g2_features_async<T, E>(_camera: &AsyncCamera<PtzOpticsG2, T, E>)
-        where
-            T: AsyncTransport + Send + Sync + 'static,
-            E: Executor,
-        {
-            // This compiles because PtzOpticsG2 implements MotionSync
-            fn requires_motion_sync<P: MotionSync>() {}
-
-            requires_motion_sync::<PtzOpticsG2>();
         }
 
         // GenericVisca only has basic features
@@ -177,7 +165,7 @@ fn test_profile_specific_compile_time_checks() {
             T: AsyncTransport + Send + Sync + 'static,
             E: Executor,
         {
-            // GenericVisca doesn't have NdFilter, MotionSync, or VariableSpeed
+            // GenericVisca doesn't have typed optional vendor feature support.
             // So we can only use basic Profile features
             fn requires_profile<P: Profile>() {}
 
@@ -189,19 +177,11 @@ fn test_profile_specific_compile_time_checks() {
     {
         // Same checks for blocking mode
         fn _sony_fr7_features_blocking(_camera: &BlockingClient<SonyFR7, BlockingTransportHandle>) {
-            fn requires_nd<P: NdFilter>() {}
-            fn requires_var_speed<P: VariableSpeed>() {}
+            fn requires_nd<P: HasNdFilter>() {}
+            fn requires_var_speed<P: HasVariableSpeed>() {}
 
             requires_nd::<SonyFR7>();
             requires_var_speed::<SonyFR7>();
-        }
-
-        fn _ptzoptics_g2_features_blocking(
-            _camera: &BlockingClient<PtzOpticsG2, BlockingTransportHandle>,
-        ) {
-            fn requires_motion_sync<P: MotionSync>() {}
-
-            requires_motion_sync::<PtzOpticsG2>();
         }
 
         fn _generic_visca_features_blocking(

--- a/tests/simple_compile_test.rs
+++ b/tests/simple_compile_test.rs
@@ -1,6 +1,6 @@
 //! Simple test to verify compilation succeeds with generic Camera implementation.
 
-use grafton_visca::capabilities::{NdFilter, Profile};
+use grafton_visca::capabilities::{HasNdFilter, Profile};
 
 #[cfg(feature = "mode-async")]
 use grafton_visca::{
@@ -36,7 +36,7 @@ fn test_compile_time_safety() {
     #[cfg(feature = "mode-async")]
     fn _use_nd_filter_async<P, T, E>(_camera: &AsyncCamera<P, T, E>)
     where
-        P: Profile + NdFilter,
+        P: Profile + HasNdFilter,
         T: AsyncTransport + Send + Sync + 'static,
         E: grafton_visca::Executor,
     {
@@ -45,7 +45,7 @@ fn test_compile_time_safety() {
     #[cfg(not(feature = "mode-async"))]
     fn _use_nd_filter_blocking<P, T>(_camera: &BlockingClient<P, T>)
     where
-        P: Profile + NdFilter,
+        P: Profile + HasNdFilter,
     {
     }
 


### PR DESCRIPTION
## Summary

- Splits optional vendor capability traits into runtime metadata traits (`NdFilterMetadata`, `MotionSyncMetadata`, `VariableSpeedMetadata`) and explicit typed API support markers (`HasNdFilter`, `HasMotionSync`, `HasVariableSpeed`).
- Removes the blanket `impl<T: ProfileMetadata + Trait> Has* for T` implementations so support markers must be opted into per profile. Typed controls, accessors, direct convenience methods, and feature-specific inquiries (`NdFilterInquiryControl`, motion sync via `MotionSyncControl`) are now gated on these markers.
- Built-in support follows source documents: `SonyFR7` exposes ND filter + variable speed typed controls; PTZOptics G2/G3/30X and `GenericVisca` remain unmarked. ND filter inquiries split off from the broad `InquiryControl` trait.
- Adds compile-fail fixtures proving unsupported profiles cannot reach typed accessors / direct methods / inquiries, plus pass fixtures for `SonyFR7` typed surfaces and `MotionSync` over generic profiles.

## Deviation from the issue's literal support matrix

The acceptance criteria says PTZOptics G2/G3/30X should satisfy `HasMotionSync`. The PR does **not** mark them. The issue explicitly permits adjusting the matrix when the source evidence does not establish support, and the change:

- Adds a new "Capability boundaries" section to `docs/PTZOptics-NDI-HX-Gen2-Specs.md` stating the manual/datasheet capability tables do not list PTZ Motion Sync.
- Updates `docs/visca_unified_reference.md`, `CHANGELOG.md`, and `README.md` to call this out (and marks the command-list opcode as `No*`).
- Adds compile-fail fixtures (`unsupported_optional_support_markers.rs`, `ptzoptics_motion_sync_*_removed.rs`) that lock the conservative stance into the contract.

Raw / custom command escape hatches remain available for downstream users who do have Motion Sync working on a specific firmware.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo test --no-default-features` and per-feature variants
- [x] `bash .github/scripts/test-all-features.sh` (full declared 1.0 matrix)
- [x] `cargo build --release --all-features` and `cargo build --release --examples --all-features`