### PR TITLE
Replace exclusive profile ranges with inclusive capability ranges

### DIFF
--- a/examples/type_safe_commands.rs
+++ b/examples/type_safe_commands.rs
@@ -55,13 +55,13 @@ where
     println!("  Inquiry support: {:?}", P::INQUIRY_SUPPORT);
     println!(
         "  Pan range: {}..{} VISCA units",
-        P::PAN_RANGE.start,
-        P::PAN_RANGE.end - 1
+        P::PAN_RANGE.min(),
+        P::PAN_RANGE.max()
     );
     println!(
         "  Tilt range: {}..{} VISCA units",
-        P::TILT_RANGE.start,
-        P::TILT_RANGE.end - 1
+        P::TILT_RANGE.min(),
+        P::TILT_RANGE.max()
     );
     println!("  Optical zoom max: 0x{:04X}", P::OPTICAL_ZOOM_MAX);
     println!("  Digital zoom max: {:?}", P::DIGITAL_ZOOM_MAX);

--- a/src/camera/controls/color.rs
+++ b/src/camera/controls/color.rs
@@ -17,6 +17,7 @@
 
 use crate::{
     camera::ViscaClient,
+    capabilities::white_balance::WhiteBalanceExt,
     command::color::{
         BlueGain, BlueTuningCommand, ColorTemperature, OnePushTriggerCommand, RedGain,
         RedTuningCommand,
@@ -195,6 +196,10 @@ where
     }
 
     fn set_color_temperature(&self, temp: ColorTemp) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_color_temp(temp.to_kelvin()) {
+            return self.error(err.into());
+        }
+
         self.execute(ColorTemperature::SetTemperature(temp))
     }
 
@@ -221,6 +226,10 @@ where
     type Mode = M;
 
     fn set_red_gain(&self, gain: RedChannel) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_red_gain(gain.value()) {
+            return self.error(err.into());
+        }
+
         self.execute(RedGain::SetValue(gain))
     }
 
@@ -229,6 +238,10 @@ where
     }
 
     fn set_blue_gain(&self, gain: BlueChannel) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_blue_gain(gain.value()) {
+            return self.error(err.into());
+        }
+
         self.execute(BlueGain::SetValue(gain))
     }
 
@@ -247,10 +260,18 @@ where
     type Mode = M;
 
     fn set_red_tuning(&self, tuning: RedTuning) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_rg_tuning(tuning.value()) {
+            return self.error(err.into());
+        }
+
         self.execute(RedTuningCommand::new(tuning))
     }
 
     fn set_blue_tuning(&self, tuning: BlueTuning) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_bg_tuning(tuning.value()) {
+            return self.error(err.into());
+        }
+
         self.execute(BlueTuningCommand::new(tuning))
     }
 }

--- a/src/camera/controls/exposure.rs
+++ b/src/camera/controls/exposure.rs
@@ -14,7 +14,7 @@
 //! The implementation uses the Mode trait to provide both blocking and async APIs
 //! from a single unified codebase.
 
-use crate::{camera::ViscaClient, mode::Mode, Error};
+use crate::{camera::ViscaClient, capabilities::exposure::ExposureExt, mode::Mode, Error};
 
 fn exposure_mode_feature(mode: crate::command::exposure::ExposureMode) -> &'static str {
     match mode {
@@ -384,6 +384,10 @@ where
     }
 
     fn set_gain(&self, gain: crate::types::GainLevel) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_gain(gain.value()) {
+            return self.error(err.into());
+        }
+
         let cmd = crate::command::gain::Gain::SetValue(gain);
         self.execute(cmd)
     }
@@ -483,6 +487,10 @@ where
         &self,
         level: crate::types::BrightnessLevel,
     ) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_brightness(level.value()) {
+            return self.error(err.into());
+        }
+
         let cmd = crate::command::exposure::Brightness::SetLevel(level);
         self.execute(cmd)
     }
@@ -506,6 +514,10 @@ where
         &self,
         level: crate::types::BrightnessLevel,
     ) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_brightness(level.value()) {
+            return self.error(err.into());
+        }
+
         let cmd = crate::command::exposure::Brightness::Direct(level);
         self.execute(cmd)
     }
@@ -531,6 +543,10 @@ where
     }
 
     fn set_iris(&self, level: crate::types::IrisLevel) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_iris(u16::from(level.value())) {
+            return self.error(err.into());
+        }
+
         let cmd = crate::command::exposure::Iris::SetAperture(level);
         self.execute(cmd)
     }
@@ -696,6 +712,10 @@ where
     }
 
     fn set_exposure_compensation_level(&self, level: i8) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_exposure_comp(level) {
+            return self.error(err.into());
+        }
+
         match crate::types::ExposureCompensationLevel::try_from(level) {
             Ok(comp_level) => {
                 let cmd = crate::command::exposure::ExposureCompensation::SetLevel(comp_level);

--- a/src/camera/controls/focus.rs
+++ b/src/camera/controls/focus.rs
@@ -297,7 +297,7 @@ where
         let cmd = if focus_speed_val == 0 {
             Focus::Near
         } else {
-            match FocusSpeed::new(focus_speed_val.min(7)) {
+            match FocusSpeed::new(focus_speed_val.min(P::MAX_FOCUS_SPEED)) {
                 Ok(focus_speed) => Focus::NearWithSpeed(focus_speed),
                 Err(e) => return self.error(e),
             }
@@ -310,7 +310,7 @@ where
         let cmd = if focus_speed_val == 0 {
             Focus::Far
         } else {
-            match FocusSpeed::new(focus_speed_val.min(7)) {
+            match FocusSpeed::new(focus_speed_val.min(P::MAX_FOCUS_SPEED)) {
                 Ok(focus_speed) => Focus::FarWithSpeed(focus_speed),
                 Err(e) => return self.error(e),
             }

--- a/src/camera/controls/image_processing.rs
+++ b/src/camera/controls/image_processing.rs
@@ -16,7 +16,7 @@
 
 use crate::{
     camera::ViscaClient,
-    capabilities::ImageProcessing as ImageProcessingCap,
+    capabilities::{image_processing::ImageProcessingExt, ImageProcessing as ImageProcessingCap},
     command::{ImageFlipMode, PictureEffectMode},
     mode::Mode,
     types::{
@@ -372,6 +372,10 @@ where
     type Mode = M;
 
     fn set_contrast(&self, level: ContrastLevel) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_contrast(level.value()) {
+            return self.error(err.into());
+        }
+
         let cmd = crate::command::image::Contrast::new(level);
         self.execute(cmd)
     }
@@ -390,6 +394,10 @@ where
     type Mode = M;
 
     fn set_sharpness(&self, level: SharpnessLevel) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_sharpness(level.value()) {
+            return self.error(err.into());
+        }
+
         let cmd = crate::command::image::Sharpness::SetLevel {
             value: level.value(),
         };
@@ -451,6 +459,10 @@ where
     type Mode = M;
 
     fn set_saturation(&self, level: SaturationLevel) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_saturation(level.value()) {
+            return self.error(err.into());
+        }
+
         let cmd = crate::command::color::SaturationCommand::new(level);
         self.execute(cmd)
     }
@@ -469,6 +481,10 @@ where
     type Mode = M;
 
     fn set_hue(&self, level: HueLevel) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_hue(level.value()) {
+            return self.error(err.into());
+        }
+
         let cmd = crate::command::color::HueCommand::new(level);
         self.execute(cmd)
     }
@@ -487,6 +503,10 @@ where
     type Mode = M;
 
     fn set_luminance(&self, level: LuminanceLevel) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_luminance(level.value()) {
+            return self.error(err.into());
+        }
+
         let cmd = crate::command::image::Luminance::new(level);
         self.execute(cmd)
     }
@@ -505,6 +525,10 @@ where
     type Mode = M;
 
     fn set_gamma(&self, level: GammaLevel) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_gamma(level.value()) {
+            return self.error(err.into());
+        }
+
         let cmd = crate::command::image::GammaCommand::new(level);
         self.execute(cmd)
     }

--- a/src/camera/controls/pan_tilt.rs
+++ b/src/camera/controls/pan_tilt.rs
@@ -12,6 +12,7 @@
 
 use crate::{
     camera::ViscaClient,
+    capabilities::ValidationError,
     command::{pan_tilt::PanTilt as PanTiltCommand, PanTiltDirection, PanTiltLimitCorner},
     mode::Mode,
     types::{PanPosition, PanSpeed, SpeedLevel, TiltPosition, TiltSpeed},
@@ -174,15 +175,80 @@ where
     let pan_pos = PanPosition::from_degrees(pan_deg.0)?;
     let tilt_pos = TiltPosition::from_degrees(tilt_deg.0)?;
 
+    validate_pan_position::<P>(pan_pos.value())?;
+    validate_tilt_position::<P>(tilt_pos.value())?;
+
     let (pan_u16, tilt_u16) =
         P::COORDINATE_SYSTEM.to_camera_coords(pan_pos.value(), tilt_pos.value());
 
-    Ok((
-        pan_u16,
-        tilt_u16,
-        PanSpeed::from(speed),
-        TiltSpeed::from(speed),
-    ))
+    let pan_speed = PanSpeed::from(speed);
+    let tilt_speed = TiltSpeed::from(speed);
+    validate_pan_tilt_speed::<P>(pan_speed, tilt_speed)?;
+
+    Ok((pan_u16, tilt_u16, pan_speed, tilt_speed))
+}
+
+fn validate_pan_position<P>(pan: i16) -> Result<(), Error>
+where
+    P: crate::capabilities::PanTilt,
+{
+    if P::PAN_RANGE.contains(pan) {
+        Ok(())
+    } else {
+        Err(ValidationError::OutOfRange {
+            parameter: "pan",
+            value: f64::from(pan),
+            min: f64::from(P::PAN_RANGE.min()),
+            max: f64::from(P::PAN_RANGE.max()),
+        }
+        .into())
+    }
+}
+
+fn validate_tilt_position<P>(tilt: i16) -> Result<(), Error>
+where
+    P: crate::capabilities::PanTilt,
+{
+    if P::TILT_RANGE.contains(tilt) {
+        Ok(())
+    } else {
+        Err(ValidationError::OutOfRange {
+            parameter: "tilt",
+            value: f64::from(tilt),
+            min: f64::from(P::TILT_RANGE.min()),
+            max: f64::from(P::TILT_RANGE.max()),
+        }
+        .into())
+    }
+}
+
+fn validate_pan_tilt_speed<P>(pan_speed: PanSpeed, tilt_speed: TiltSpeed) -> Result<(), Error>
+where
+    P: crate::capabilities::PanTilt,
+{
+    let pan_speed = pan_speed.value();
+    if !(1..=P::MAX_PAN_SPEED).contains(&pan_speed) {
+        return Err(ValidationError::OutOfRange {
+            parameter: "pan speed",
+            value: f64::from(pan_speed),
+            min: 1.0,
+            max: f64::from(P::MAX_PAN_SPEED),
+        }
+        .into());
+    }
+
+    let tilt_speed = tilt_speed.value();
+    if !(1..=P::MAX_TILT_SPEED).contains(&tilt_speed) {
+        return Err(ValidationError::OutOfRange {
+            parameter: "tilt speed",
+            value: f64::from(tilt_speed),
+            min: 1.0,
+            max: f64::from(P::MAX_TILT_SPEED),
+        }
+        .into());
+    }
+
+    Ok(())
 }
 
 fn pan_tilt_absolute_command<P>(
@@ -276,6 +342,10 @@ where
         pan_speed: PanSpeed,
         tilt_speed: TiltSpeed,
     ) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = validate_pan_tilt_speed::<P>(pan_speed, tilt_speed) {
+            return self.error(err);
+        }
+
         let cmd = PanTiltCommand::Move {
             direction,
             pan_speed,
@@ -294,6 +364,12 @@ where
         pan: PanPosition,
         tilt: TiltPosition,
     ) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = validate_pan_position::<P>(pan.value())
+            .and_then(|()| validate_tilt_position::<P>(tilt.value()))
+        {
+            return self.error(err);
+        }
+
         // Convert logical positions to camera coordinates using profile's coordinate system
         let (pan_u16, tilt_u16) = P::COORDINATE_SYSTEM.to_camera_coords(pan.value(), tilt.value());
 

--- a/src/camera/controls/presets.rs
+++ b/src/camera/controls/presets.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     camera::ViscaClient,
-    capabilities::presets::Presets,
+    capabilities::presets::{Presets, PresetsExt},
     command::preset::{PresetAction, PresetCommand, PresetNumber},
     mode::Mode,
     Error,
@@ -201,6 +201,10 @@ where
         &self,
         speed: crate::command::preset::PresetRecallSpeed,
     ) -> M::Fut<'_, Result<(), Error>> {
+        if let Err(err) = P::default().validate_preset_speed(speed.value()) {
+            return self.error(err.into());
+        }
+
         let cmd = crate::command::preset::PresetRecallSpeedCommand { speed };
         self.execute(cmd)
     }

--- a/src/camera/controls/zoom.rs
+++ b/src/camera/controls/zoom.rs
@@ -185,17 +185,46 @@ pub trait DigitalZoomRangeControl {
     ) -> <Self::Mode as Mode>::Fut<'_, Result<(), Error>>;
 }
 
-fn zoom_tele_command(speed: Option<ZoomSpeed>) -> ZoomCommand {
-    match speed {
-        None => ZoomCommand::TeleStd,
-        Some(speed) => ZoomCommand::TeleVariable(speed),
+fn validate_zoom_speed<P>(speed: ZoomSpeed) -> Result<(), Error>
+where
+    P: crate::capabilities::zoom::Zoom,
+{
+    if P::ZOOM_SPEED_RANGE.contains(speed.value()) {
+        Ok(())
+    } else {
+        Err(crate::capabilities::ValidationError::OutOfRange {
+            parameter: "zoom speed",
+            value: f64::from(speed.value()),
+            min: f64::from(P::ZOOM_SPEED_RANGE.min()),
+            max: f64::from(P::ZOOM_SPEED_RANGE.max()),
+        }
+        .into())
     }
 }
 
-fn zoom_wide_command(speed: Option<ZoomSpeed>) -> ZoomCommand {
+fn zoom_tele_command<P>(speed: Option<ZoomSpeed>) -> Result<ZoomCommand, Error>
+where
+    P: crate::capabilities::zoom::Zoom,
+{
     match speed {
-        None => ZoomCommand::WideStd,
-        Some(speed) => ZoomCommand::WideVariable(speed),
+        None => Ok(ZoomCommand::TeleStd),
+        Some(speed) => {
+            validate_zoom_speed::<P>(speed)?;
+            Ok(ZoomCommand::TeleVariable(speed))
+        }
+    }
+}
+
+fn zoom_wide_command<P>(speed: Option<ZoomSpeed>) -> Result<ZoomCommand, Error>
+where
+    P: crate::capabilities::zoom::Zoom,
+{
+    match speed {
+        None => Ok(ZoomCommand::WideStd),
+        Some(speed) => {
+            validate_zoom_speed::<P>(speed)?;
+            Ok(ZoomCommand::WideVariable(speed))
+        }
     }
 }
 
@@ -255,11 +284,17 @@ where
     }
 
     fn zoom_tele(&self, speed: Option<ZoomSpeed>) -> M::Fut<'_, Result<(), Error>> {
-        self.execute(zoom_tele_command(speed))
+        match zoom_tele_command::<P>(speed) {
+            Ok(command) => self.execute(command),
+            Err(err) => self.error(err),
+        }
     }
 
     fn zoom_wide(&self, speed: Option<ZoomSpeed>) -> M::Fut<'_, Result<(), Error>> {
-        self.execute(zoom_wide_command(speed))
+        match zoom_wide_command::<P>(speed) {
+            Ok(command) => self.execute(command),
+            Err(err) => self.error(err),
+        }
     }
 }
 
@@ -360,7 +395,8 @@ where
         &self,
         speed: Option<ZoomSpeed>,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::ZoomOperation, P, Exec>, Error> {
-        self.start_zoom_operation(zoom_tele_command(speed)).await
+        self.start_zoom_operation(zoom_tele_command::<P>(speed)?)
+            .await
     }
 
     /// Start zooming out and return an operation handle.
@@ -369,7 +405,8 @@ where
         &self,
         speed: Option<ZoomSpeed>,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::ZoomOperation, P, Exec>, Error> {
-        self.start_zoom_operation(zoom_wide_command(speed)).await
+        self.start_zoom_operation(zoom_wide_command::<P>(speed)?)
+            .await
     }
 }
 

--- a/src/camera/profile_registry.rs
+++ b/src/camera/profile_registry.rs
@@ -71,6 +71,12 @@ macro_rules! __transport_is_supported {
     };
 }
 
+macro_rules! range {
+    ($ty:ty, $min:expr, $max:expr) => {
+        $crate::capabilities::CapabilityRange::<$ty>::new($min, $max)
+    };
+}
+
 macro_rules! __transport_default_port {
     (none) => {
         None
@@ -478,8 +484,8 @@ macro_rules! __define_builtin_profiles {
             }
 
             impl $crate::capabilities::PanTilt for $profile {
-                const PAN_RANGE: std::ops::Range<i16> = $pan_range;
-                const TILT_RANGE: std::ops::Range<i16> = $tilt_range;
+                const PAN_RANGE: $crate::capabilities::CapabilityRange<i16> = $pan_range;
+                const TILT_RANGE: $crate::capabilities::CapabilityRange<i16> = $tilt_range;
                 const MAX_PAN_SPEED: u8 = $max_pan_speed;
                 const MAX_TILT_SPEED: u8 = $max_tilt_speed;
                 const PAN_TILT_SIMULTANEOUS: bool = $pan_tilt_simultaneous;
@@ -493,7 +499,7 @@ macro_rules! __define_builtin_profiles {
             impl $crate::capabilities::Zoom for $profile {
                 const OPTICAL_ZOOM_MAX: u16 = $optical_zoom_max;
                 const DIGITAL_ZOOM_MAX: Option<u16> = $digital_zoom_max;
-                const ZOOM_SPEED_RANGE: std::ops::Range<u8> = $zoom_speed_range;
+                const ZOOM_SPEED_RANGE: $crate::capabilities::CapabilityRange<u8> = $zoom_speed_range;
                 const SUPPORTS_DIRECT_ZOOM: bool = $supports_direct_zoom;
                 const SUPPORTS_VARIABLE_ZOOM: bool = $supports_variable_zoom;
                 const ZOOM_MAGNIFICATION_TO_UNITS: f32 = $zoom_magnification_to_units;
@@ -514,52 +520,52 @@ macro_rules! __define_builtin_profiles {
             impl $crate::capabilities::Exposure for $profile {
                 const EXPOSURE_MODES: &'static [$crate::command::exposure::ExposureMode] =
                     $exposure_modes;
-                const IRIS_RANGE: Option<std::ops::Range<u16>> = $iris_range;
+                const IRIS_RANGE: Option<$crate::capabilities::CapabilityRange<u16>> = $iris_range;
                 const SHUTTER_SPEEDS: &'static [$crate::capabilities::ShutterSpeed] =
                     $shutter_speeds;
-                const GAIN_RANGE: std::ops::Range<u8> = $gain_range;
-                const BRIGHTNESS_RANGE: Option<std::ops::Range<u16>> = $brightness_range;
+                const GAIN_RANGE: $crate::capabilities::CapabilityRange<u8> = $gain_range;
+                const BRIGHTNESS_RANGE: Option<$crate::capabilities::CapabilityRange<u16>> = $brightness_range;
                 const SUPPORTS_BACKLIGHT_COMP: bool = $supports_backlight_comp;
                 const SUPPORTS_EXPOSURE_COMP: bool = $supports_exposure_comp;
-                const EXPOSURE_COMP_RANGE: std::ops::Range<i8> = $exposure_comp_range;
+                const EXPOSURE_COMP_RANGE: $crate::capabilities::CapabilityRange<i8> = $exposure_comp_range;
                 const SUPPORTS_WDR: bool = $supports_wdr;
             }
 
             impl $crate::capabilities::WhiteBalance for $profile {
                 const WB_MODES: &'static [$crate::WhiteBalanceMode] = $wb_modes;
                 const SUPPORTS_ONE_PUSH_WB: bool = $supports_one_push_wb;
-                const RG_TUNING_RANGE: Option<std::ops::Range<i8>> = $rg_tuning_range;
-                const BG_TUNING_RANGE: Option<std::ops::Range<i8>> = $bg_tuning_range;
+                const RG_TUNING_RANGE: Option<$crate::capabilities::CapabilityRange<i8>> = $rg_tuning_range;
+                const BG_TUNING_RANGE: Option<$crate::capabilities::CapabilityRange<i8>> = $bg_tuning_range;
                 const SUPPORTS_COLOR_TEMP: bool = $supports_color_temp;
-                const COLOR_TEMP_RANGE: Option<std::ops::Range<u16>> = $color_temp_range;
+                const COLOR_TEMP_RANGE: Option<$crate::capabilities::CapabilityRange<u16>> = $color_temp_range;
                 const SUPPORTS_RGB_GAIN: bool = $supports_rgb_gain;
-                const RED_GAIN_RANGE: Option<std::ops::Range<u8>> = $red_gain_range;
-                const BLUE_GAIN_RANGE: Option<std::ops::Range<u8>> = $blue_gain_range;
+                const RED_GAIN_RANGE: Option<$crate::capabilities::CapabilityRange<u8>> = $red_gain_range;
+                const BLUE_GAIN_RANGE: Option<$crate::capabilities::CapabilityRange<u8>> = $blue_gain_range;
             }
 
             impl $crate::capabilities::ImageProcessing for $profile {
-                const CONTRAST_RANGE: Option<std::ops::Range<u8>> = $contrast_range;
-                const SHARPNESS_RANGE: Option<std::ops::Range<u8>> = $sharpness_range;
-                const SATURATION_RANGE: Option<std::ops::Range<u8>> = $saturation_range;
+                const CONTRAST_RANGE: Option<$crate::capabilities::CapabilityRange<u8>> = $contrast_range;
+                const SHARPNESS_RANGE: Option<$crate::capabilities::CapabilityRange<u8>> = $sharpness_range;
+                const SATURATION_RANGE: Option<$crate::capabilities::CapabilityRange<u8>> = $saturation_range;
                 const SUPPORTS_FLIP: bool = $supports_flip;
                 const SUPPORTS_MIRROR: bool = $supports_mirror;
                 const SUPPORTS_HUE: bool = $supports_hue;
-                const HUE_RANGE: Option<std::ops::Range<u8>> = $hue_range;
+                const HUE_RANGE: Option<$crate::capabilities::CapabilityRange<u8>> = $hue_range;
                 const SUPPORTS_NOISE_REDUCTION: bool = $supports_noise_reduction;
                 const SUPPORTS_2D_NR: bool = $supports_2d_nr;
                 const SUPPORTS_3D_NR: bool = $supports_3d_nr;
                 const SUPPORTS_LUMINANCE: bool = $supports_luminance;
                 const SUPPORTS_PICTURE_EFFECT: bool = $supports_picture_effect;
-                const LUMINANCE_RANGE: Option<std::ops::Range<u8>> = $luminance_range;
+                const LUMINANCE_RANGE: Option<$crate::capabilities::CapabilityRange<u8>> = $luminance_range;
                 const USES_COMBINED_FLIP_COMMAND: bool = $uses_combined_flip_command;
                 const REQUIRES_SETTINGS_SAVE_FOR_FLIP: bool = $requires_settings_save_for_flip;
                 const SUPPORTS_GAMMA: bool = $supports_gamma;
-                const GAMMA_RANGE: Option<std::ops::Range<u8>> = $gamma_range;
+                const GAMMA_RANGE: Option<$crate::capabilities::CapabilityRange<u8>> = $gamma_range;
             }
 
             impl $crate::capabilities::Presets for $profile {
                 const MAX_PRESETS: u8 = $max_presets;
-                const PRESET_SPEED_RANGE: std::ops::Range<u8> = $preset_speed_range;
+                const PRESET_SPEED_RANGE: $crate::capabilities::CapabilityRange<u8> = $preset_speed_range;
                 const SUPPORTS_PRESET_TOUR: bool = $supports_preset_tour;
                 const PRESET_RECALL_DELAY: std::time::Duration =
                     std::time::Duration::from_millis($preset_recall_delay_ms);
@@ -961,24 +967,93 @@ macro_rules! __define_builtin_profiles {
                     facts.envelope == profile_registry::EnvelopeKind::SonyEncapsulated,
                     id.uses_sony_encapsulation()
                 );
+                assert!(P::PAN_RANGE.min() <= P::PAN_RANGE.max(), "{id:?} pan metadata must be non-empty");
+                assert!(
+                    P::TILT_RANGE.min() <= P::TILT_RANGE.max(),
+                    "{id:?} tilt metadata must be non-empty"
+                );
+                assert!(
+                    P::ZOOM_SPEED_RANGE.min() <= P::ZOOM_SPEED_RANGE.max(),
+                    "{id:?} zoom-speed metadata must be non-empty"
+                );
+                if let Some(range) = P::IRIS_RANGE {
+                    assert!(range.min() <= range.max(), "{id:?} iris metadata must be non-empty");
+                }
+                assert!(
+                    P::GAIN_RANGE.min() <= P::GAIN_RANGE.max(),
+                    "{id:?} gain metadata must be non-empty"
+                );
                 if let Some(range) = P::BRIGHTNESS_RANGE {
                     assert!(
-                        range.start < range.end,
+                        range.min() <= range.max(),
                         "{id:?} exposure brightness metadata must be non-empty"
                     );
                 }
-                if let Some(range) = P::CONTRAST_RANGE {
+                assert!(
+                    P::EXPOSURE_COMP_RANGE.min() <= P::EXPOSURE_COMP_RANGE.max(),
+                    "{id:?} exposure-compensation metadata must be non-empty"
+                );
+                if let Some(range) = P::RG_TUNING_RANGE {
                     assert!(
-                        range.start < range.end,
-                        "{id:?} contrast metadata must be non-empty"
+                        range.min() <= range.max(),
+                        "{id:?} red tuning metadata must be non-empty"
                     );
+                }
+                if let Some(range) = P::BG_TUNING_RANGE {
+                    assert!(
+                        range.min() <= range.max(),
+                        "{id:?} blue tuning metadata must be non-empty"
+                    );
+                }
+                if let Some(range) = P::COLOR_TEMP_RANGE {
+                    assert!(
+                        range.min() <= range.max(),
+                        "{id:?} color-temperature metadata must be non-empty"
+                    );
+                }
+                if let Some(range) = P::RED_GAIN_RANGE {
+                    assert!(
+                        range.min() <= range.max(),
+                        "{id:?} red gain metadata must be non-empty"
+                    );
+                }
+                if let Some(range) = P::BLUE_GAIN_RANGE {
+                    assert!(
+                        range.min() <= range.max(),
+                        "{id:?} blue gain metadata must be non-empty"
+                    );
+                }
+                if let Some(range) = P::CONTRAST_RANGE {
+                    assert!(range.min() <= range.max(), "{id:?} contrast metadata must be non-empty");
                 }
                 if let Some(range) = P::SHARPNESS_RANGE {
                     assert!(
-                        range.start < range.end,
+                        range.min() <= range.max(),
                         "{id:?} sharpness metadata must be non-empty"
                     );
                 }
+                if let Some(range) = P::SATURATION_RANGE {
+                    assert!(
+                        range.min() <= range.max(),
+                        "{id:?} saturation metadata must be non-empty"
+                    );
+                }
+                if let Some(range) = P::HUE_RANGE {
+                    assert!(range.min() <= range.max(), "{id:?} hue metadata must be non-empty");
+                }
+                if let Some(range) = P::LUMINANCE_RANGE {
+                    assert!(
+                        range.min() <= range.max(),
+                        "{id:?} luminance metadata must be non-empty"
+                    );
+                }
+                if let Some(range) = P::GAMMA_RANGE {
+                    assert!(range.min() <= range.max(), "{id:?} gamma metadata must be non-empty");
+                }
+                assert!(
+                    P::PRESET_SPEED_RANGE.min() <= P::PRESET_SPEED_RANGE.max(),
+                    "{id:?} preset-speed metadata must be non-empty"
+                );
                 assert_eq!(
                     facts.has_typed_support($crate::capabilities::TypedSupportSurface::BrightnessControl),
                     P::BRIGHTNESS_RANGE.is_some(),
@@ -1011,8 +1086,8 @@ macro_rules! __define_builtin_profiles {
                 assert_eq!(caps.default_udp_port, id.default_udp_port());
                 assert_eq!(caps.pan_speed, 1..=P::MAX_PAN_SPEED);
                 assert_eq!(caps.tilt_speed, 1..=P::MAX_TILT_SPEED);
-                assert_eq!(caps.pan_range, P::PAN_RANGE.start..=(P::PAN_RANGE.end - 1));
-                assert_eq!(caps.tilt_range, P::TILT_RANGE.start..=(P::TILT_RANGE.end - 1));
+                assert_eq!(caps.pan_range, P::PAN_RANGE.as_inclusive());
+                assert_eq!(caps.tilt_range, P::TILT_RANGE.as_inclusive());
                 assert_eq!(caps.pan_tilt_simultaneous, P::PAN_TILT_SIMULTANEOUS);
                 assert_eq!(caps.has_digital_zoom, P::DIGITAL_ZOOM_MAX.is_some());
                 assert_eq!(caps.zoom_range_optical, 0..=P::OPTICAL_ZOOM_MAX);
@@ -1020,13 +1095,13 @@ macro_rules! __define_builtin_profiles {
                     caps.zoom_range_digital,
                     P::DIGITAL_ZOOM_MAX.map(|max| P::OPTICAL_ZOOM_MAX..=max)
                 );
-                assert_eq!(caps.zoom_speed, P::ZOOM_SPEED_RANGE.start..=(P::ZOOM_SPEED_RANGE.end - 1));
+                assert_eq!(caps.zoom_speed, P::ZOOM_SPEED_RANGE.as_inclusive());
                 assert_eq!(caps.supports_direct_zoom, P::SUPPORTS_DIRECT_ZOOM);
                 assert_eq!(caps.supports_variable_zoom, P::SUPPORTS_VARIABLE_ZOOM);
                 assert_eq!(caps.has_auto_focus, P::SUPPORTS_AUTO_FOCUS);
                 assert_eq!(caps.has_one_push_focus, P::SUPPORTS_ONE_PUSH_FOCUS);
                 assert_eq!(caps.focus_range, P::FOCUS_NEAR_LIMIT..=P::FOCUS_FAR_LIMIT);
-                assert_eq!(caps.focus_speed, 0..=7);
+                assert_eq!(caps.focus_speed, 0..=P::MAX_FOCUS_SPEED);
                 assert_eq!(caps.has_focus_zone, P::SUPPORTS_FOCUS_ZONE);
                 assert_eq!(caps.has_af_sensitivity, P::SUPPORTS_AF_SENSITIVITY);
                 assert_eq!(
@@ -1040,51 +1115,65 @@ macro_rules! __define_builtin_profiles {
                 assert_eq!(caps.has_exposure_comp, P::SUPPORTS_EXPOSURE_COMP);
                 assert_eq!(
                     caps.iris_range,
-                    P::IRIS_RANGE.as_ref().map(|range| range.start..=range.end - 1)
+                    P::IRIS_RANGE.map(|range| range.as_inclusive())
                 );
-                assert_eq!(caps.gain_range, P::GAIN_RANGE.start..=P::GAIN_RANGE.end - 1);
+                assert_eq!(caps.gain_range, P::GAIN_RANGE.as_inclusive());
                 assert_eq!(caps.shutter_speed_count, P::SHUTTER_SPEEDS.len());
                 assert_eq!(
                     caps.exposure_brightness_range,
-                    P::BRIGHTNESS_RANGE
-                        .as_ref()
-                        .map(|range| range.start..=range.end - 1)
+                    P::BRIGHTNESS_RANGE.map(|range| range.as_inclusive())
+                );
+                assert_eq!(
+                    caps.exposure_comp_range,
+                    P::SUPPORTS_EXPOSURE_COMP.then(|| P::EXPOSURE_COMP_RANGE.as_inclusive())
                 );
                 assert_eq!(caps.has_one_push_wb, P::SUPPORTS_ONE_PUSH_WB);
                 assert_eq!(caps.has_color_temp, P::SUPPORTS_COLOR_TEMP);
                 assert_eq!(
                     caps.color_temp_range,
-                    P::COLOR_TEMP_RANGE.as_ref().map(|range| range.start..=range.end - 1)
+                    P::COLOR_TEMP_RANGE.map(|range| range.as_inclusive())
                 );
                 assert_eq!(
                     caps.rg_tuning_range,
-                    P::RG_TUNING_RANGE.as_ref().map(|range| range.start..=range.end - 1)
+                    P::RG_TUNING_RANGE.map(|range| range.as_inclusive())
                 );
                 assert_eq!(
                     caps.bg_tuning_range,
-                    P::BG_TUNING_RANGE.as_ref().map(|range| range.start..=range.end - 1)
+                    P::BG_TUNING_RANGE.map(|range| range.as_inclusive())
                 );
                 assert_eq!(caps.has_rgb_gain, P::SUPPORTS_RGB_GAIN);
+                assert_eq!(
+                    caps.red_gain_range,
+                    P::RED_GAIN_RANGE.map(|range| range.as_inclusive())
+                );
+                assert_eq!(
+                    caps.blue_gain_range,
+                    P::BLUE_GAIN_RANGE.map(|range| range.as_inclusive())
+                );
                 assert_eq!(caps.wb_mode_count, P::WB_MODES.len());
                 assert_eq!(
                     caps.contrast_range,
-                    P::CONTRAST_RANGE
-                        .as_ref()
-                        .map(|range| range.start..=range.end - 1)
+                    P::CONTRAST_RANGE.map(|range| range.as_inclusive())
                 );
                 assert_eq!(
                     caps.sharpness_range,
-                    P::SHARPNESS_RANGE
-                        .as_ref()
-                        .map(|range| range.start..=range.end - 1)
+                    P::SHARPNESS_RANGE.map(|range| range.as_inclusive())
                 );
                 assert_eq!(
                     caps.saturation_range,
-                    P::SATURATION_RANGE.as_ref().map(|range| range.start..=range.end - 1)
+                    P::SATURATION_RANGE.map(|range| range.as_inclusive())
                 );
                 assert_eq!(
                     caps.hue_range,
-                    P::HUE_RANGE.as_ref().map(|range| range.start..=range.end - 1)
+                    P::HUE_RANGE.map(|range| range.as_inclusive())
+                );
+                assert_eq!(
+                    caps.luminance_range,
+                    P::LUMINANCE_RANGE.map(|range| range.as_inclusive())
+                );
+                assert_eq!(
+                    caps.gamma_range,
+                    P::GAMMA_RANGE.map(|range| range.as_inclusive())
                 );
                 assert_eq!(caps.supports_flip, P::SUPPORTS_FLIP);
                 assert_eq!(caps.supports_mirror, P::SUPPORTS_MIRROR);
@@ -1098,7 +1187,7 @@ macro_rules! __define_builtin_profiles {
                 assert_eq!(caps.max_presets, P::MAX_PRESETS);
                 assert_eq!(
                     caps.preset_speed_range,
-                    P::PRESET_SPEED_RANGE.start..=P::PRESET_SPEED_RANGE.end - 1
+                    P::PRESET_SPEED_RANGE.as_inclusive()
                 );
                 assert_eq!(caps.supports_preset_tour, P::SUPPORTS_PRESET_TOUR);
                 assert_eq!(caps.supports_preset_thumbnail, P::SUPPORTS_PRESET_THUMBNAIL);
@@ -1185,8 +1274,8 @@ macro_rules! __define_builtin_profiles {
                         <P as $crate::capabilities::SupportsUdp>::DEFAULT_UDP_PORT,
                         1259
                     );
-                    assert_eq!(P::PAN_RANGE, -2448..2449);
-                    assert_eq!(P::TILT_RANGE, -432..1297);
+                    assert_eq!(P::PAN_RANGE, range!(i16, -2448, 2448));
+                    assert_eq!(P::TILT_RANGE, range!(i16, -432, 1296));
                     assert_eq!(P::MAX_PAN_SPEED, 24);
                     assert_eq!(P::MAX_TILT_SPEED, 20);
                     assert_eq!(P::OPTICAL_ZOOM_MAX, 0x4000);
@@ -1591,8 +1680,8 @@ macro_rules! define_builtin_profiles {
                         min_command_spacing_ms: 100,
                     },
                     pan_tilt: {
-                        pan_range: -2448..2449,
-                        tilt_range: -432..1297,
+                        pan_range: range!(i16, -2448, 2448),
+                        tilt_range: range!(i16, -432, 1296),
                         max_pan_speed: 24,
                         max_tilt_speed: 20,
                         simultaneous: true,
@@ -1604,7 +1693,7 @@ macro_rules! define_builtin_profiles {
                     zoom: {
                         optical_max: 0x4000,
                         digital_max: None,
-                        speed_range: 0..8,
+                        speed_range: range!(u8, 0, 7),
                         supports_direct: true,
                         supports_variable: true,
                         magnification_to_units: 862.3,
@@ -1621,48 +1710,48 @@ macro_rules! define_builtin_profiles {
                     },
                     exposure: {
                         modes: profile_constants::PTZ_OPTICS_EXPOSURE_MODES,
-                        iris_range: Some(0x00..0x0D),
+                        iris_range: Some(range!(u16, 0x00, 0x0C)),
                         shutter_speeds: profile_constants::PTZ_OPTICS_G2_SHUTTER_SPEEDS,
-                        gain_range: 0..8,
-                        brightness_range: Some(0..18),
+                        gain_range: range!(u8, 0, 7),
+                        brightness_range: Some(range!(u16, 0, 17)),
                         backlight_comp: true,
                         exposure_comp: true,
-                        exposure_comp_range: -7..8,
+                        exposure_comp_range: range!(i8, -7, 7),
                         wdr: true,
                     },
                     white_balance: {
                         modes: profile_constants::PTZ_OPTICS_WB_MODES,
                         one_push: true,
-                        rg_tuning_range: Some(-10..11),
-                        bg_tuning_range: Some(-10..11),
+                        rg_tuning_range: Some(range!(i8, -10, 10)),
+                        bg_tuning_range: Some(range!(i8, -10, 10)),
                         color_temp: true,
-                        color_temp_range: Some(2500..8001),
+                        color_temp_range: Some(range!(u16, 2500, 8000)),
                         rgb_gain: true,
                         red_gain_range: None,
                         blue_gain_range: None,
                     },
                     image: {
-                        contrast_range: Some(0..15),
-                        sharpness_range: Some(0..16),
-                        saturation_range: Some(0..15),
+                        contrast_range: Some(range!(u8, 0, 14)),
+                        sharpness_range: Some(range!(u8, 0, 15)),
+                        saturation_range: Some(range!(u8, 0, 14)),
                         flip: true,
                         mirror: true,
                         hue: true,
-                        hue_range: Some(0..15),
+                        hue_range: Some(range!(u8, 0, 14)),
                         noise_reduction: true,
                         nr_2d: true,
                         nr_3d: true,
                         luminance: true,
                         picture_effect: true,
-                        luminance_range: Some(0..15),
+                        luminance_range: Some(range!(u8, 0, 14)),
                         combined_flip: true,
                         save_after_flip: true,
                         gamma: true,
-                        gamma_range: Some(0..5),
+                        gamma_range: Some(range!(u8, 0, 4)),
                     },
                     presets: {
                         max: 127,
-                        speed_range: 1..25,
+                        speed_range: range!(u8, 1, 24),
                         tour: false,
                         recall_delay_ms: 0,
                         thumbnail: false,
@@ -1742,8 +1831,8 @@ macro_rules! define_builtin_profiles {
                         min_command_spacing_ms: 100,
                     },
                     pan_tilt: {
-                        pan_range: -2448..2449,
-                        tilt_range: -432..1297,
+                        pan_range: range!(i16, -2448, 2448),
+                        tilt_range: range!(i16, -432, 1296),
                         max_pan_speed: 24,
                         max_tilt_speed: 20,
                         simultaneous: true,
@@ -1755,7 +1844,7 @@ macro_rules! define_builtin_profiles {
                     zoom: {
                         optical_max: 0x4000,
                         digital_max: None,
-                        speed_range: 0..8,
+                        speed_range: range!(u8, 0, 7),
                         supports_direct: true,
                         supports_variable: true,
                         magnification_to_units: 862.3,
@@ -1772,48 +1861,48 @@ macro_rules! define_builtin_profiles {
                     },
                     exposure: {
                         modes: profile_constants::PTZ_OPTICS_EXPOSURE_MODES,
-                        iris_range: Some(0x00..0x0D),
+                        iris_range: Some(range!(u16, 0x00, 0x0C)),
                         shutter_speeds: profile_constants::PTZ_OPTICS_G2_SHUTTER_SPEEDS,
-                        gain_range: 0..8,
-                        brightness_range: Some(0..18),
+                        gain_range: range!(u8, 0, 7),
+                        brightness_range: Some(range!(u16, 0, 17)),
                         backlight_comp: true,
                         exposure_comp: true,
-                        exposure_comp_range: -7..8,
+                        exposure_comp_range: range!(i8, -7, 7),
                         wdr: true,
                     },
                     white_balance: {
                         modes: profile_constants::PTZ_OPTICS_WB_MODES,
                         one_push: true,
-                        rg_tuning_range: Some(-10..11),
-                        bg_tuning_range: Some(-10..11),
+                        rg_tuning_range: Some(range!(i8, -10, 10)),
+                        bg_tuning_range: Some(range!(i8, -10, 10)),
                         color_temp: true,
-                        color_temp_range: Some(2500..8001),
+                        color_temp_range: Some(range!(u16, 2500, 8000)),
                         rgb_gain: true,
                         red_gain_range: None,
                         blue_gain_range: None,
                     },
                     image: {
-                        contrast_range: Some(0..15),
-                        sharpness_range: Some(0..16),
-                        saturation_range: Some(0..15),
+                        contrast_range: Some(range!(u8, 0, 14)),
+                        sharpness_range: Some(range!(u8, 0, 15)),
+                        saturation_range: Some(range!(u8, 0, 14)),
                         flip: true,
                         mirror: true,
                         hue: true,
-                        hue_range: Some(0..15),
+                        hue_range: Some(range!(u8, 0, 14)),
                         noise_reduction: true,
                         nr_2d: true,
                         nr_3d: true,
                         luminance: true,
                         picture_effect: true,
-                        luminance_range: Some(0..15),
+                        luminance_range: Some(range!(u8, 0, 14)),
                         combined_flip: true,
                         save_after_flip: true,
                         gamma: true,
-                        gamma_range: Some(0..5),
+                        gamma_range: Some(range!(u8, 0, 4)),
                     },
                     presets: {
                         max: 127,
-                        speed_range: 1..25,
+                        speed_range: range!(u8, 1, 24),
                         tour: false,
                         recall_delay_ms: 0,
                         thumbnail: false,
@@ -1894,8 +1983,8 @@ macro_rules! define_builtin_profiles {
                         min_command_spacing_ms: 100,
                     },
                     pan_tilt: {
-                        pan_range: -2448..2449,
-                        tilt_range: -432..1297,
+                        pan_range: range!(i16, -2448, 2448),
+                        tilt_range: range!(i16, -432, 1296),
                         max_pan_speed: 24,
                         max_tilt_speed: 20,
                         simultaneous: true,
@@ -1907,7 +1996,7 @@ macro_rules! define_builtin_profiles {
                     zoom: {
                         optical_max: 0x4000,
                         digital_max: None,
-                        speed_range: 0..8,
+                        speed_range: range!(u8, 0, 7),
                         supports_direct: true,
                         supports_variable: true,
                         magnification_to_units: 565.0,
@@ -1924,48 +2013,48 @@ macro_rules! define_builtin_profiles {
                     },
                     exposure: {
                         modes: profile_constants::PTZ_OPTICS_EXPOSURE_MODES,
-                        iris_range: Some(0x00..0x0D),
+                        iris_range: Some(range!(u16, 0x00, 0x0C)),
                         shutter_speeds: profile_constants::PTZ_OPTICS_G2_SHUTTER_SPEEDS,
-                        gain_range: 0..8,
-                        brightness_range: Some(0..18),
+                        gain_range: range!(u8, 0, 7),
+                        brightness_range: Some(range!(u16, 0, 17)),
                         backlight_comp: true,
                         exposure_comp: true,
-                        exposure_comp_range: -7..8,
+                        exposure_comp_range: range!(i8, -7, 7),
                         wdr: true,
                     },
                     white_balance: {
                         modes: profile_constants::PTZ_OPTICS_WB_MODES,
                         one_push: true,
-                        rg_tuning_range: Some(-10..11),
-                        bg_tuning_range: Some(-10..11),
+                        rg_tuning_range: Some(range!(i8, -10, 10)),
+                        bg_tuning_range: Some(range!(i8, -10, 10)),
                         color_temp: true,
-                        color_temp_range: Some(2500..8001),
+                        color_temp_range: Some(range!(u16, 2500, 8000)),
                         rgb_gain: true,
                         red_gain_range: None,
                         blue_gain_range: None,
                     },
                     image: {
-                        contrast_range: Some(0..15),
-                        sharpness_range: Some(0..16),
-                        saturation_range: Some(0..15),
+                        contrast_range: Some(range!(u8, 0, 14)),
+                        sharpness_range: Some(range!(u8, 0, 15)),
+                        saturation_range: Some(range!(u8, 0, 14)),
                         flip: true,
                         mirror: true,
                         hue: true,
-                        hue_range: Some(0..15),
+                        hue_range: Some(range!(u8, 0, 14)),
                         noise_reduction: true,
                         nr_2d: true,
                         nr_3d: true,
                         luminance: true,
                         picture_effect: true,
-                        luminance_range: Some(0..15),
+                        luminance_range: Some(range!(u8, 0, 14)),
                         combined_flip: true,
                         save_after_flip: true,
                         gamma: true,
-                        gamma_range: Some(0..5),
+                        gamma_range: Some(range!(u8, 0, 4)),
                     },
                     presets: {
                         max: 127,
-                        speed_range: 1..25,
+                        speed_range: range!(u8, 1, 24),
                         tour: false,
                         recall_delay_ms: 0,
                         thumbnail: false,
@@ -2050,8 +2139,8 @@ macro_rules! define_builtin_profiles {
                         min_command_spacing_ms: 35,
                     },
                     pan_tilt: {
-                        pan_range: -2700..2701,
-                        tilt_range: -300..1201,
+                        pan_range: range!(i16, -2700, 2700),
+                        tilt_range: range!(i16, -300, 1200),
                         max_pan_speed: 24,
                         max_tilt_speed: 24,
                         simultaneous: true,
@@ -2063,7 +2152,7 @@ macro_rules! define_builtin_profiles {
                     zoom: {
                         optical_max: 0x4000,
                         digital_max: Some(0x7000),
-                        speed_range: 0..8,
+                        speed_range: range!(u8, 0, 7),
                         supports_direct: true,
                         supports_variable: true,
                         magnification_to_units: 1000.0,
@@ -2080,34 +2169,34 @@ macro_rules! define_builtin_profiles {
                     },
                     exposure: {
                         modes: profile_constants::STANDARD_EXPOSURE_MODES,
-                        iris_range: Some(0x00..0x1F),
+                        iris_range: Some(range!(u16, 0x00, 0x1E)),
                         shutter_speeds: profile_constants::PTZ_OPTICS_G2_SHUTTER_SPEEDS,
-                        gain_range: 0..16,
-                        brightness_range: Some(0..18),
+                        gain_range: range!(u8, 0, 15),
+                        brightness_range: Some(range!(u16, 0, 17)),
                         backlight_comp: true,
                         exposure_comp: true,
-                        exposure_comp_range: -7..8,
+                        exposure_comp_range: range!(i8, -7, 7),
                         wdr: true,
                     },
                     white_balance: {
                         modes: profile_constants::SONY_FR7_WB_MODES,
                         one_push: true,
-                        rg_tuning_range: Some(-7..8),
-                        bg_tuning_range: Some(-7..8),
+                        rg_tuning_range: Some(range!(i8, -7, 7)),
+                        bg_tuning_range: Some(range!(i8, -7, 7)),
                         color_temp: false,
                         color_temp_range: None,
                         rgb_gain: true,
-                        red_gain_range: Some(0..255),
-                        blue_gain_range: Some(0..255),
+                        red_gain_range: Some(range!(u8, 0x00, 0xFF)),
+                        blue_gain_range: Some(range!(u8, 0x00, 0xFF)),
                     },
                     image: {
-                        contrast_range: Some(0..15),
-                        sharpness_range: Some(0..15),
-                        saturation_range: Some(0..15),
+                        contrast_range: Some(range!(u8, 0, 14)),
+                        sharpness_range: Some(range!(u8, 0, 14)),
+                        saturation_range: Some(range!(u8, 0, 14)),
                         flip: true,
                         mirror: true,
                         hue: true,
-                        hue_range: Some(0..15),
+                        hue_range: Some(range!(u8, 0, 14)),
                         noise_reduction: true,
                         nr_2d: true,
                         nr_3d: true,
@@ -2117,11 +2206,11 @@ macro_rules! define_builtin_profiles {
                         combined_flip: false,
                         save_after_flip: false,
                         gamma: true,
-                        gamma_range: Some(0..5),
+                        gamma_range: Some(range!(u8, 0, 4)),
                     },
                     presets: {
                         max: 255,
-                        speed_range: 1..25,
+                        speed_range: range!(u8, 1, 24),
                         tour: true,
                         recall_delay_ms: 0,
                         thumbnail: true,
@@ -2211,8 +2300,8 @@ macro_rules! define_builtin_profiles {
                         min_command_spacing_ms: 35,
                     },
                     pan_tilt: {
-                        pan_range: -2700..2701,
-                        tilt_range: -300..1201,
+                        pan_range: range!(i16, -2700, 2700),
+                        tilt_range: range!(i16, -300, 1200),
                         max_pan_speed: 24,
                         max_tilt_speed: 24,
                         simultaneous: true,
@@ -2224,7 +2313,7 @@ macro_rules! define_builtin_profiles {
                     zoom: {
                         optical_max: 0x4000,
                         digital_max: Some(0x7000),
-                        speed_range: 0..8,
+                        speed_range: range!(u8, 0, 7),
                         supports_direct: true,
                         supports_variable: true,
                         magnification_to_units: 862.3,
@@ -2241,30 +2330,30 @@ macro_rules! define_builtin_profiles {
                     },
                     exposure: {
                         modes: profile_constants::STANDARD_EXPOSURE_MODES,
-                        iris_range: Some(0x00..0x1F),
+                        iris_range: Some(range!(u16, 0x00, 0x1E)),
                         shutter_speeds: profile_constants::GENERIC_VISCA_SHUTTER_SPEEDS,
-                        gain_range: 0..16,
-                        brightness_range: Some(0..18),
+                        gain_range: range!(u8, 0, 15),
+                        brightness_range: Some(range!(u16, 0, 17)),
                         backlight_comp: true,
                         exposure_comp: false,
-                        exposure_comp_range: -7..8,
+                        exposure_comp_range: range!(i8, -7, 7),
                         wdr: true,
                     },
                     white_balance: {
                         modes: profile_constants::SONY_COLOR_TEMP_WB_MODES,
                         one_push: true,
-                        rg_tuning_range: Some(-7..8),
-                        bg_tuning_range: Some(-7..8),
+                        rg_tuning_range: Some(range!(i8, -7, 7)),
+                        bg_tuning_range: Some(range!(i8, -7, 7)),
                         color_temp: true,
-                        color_temp_range: Some(2500..8001),
+                        color_temp_range: Some(range!(u16, 2500, 8000)),
                         rgb_gain: false,
                         red_gain_range: None,
                         blue_gain_range: None,
                     },
                     image: {
-                        contrast_range: Some(0..15),
-                        sharpness_range: Some(0..15),
-                        saturation_range: Some(0..15),
+                        contrast_range: Some(range!(u8, 0, 14)),
+                        sharpness_range: Some(range!(u8, 0, 14)),
+                        saturation_range: Some(range!(u8, 0, 14)),
                         flip: true,
                         mirror: true,
                         hue: false,
@@ -2278,11 +2367,11 @@ macro_rules! define_builtin_profiles {
                         combined_flip: false,
                         save_after_flip: false,
                         gamma: true,
-                        gamma_range: Some(0..5),
+                        gamma_range: Some(range!(u8, 0, 4)),
                     },
                     presets: {
                         max: 100,
-                        speed_range: 1..25,
+                        speed_range: range!(u8, 1, 24),
                         tour: true,
                         recall_delay_ms: 0,
                         thumbnail: false,
@@ -2358,8 +2447,8 @@ macro_rules! define_builtin_profiles {
                         min_command_spacing_ms: 0,
                     },
                     pan_tilt: {
-                        pan_range: -1440..1441,
-                        tilt_range: -480..481,
+                        pan_range: range!(i16, -1440, 1440),
+                        tilt_range: range!(i16, -480, 480),
                         max_pan_speed: 18,
                         max_tilt_speed: 18,
                         simultaneous: true,
@@ -2371,7 +2460,7 @@ macro_rules! define_builtin_profiles {
                     zoom: {
                         optical_max: 0x4000,
                         digital_max: None,
-                        speed_range: 0..8,
+                        speed_range: range!(u8, 0, 7),
                         supports_direct: true,
                         supports_variable: true,
                         magnification_to_units: 862.3,
@@ -2388,22 +2477,22 @@ macro_rules! define_builtin_profiles {
                     },
                     exposure: {
                         modes: profile_constants::STANDARD_EXPOSURE_MODES,
-                        iris_range: Some(0x00..0x1C),
+                        iris_range: Some(range!(u16, 0x00, 0x1B)),
                         shutter_speeds: profile_constants::GENERIC_VISCA_SHUTTER_SPEEDS,
-                        gain_range: 0..8,
+                        gain_range: range!(u8, 0, 7),
                         brightness_range: None,
                         backlight_comp: true,
                         exposure_comp: false,
-                        exposure_comp_range: -7..8,
+                        exposure_comp_range: range!(i8, -7, 7),
                         wdr: false,
                     },
                     white_balance: {
                         modes: profile_constants::SONY_COLOR_TEMP_WB_MODES,
                         one_push: true,
-                        rg_tuning_range: Some(-7..8),
-                        bg_tuning_range: Some(-7..8),
+                        rg_tuning_range: Some(range!(i8, -7, 7)),
+                        bg_tuning_range: Some(range!(i8, -7, 7)),
                         color_temp: true,
-                        color_temp_range: Some(2500..8001),
+                        color_temp_range: Some(range!(u16, 2500, 8000)),
                         rgb_gain: false,
                         red_gain_range: None,
                         blue_gain_range: None,
@@ -2425,11 +2514,11 @@ macro_rules! define_builtin_profiles {
                         combined_flip: false,
                         save_after_flip: false,
                         gamma: true,
-                        gamma_range: Some(0..5),
+                        gamma_range: Some(range!(u8, 0, 4)),
                     },
                     presets: {
                         max: 6,
-                        speed_range: 1..20,
+                        speed_range: range!(u8, 1, 19),
                         tour: false,
                         recall_delay_ms: 0,
                         thumbnail: false,
@@ -2492,8 +2581,8 @@ macro_rules! define_builtin_profiles {
                         min_command_spacing_ms: 0,
                     },
                     pan_tilt: {
-                        pan_range: -1170..1171,
-                        tilt_range: -390..391,
+                        pan_range: range!(i16, -1170, 1170),
+                        tilt_range: range!(i16, -390, 390),
                         max_pan_speed: 18,
                         max_tilt_speed: 17,
                         simultaneous: true,
@@ -2505,7 +2594,7 @@ macro_rules! define_builtin_profiles {
                     zoom: {
                         optical_max: 0x1068,
                         digital_max: None,
-                        speed_range: 0..8,
+                        speed_range: range!(u8, 0, 7),
                         supports_direct: true,
                         supports_variable: true,
                         magnification_to_units: 455.1,
@@ -2522,13 +2611,13 @@ macro_rules! define_builtin_profiles {
                     },
                     exposure: {
                         modes: profile_constants::STANDARD_EXPOSURE_MODES,
-                        iris_range: Some(0x00..0x11),
+                        iris_range: Some(range!(u16, 0x00, 0x10)),
                         shutter_speeds: profile_constants::GENERIC_VISCA_SHUTTER_SPEEDS,
-                        gain_range: 0..7,
+                        gain_range: range!(u8, 0, 6),
                         brightness_range: None,
                         backlight_comp: true,
                         exposure_comp: false,
-                        exposure_comp_range: -7..8,
+                        exposure_comp_range: range!(i8, -7, 7),
                         wdr: false,
                     },
                     white_balance: {
@@ -2563,7 +2652,7 @@ macro_rules! define_builtin_profiles {
                     },
                     presets: {
                         max: 16,
-                        speed_range: 1..18,
+                        speed_range: range!(u8, 1, 17),
                         tour: false,
                         recall_delay_ms: 0,
                         thumbnail: false,
@@ -2619,8 +2708,8 @@ macro_rules! define_builtin_profiles {
                         min_command_spacing_ms: 0,
                     },
                     pan_tilt: {
-                        pan_range: -1170..1171,
-                        tilt_range: -390..391,
+                        pan_range: range!(i16, -1170, 1170),
+                        tilt_range: range!(i16, -390, 390),
                         max_pan_speed: 18,
                         max_tilt_speed: 17,
                         simultaneous: true,
@@ -2632,7 +2721,7 @@ macro_rules! define_builtin_profiles {
                     zoom: {
                         optical_max: 0x1068,
                         digital_max: None,
-                        speed_range: 0..8,
+                        speed_range: range!(u8, 0, 7),
                         supports_direct: true,
                         supports_variable: true,
                         magnification_to_units: 455.1,
@@ -2649,13 +2738,13 @@ macro_rules! define_builtin_profiles {
                     },
                     exposure: {
                         modes: profile_constants::STANDARD_EXPOSURE_MODES,
-                        iris_range: Some(0x00..0x11),
+                        iris_range: Some(range!(u16, 0x00, 0x10)),
                         shutter_speeds: profile_constants::GENERIC_VISCA_SHUTTER_SPEEDS,
-                        gain_range: 0..7,
+                        gain_range: range!(u8, 0, 6),
                         brightness_range: None,
                         backlight_comp: true,
                         exposure_comp: false,
-                        exposure_comp_range: -7..8,
+                        exposure_comp_range: range!(i8, -7, 7),
                         wdr: false,
                     },
                     white_balance: {
@@ -2672,7 +2761,7 @@ macro_rules! define_builtin_profiles {
                     image: {
                         contrast_range: None,
                         sharpness_range: None,
-                        saturation_range: Some(0..16),
+                        saturation_range: Some(range!(u8, 0, 15)),
                         flip: false,
                         mirror: false,
                         hue: false,
@@ -2690,7 +2779,7 @@ macro_rules! define_builtin_profiles {
                     },
                     presets: {
                         max: 16,
-                        speed_range: 1..18,
+                        speed_range: range!(u8, 1, 17),
                         tour: false,
                         recall_delay_ms: 0,
                         thumbnail: false,
@@ -2747,8 +2836,8 @@ macro_rules! define_builtin_profiles {
                         min_command_spacing_ms: 0,
                     },
                     pan_tilt: {
-                        pan_range: -2880..2881,
-                        tilt_range: -1440..1441,
+                        pan_range: range!(i16, -2880, 2880),
+                        tilt_range: range!(i16, -1440, 1440),
                         max_pan_speed: 24,
                         max_tilt_speed: 24,
                         simultaneous: true,
@@ -2760,7 +2849,7 @@ macro_rules! define_builtin_profiles {
                     zoom: {
                         optical_max: 0xFFFF,
                         digital_max: None,
-                        speed_range: 0..8,
+                        speed_range: range!(u8, 0, 7),
                         supports_direct: false,
                         supports_variable: true,
                         magnification_to_units: 1000.0,
@@ -2777,13 +2866,13 @@ macro_rules! define_builtin_profiles {
                     },
                     exposure: {
                         modes: profile_constants::STANDARD_EXPOSURE_MODES,
-                        iris_range: Some(0x00..0x1C),
+                        iris_range: Some(range!(u16, 0x00, 0x1B)),
                         shutter_speeds: profile_constants::GENERIC_VISCA_SHUTTER_SPEEDS,
-                        gain_range: 0..8,
+                        gain_range: range!(u8, 0, 7),
                         brightness_range: None,
                         backlight_comp: false,
                         exposure_comp: false,
-                        exposure_comp_range: -7..8,
+                        exposure_comp_range: range!(i8, -7, 7),
                         wdr: false,
                     },
                     white_balance: {
@@ -2818,7 +2907,7 @@ macro_rules! define_builtin_profiles {
                     },
                     presets: {
                         max: 6,
-                        speed_range: 1..24,
+                        speed_range: range!(u8, 1, 23),
                         tour: false,
                         recall_delay_ms: 0,
                         thumbnail: false,

--- a/src/capabilities/discovery.rs
+++ b/src/capabilities/discovery.rs
@@ -4,27 +4,12 @@
 //! camera capabilities at runtime, complementing the compile-time
 //! trait-based capability system.
 
-use std::{
-    borrow::Cow,
-    ops::{Range, RangeInclusive},
-};
+use std::{borrow::Cow, ops::RangeInclusive};
 
 use super::{
     profile_metadata::InquirySupport, ProfileTypedSupport, TypedSupportSet, TypedSupportSurface,
 };
 use crate::command::exposure::ExposureMode;
-
-fn inclusive_u8_range(range: &Range<u8>) -> RangeInclusive<u8> {
-    range.start..=range.end - 1
-}
-
-fn inclusive_u16_range(range: &Range<u16>) -> RangeInclusive<u16> {
-    range.start..=range.end - 1
-}
-
-fn inclusive_i8_range(range: &Range<i8>) -> RangeInclusive<i8> {
-    range.start..=range.end - 1
-}
 
 /// Structured capabilities response for runtime feature discovery.
 ///
@@ -193,6 +178,9 @@ pub struct Capabilities {
     /// Whether camera supports exposure compensation.
     pub has_exposure_comp: bool,
 
+    /// Exposure compensation range, if supported.
+    pub exposure_comp_range: Option<RangeInclusive<i8>>,
+
     /// Iris range in VISCA units, if iris control is supported.
     pub iris_range: Option<RangeInclusive<u16>>,
 
@@ -230,6 +218,12 @@ pub struct Capabilities {
     /// Whether camera supports manual RGB gain control (red/blue gain inquiries).
     pub has_rgb_gain: bool,
 
+    /// Red gain range if supported.
+    pub red_gain_range: Option<RangeInclusive<u8>>,
+
+    /// Blue gain range if supported.
+    pub blue_gain_range: Option<RangeInclusive<u8>>,
+
     /// Number of white balance modes supported.
     pub wb_mode_count: usize,
 
@@ -248,6 +242,12 @@ pub struct Capabilities {
 
     /// Hue adjustment range if supported.
     pub hue_range: Option<RangeInclusive<u8>>,
+
+    /// Image luminance range if supported.
+    pub luminance_range: Option<RangeInclusive<u8>>,
+
+    /// Gamma curve range if supported.
+    pub gamma_range: Option<RangeInclusive<u8>>,
 
     /// Whether camera supports image flip.
     pub supports_flip: bool,
@@ -354,15 +354,15 @@ impl Capabilities {
         P: crate::capabilities::Profile,
     {
         // Extract pan/tilt capabilities
-        let pan_min_deg = P::PAN_RANGE.start as f32 / P::PAN_DEGREES_TO_UNITS;
-        let pan_max_deg = (P::PAN_RANGE.end - 1) as f32 / P::PAN_DEGREES_TO_UNITS;
-        let tilt_min_deg = P::TILT_RANGE.start as f32 / P::TILT_DEGREES_TO_UNITS;
-        let tilt_max_deg = (P::TILT_RANGE.end - 1) as f32 / P::TILT_DEGREES_TO_UNITS;
+        let pan_min_deg = P::PAN_RANGE.min() as f32 / P::PAN_DEGREES_TO_UNITS;
+        let pan_max_deg = P::PAN_RANGE.max() as f32 / P::PAN_DEGREES_TO_UNITS;
+        let tilt_min_deg = P::TILT_RANGE.min() as f32 / P::TILT_DEGREES_TO_UNITS;
+        let tilt_max_deg = P::TILT_RANGE.max() as f32 / P::TILT_DEGREES_TO_UNITS;
 
         let pan_speed = 1..=P::MAX_PAN_SPEED;
         let tilt_speed = 1..=P::MAX_TILT_SPEED;
-        let pan_range = P::PAN_RANGE.start..=(P::PAN_RANGE.end - 1);
-        let tilt_range = P::TILT_RANGE.start..=(P::TILT_RANGE.end - 1);
+        let pan_range = P::PAN_RANGE.as_inclusive();
+        let tilt_range = P::TILT_RANGE.as_inclusive();
         let pan_range_degrees = pan_min_deg..=pan_max_deg;
         let tilt_range_degrees = tilt_min_deg..=tilt_max_deg;
         let pan_tilt_simultaneous = P::PAN_TILT_SIMULTANEOUS;
@@ -373,29 +373,37 @@ impl Capabilities {
 
         // Extract focus capabilities
         let focus_range = P::FOCUS_NEAR_LIMIT..=P::FOCUS_FAR_LIMIT;
-        let focus_speed = 0..=7; // Standard VISCA focus speed range
+        let focus_speed = 0..=P::MAX_FOCUS_SPEED;
 
         // Extract exposure capabilities
         let has_iris_control = P::IRIS_RANGE.is_some();
         let exposure_modes = P::EXPOSURE_MODES.to_vec();
-        let iris_range = P::IRIS_RANGE.as_ref().map(inclusive_u16_range);
-        let gain_range = P::GAIN_RANGE.start..=P::GAIN_RANGE.end.saturating_sub(1);
-        let exposure_brightness_range = P::BRIGHTNESS_RANGE.as_ref().map(inclusive_u16_range);
+        let iris_range = P::IRIS_RANGE.map(|range| range.as_inclusive());
+        let gain_range = P::GAIN_RANGE.as_inclusive();
+        let exposure_brightness_range = P::BRIGHTNESS_RANGE.map(|range| range.as_inclusive());
+        let exposure_comp_range =
+            P::SUPPORTS_EXPOSURE_COMP.then(|| P::EXPOSURE_COMP_RANGE.as_inclusive());
 
         // Extract white balance capabilities
-        let color_temp_range = P::COLOR_TEMP_RANGE.as_ref().map(inclusive_u16_range);
-        let rg_tuning_range = P::RG_TUNING_RANGE.as_ref().map(inclusive_i8_range);
-        let bg_tuning_range = P::BG_TUNING_RANGE.as_ref().map(inclusive_i8_range);
+        let color_temp_range = P::COLOR_TEMP_RANGE.map(|range| range.as_inclusive());
+        let rg_tuning_range = P::RG_TUNING_RANGE.map(|range| range.as_inclusive());
+        let bg_tuning_range = P::BG_TUNING_RANGE.map(|range| range.as_inclusive());
+        let red_gain_range = P::RED_GAIN_RANGE.map(|range| range.as_inclusive());
+        let blue_gain_range = P::BLUE_GAIN_RANGE.map(|range| range.as_inclusive());
 
         // Extract image processing capabilities
-        let contrast_range = P::CONTRAST_RANGE.as_ref().map(inclusive_u8_range);
-        let sharpness_range = P::SHARPNESS_RANGE.as_ref().map(inclusive_u8_range);
-        let saturation_range = P::SATURATION_RANGE.as_ref().map(inclusive_u8_range);
-        let hue_range = P::HUE_RANGE.as_ref().map(inclusive_u8_range);
+        let contrast_range = P::CONTRAST_RANGE.map(|range| range.as_inclusive());
+        let sharpness_range = P::SHARPNESS_RANGE.map(|range| range.as_inclusive());
+        let saturation_range = P::SATURATION_RANGE.map(|range| range.as_inclusive());
+        let hue_range = P::HUE_RANGE.map(|range| range.as_inclusive());
+        let luminance_range = P::LUMINANCE_RANGE.map(|range| range.as_inclusive());
+        let gamma_range = P::GAMMA_RANGE.map(|range| range.as_inclusive());
         let has_image_processing = contrast_range.is_some()
             || sharpness_range.is_some()
             || saturation_range.is_some()
             || hue_range.is_some()
+            || luminance_range.is_some()
+            || gamma_range.is_some()
             || P::SUPPORTS_FLIP
             || P::SUPPORTS_MIRROR
             || P::SUPPORTS_NOISE_REDUCTION
@@ -406,8 +414,7 @@ impl Capabilities {
             || P::SUPPORTS_LUMINANCE;
 
         // Extract preset capabilities
-        let preset_speed_range =
-            P::PRESET_SPEED_RANGE.start..=P::PRESET_SPEED_RANGE.end.saturating_sub(1);
+        let preset_speed_range = P::PRESET_SPEED_RANGE.as_inclusive();
 
         // Extract ND filter capabilities from profile metadata.
         let has_nd_filter = !matches!(P::ND_MODE, crate::capabilities::NdFilterMode::None);
@@ -450,7 +457,7 @@ impl Capabilities {
             has_digital_zoom,
             zoom_range_optical: 0x0000..=P::OPTICAL_ZOOM_MAX,
             zoom_range_digital,
-            zoom_speed: P::ZOOM_SPEED_RANGE.start..=(P::ZOOM_SPEED_RANGE.end - 1),
+            zoom_speed: P::ZOOM_SPEED_RANGE.as_inclusive(),
             supports_direct_zoom: P::SUPPORTS_DIRECT_ZOOM,
             supports_variable_zoom: P::SUPPORTS_VARIABLE_ZOOM,
             zoom_magnification_to_units: P::ZOOM_MAGNIFICATION_TO_UNITS,
@@ -472,6 +479,7 @@ impl Capabilities {
             has_backlight_comp: P::SUPPORTS_BACKLIGHT_COMP,
             has_wdr: P::SUPPORTS_WDR,
             has_exposure_comp: P::SUPPORTS_EXPOSURE_COMP,
+            exposure_comp_range,
             iris_range,
             gain_range,
             shutter_speed_count: P::SHUTTER_SPEEDS.len(),
@@ -485,6 +493,8 @@ impl Capabilities {
             rg_tuning_range,
             bg_tuning_range,
             has_rgb_gain: P::SUPPORTS_RGB_GAIN,
+            red_gain_range,
+            blue_gain_range,
             wb_mode_count: P::WB_MODES.len(),
 
             // Image processing capabilities
@@ -493,6 +503,8 @@ impl Capabilities {
             sharpness_range,
             saturation_range,
             hue_range,
+            luminance_range,
+            gamma_range,
             supports_flip: P::SUPPORTS_FLIP,
             supports_mirror: P::SUPPORTS_MIRROR,
             has_noise_reduction: P::SUPPORTS_NOISE_REDUCTION,
@@ -743,7 +755,7 @@ mod tests {
         SonyBRCH900, SonyEVIH100, SonyFR7,
     };
     use crate::capabilities::{
-        exposure::ShutterSpeed, Exposure, Focus, ImageProcessing, MenuCapability,
+        exposure::ShutterSpeed, CapabilityRange, Exposure, Focus, ImageProcessing, MenuCapability,
         MotionSyncMetadata, NdFilterMetadata, PanTilt, Power, Presets, ProfileMetadata,
         ProfileTypedSupport, Tally, VariableSpeedMetadata, WhiteBalance, Zoom,
     };
@@ -769,8 +781,8 @@ mod tests {
     }
 
     impl PanTilt for MetadataEnabledNoTypedSupport {
-        const PAN_RANGE: Range<i16> = -1700..1701;
-        const TILT_RANGE: Range<i16> = -300..901;
+        const PAN_RANGE: CapabilityRange<i16> = CapabilityRange::<i16>::new(-1700, 1700);
+        const TILT_RANGE: CapabilityRange<i16> = CapabilityRange::<i16>::new(-300, 900);
         const MAX_PAN_SPEED: u8 = 24;
         const MAX_TILT_SPEED: u8 = 20;
         const PAN_DEGREES_TO_UNITS: f32 = 10.0;
@@ -780,7 +792,7 @@ mod tests {
     impl Zoom for MetadataEnabledNoTypedSupport {
         const OPTICAL_ZOOM_MAX: u16 = 0x4000;
         const DIGITAL_ZOOM_MAX: Option<u16> = Some(0x7000);
-        const ZOOM_SPEED_RANGE: Range<u8> = 0..8;
+        const ZOOM_SPEED_RANGE: CapabilityRange<u8> = CapabilityRange::<u8>::new(0, 7);
         const SUPPORTS_DIRECT_ZOOM: bool = true;
         const ZOOM_MAGNIFICATION_TO_UNITS: f32 = 862.3;
     }
@@ -796,30 +808,30 @@ mod tests {
 
     impl Exposure for MetadataEnabledNoTypedSupport {
         const EXPOSURE_MODES: &'static [ExposureMode] = SYNTHETIC_EXPOSURE_MODES;
-        const IRIS_RANGE: Option<Range<u16>> = None;
+        const IRIS_RANGE: Option<CapabilityRange<u16>> = None;
         const SHUTTER_SPEEDS: &'static [ShutterSpeed] = SYNTHETIC_SHUTTER_SPEEDS;
-        const GAIN_RANGE: Range<u8> = 0..16;
+        const GAIN_RANGE: CapabilityRange<u8> = CapabilityRange::<u8>::new(0, 15);
         const SUPPORTS_BACKLIGHT_COMP: bool = false;
     }
 
     impl WhiteBalance for MetadataEnabledNoTypedSupport {
         const WB_MODES: &'static [WhiteBalanceMode] = SYNTHETIC_WB_MODES;
         const SUPPORTS_ONE_PUSH_WB: bool = false;
-        const RG_TUNING_RANGE: Option<Range<i8>> = None;
-        const BG_TUNING_RANGE: Option<Range<i8>> = None;
+        const RG_TUNING_RANGE: Option<CapabilityRange<i8>> = None;
+        const BG_TUNING_RANGE: Option<CapabilityRange<i8>> = None;
     }
 
     impl ImageProcessing for MetadataEnabledNoTypedSupport {
-        const CONTRAST_RANGE: Option<Range<u8>> = None;
-        const SHARPNESS_RANGE: Option<Range<u8>> = None;
-        const SATURATION_RANGE: Option<Range<u8>> = None;
+        const CONTRAST_RANGE: Option<CapabilityRange<u8>> = None;
+        const SHARPNESS_RANGE: Option<CapabilityRange<u8>> = None;
+        const SATURATION_RANGE: Option<CapabilityRange<u8>> = None;
         const SUPPORTS_FLIP: bool = false;
         const SUPPORTS_MIRROR: bool = false;
     }
 
     impl Presets for MetadataEnabledNoTypedSupport {
         const MAX_PRESETS: u8 = 6;
-        const PRESET_SPEED_RANGE: Range<u8> = 1..24;
+        const PRESET_SPEED_RANGE: CapabilityRange<u8> = CapabilityRange::<u8>::new(1, 23);
         const SUPPORTS_PRESET_TOUR: bool = false;
     }
 
@@ -864,7 +876,10 @@ mod tests {
         assert!(caps.has_iris_control);
         assert!(caps.supports_exposure_mode(ExposureMode::Iris));
         assert_eq!(caps.iris_range, Some(0..=12));
+        assert_eq!(caps.exposure_comp_range, Some(-7..=7));
         assert!(caps.has_rgb_gain);
+        assert_eq!(caps.red_gain_range, None);
+        assert_eq!(caps.blue_gain_range, None);
 
         assert_eq!(caps.max_presets, 127);
         assert!(!caps.supports_preset_tour);
@@ -876,6 +891,8 @@ mod tests {
         assert!(caps.has_image_processing);
         assert_eq!(caps.contrast_range, Some(0..=14));
         assert_eq!(caps.sharpness_range, Some(0..=15));
+        assert_eq!(caps.luminance_range, Some(0..=14));
+        assert_eq!(caps.gamma_range, Some(0..=4));
         assert!(caps.has_picture_effect);
 
         assert!(caps.has_basic_features());
@@ -896,6 +913,9 @@ mod tests {
         assert!(caps.has_af_sensitivity);
         assert!(caps.has_focus_near_limit_inquiry);
         assert!(caps.has_rgb_gain);
+        assert_eq!(caps.red_gain_range, Some(0..=0xFF));
+        assert_eq!(caps.blue_gain_range, Some(0..=0xFF));
+        assert_eq!(caps.exposure_comp_range, Some(-7..=7));
         assert!(!caps.has_color_temp);
         assert_eq!(caps.color_temp_range, None);
         assert!(caps.has_nd_filter);
@@ -907,6 +927,7 @@ mod tests {
         assert!(caps.has_image_processing);
         assert_eq!(caps.contrast_range, Some(0..=14));
         assert_eq!(caps.sharpness_range, Some(0..=14));
+        assert_eq!(caps.gamma_range, Some(0..=4));
 
         assert!(caps.has_advanced_features());
     }
@@ -987,8 +1008,11 @@ mod tests {
 
         assert!(!caps.has_image_processing);
         assert_eq!(caps.exposure_brightness_range, None);
+        assert_eq!(caps.exposure_comp_range, None);
         assert_eq!(caps.contrast_range, None);
         assert_eq!(caps.sharpness_range, None);
+        assert_eq!(caps.luminance_range, None);
+        assert_eq!(caps.gamma_range, None);
         assert!(!caps.has_basic_features());
         // GenericVisca has one-push white balance, which counts as an advanced feature
         assert!(caps.has_one_push_wb);

--- a/src/capabilities/exposure.rs
+++ b/src/capabilities/exposure.rs
@@ -1,8 +1,11 @@
 //! Exposure capability trait and associated types.
 
-use std::{borrow::Cow, ops::Range};
+use std::borrow::Cow;
 
-use crate::{capabilities::ValidationError, command::exposure::ExposureMode};
+use crate::{
+    capabilities::{CapabilityRange, ValidationError},
+    command::exposure::ExposureMode,
+};
 
 /// Trait for cameras that support exposure control.
 ///
@@ -19,20 +22,20 @@ pub trait Exposure {
     ];
 
     /// Valid range for iris values in VISCA units, if iris control is supported.
-    const IRIS_RANGE: Option<Range<u16>>;
+    const IRIS_RANGE: Option<CapabilityRange<u16>>;
 
     /// Supported shutter speeds as VISCA values.
     /// Each camera model has specific supported speeds.
     const SHUTTER_SPEEDS: &'static [ShutterSpeed];
 
     /// Valid range for gain values.
-    const GAIN_RANGE: Range<u8>;
+    const GAIN_RANGE: CapabilityRange<u8>;
 
     /// Valid range for VISCA exposure bright/bright-direct values, if supported.
     ///
     /// This is the exposure bright control (`0x04 0x0D` / `0x04 0x4D`), not
     /// image luminance (`0x04 0xA1`).
-    const BRIGHTNESS_RANGE: Option<Range<u16>> = None;
+    const BRIGHTNESS_RANGE: Option<CapabilityRange<u16>> = None;
 
     /// Whether camera supports backlight compensation.
     const SUPPORTS_BACKLIGHT_COMP: bool;
@@ -42,7 +45,7 @@ pub trait Exposure {
 
     /// Range for exposure compensation if supported.
     /// Typically -7 to +7 in steps.
-    const EXPOSURE_COMP_RANGE: Range<i8> = -7..8;
+    const EXPOSURE_COMP_RANGE: CapabilityRange<i8> = CapabilityRange::<i8>::new(-7, 7);
 
     /// Whether camera supports wide dynamic range.
     const SUPPORTS_WDR: bool = false;
@@ -66,28 +69,28 @@ pub trait ExposureExt: Exposure {
             .as_ref()
             .ok_or(ValidationError::NotSupported("Iris control"))?;
 
-        if range.contains(&iris) {
+        if range.contains(iris) {
             Ok(iris)
         } else {
             Err(ValidationError::OutOfRange {
                 parameter: "iris",
                 value: iris as f64,
-                min: range.start as f64,
-                max: (range.end - 1) as f64,
+                min: range.min() as f64,
+                max: range.max() as f64,
             })
         }
     }
 
     /// Validate gain value is within range.
     fn validate_gain(&self, gain: u8) -> Result<u8, ValidationError> {
-        if Self::GAIN_RANGE.contains(&gain) {
+        if Self::GAIN_RANGE.contains(gain) {
             Ok(gain)
         } else {
             Err(ValidationError::OutOfRange {
                 parameter: "gain",
                 value: gain as f64,
-                min: Self::GAIN_RANGE.start as f64,
-                max: (Self::GAIN_RANGE.end - 1) as f64,
+                min: Self::GAIN_RANGE.min() as f64,
+                max: Self::GAIN_RANGE.max() as f64,
             })
         }
     }
@@ -98,14 +101,14 @@ pub trait ExposureExt: Exposure {
             .as_ref()
             .ok_or(ValidationError::NotSupported("exposure brightness"))?;
 
-        if range.contains(&brightness) {
+        if range.contains(brightness) {
             Ok(brightness)
         } else {
             Err(ValidationError::OutOfRange {
                 parameter: "exposure brightness",
                 value: brightness as f64,
-                min: range.start as f64,
-                max: (range.end - 1) as f64,
+                min: range.min() as f64,
+                max: range.max() as f64,
             })
         }
     }
@@ -135,14 +138,14 @@ pub trait ExposureExt: Exposure {
     /// The compile-time check is enforced by requiring HasExposureCompensation marker trait
     /// on the methods that use exposure compensation.
     fn validate_exposure_comp(&self, value: i8) -> Result<i8, ValidationError> {
-        if Self::EXPOSURE_COMP_RANGE.contains(&value) {
+        if Self::EXPOSURE_COMP_RANGE.contains(value) {
             Ok(value)
         } else {
             Err(ValidationError::OutOfRange {
                 parameter: "exposure compensation",
                 value: value as f64,
-                min: Self::EXPOSURE_COMP_RANGE.start as f64,
-                max: (Self::EXPOSURE_COMP_RANGE.end - 1) as f64,
+                min: Self::EXPOSURE_COMP_RANGE.min() as f64,
+                max: Self::EXPOSURE_COMP_RANGE.max() as f64,
             })
         }
     }
@@ -156,12 +159,12 @@ pub trait ExposureExt: Exposure {
         // This is camera-specific and would need proper calibration
         // This is a simplified example
         let iris = match fstop {
-            f if f <= 1.8 => range.end - 1,
-            f if f >= 11.0 => range.start,
+            f if f <= 1.8 => range.max(),
+            f if f >= 11.0 => range.min(),
             f => {
-                let width = range.end - range.start;
+                let width = range.max() - range.min();
                 let normalized = 1.0 - ((f - 1.8) / (11.0 - 1.8));
-                range.start + (normalized * width as f32) as u16
+                range.min() + (normalized * width as f32) as u16
             }
         };
 
@@ -208,10 +211,12 @@ mod tests {
     struct TestCamera;
 
     impl Exposure for TestCamera {
-        const IRIS_RANGE: Option<Range<u16>> = Some(0x00..0x1D);
+        const IRIS_RANGE: Option<CapabilityRange<u16>> =
+            Some(CapabilityRange::<u16>::new(0x00, 0x1C));
         const SHUTTER_SPEEDS: &'static [ShutterSpeed] = TEST_SHUTTER_SPEEDS;
-        const GAIN_RANGE: Range<u8> = 0..16;
-        const BRIGHTNESS_RANGE: Option<Range<u16>> = Some(0..18);
+        const GAIN_RANGE: CapabilityRange<u8> = CapabilityRange::<u8>::new(0, 15);
+        const BRIGHTNESS_RANGE: Option<CapabilityRange<u16>> =
+            Some(CapabilityRange::<u16>::new(0, 17));
         const SUPPORTS_BACKLIGHT_COMP: bool = true;
         const SUPPORTS_EXPOSURE_COMP: bool = true;
     }
@@ -220,10 +225,10 @@ mod tests {
 
     impl Exposure for NoIrisCamera {
         const EXPOSURE_MODES: &'static [ExposureMode] = &[ExposureMode::Auto, ExposureMode::Manual];
-        const IRIS_RANGE: Option<Range<u16>> = None;
+        const IRIS_RANGE: Option<CapabilityRange<u16>> = None;
         const SHUTTER_SPEEDS: &'static [ShutterSpeed] = TEST_SHUTTER_SPEEDS;
-        const GAIN_RANGE: Range<u8> = 0..16;
-        const BRIGHTNESS_RANGE: Option<Range<u16>> = None;
+        const GAIN_RANGE: CapabilityRange<u8> = CapabilityRange::<u8>::new(0, 15);
+        const BRIGHTNESS_RANGE: Option<CapabilityRange<u16>> = None;
         const SUPPORTS_BACKLIGHT_COMP: bool = true;
     }
 

--- a/src/capabilities/image_processing.rs
+++ b/src/capabilities/image_processing.rs
@@ -1,8 +1,6 @@
 //! Image processing capability trait and associated types.
 
-use std::ops::Range;
-
-use crate::capabilities::ValidationError;
+use crate::capabilities::{CapabilityRange, ValidationError};
 
 /// Trait for cameras that report image-processing metadata.
 ///
@@ -11,14 +9,14 @@ use crate::capabilities::ValidationError;
 /// `None` for unsupported profile surfaces; supported ranges must be non-empty.
 pub trait ImageProcessing {
     /// Valid range for contrast adjustment, if supported.
-    const CONTRAST_RANGE: Option<Range<u8>>;
+    const CONTRAST_RANGE: Option<CapabilityRange<u8>>;
 
     /// Valid range for sharpness adjustment, if supported.
-    const SHARPNESS_RANGE: Option<Range<u8>>;
+    const SHARPNESS_RANGE: Option<CapabilityRange<u8>>;
 
     /// Valid range for saturation adjustment.
     /// None if not supported.
-    const SATURATION_RANGE: Option<Range<u8>>;
+    const SATURATION_RANGE: Option<CapabilityRange<u8>>;
 
     /// Whether camera supports image flip (vertical).
     const SUPPORTS_FLIP: bool;
@@ -30,7 +28,7 @@ pub trait ImageProcessing {
     const SUPPORTS_HUE: bool = false;
 
     /// Hue adjustment range if supported.
-    const HUE_RANGE: Option<Range<u8>> = None;
+    const HUE_RANGE: Option<CapabilityRange<u8>> = None;
 
     /// Whether camera supports noise reduction.
     const SUPPORTS_NOISE_REDUCTION: bool = false;
@@ -48,7 +46,7 @@ pub trait ImageProcessing {
     const SUPPORTS_PICTURE_EFFECT: bool = false;
 
     /// Luminance range if supported.
-    const LUMINANCE_RANGE: Option<Range<u8>> = None;
+    const LUMINANCE_RANGE: Option<CapabilityRange<u8>> = None;
 
     /// Whether camera uses the combined flip command (0xA4) instead of legacy commands (0x61/0x66).
     ///
@@ -69,7 +67,7 @@ pub trait ImageProcessing {
     const SUPPORTS_GAMMA: bool = false;
 
     /// Valid range for gamma curve selection, if supported.
-    const GAMMA_RANGE: Option<Range<u8>> = None;
+    const GAMMA_RANGE: Option<CapabilityRange<u8>> = None;
 }
 
 /// Extension trait that adds validation methods to cameras with image processing support.
@@ -77,12 +75,12 @@ pub trait ImageProcessingExt: ImageProcessing {
     /// Validate contrast value.
     fn validate_contrast(&self, value: u8) -> Result<u8, ValidationError> {
         match Self::CONTRAST_RANGE {
-            Some(ref range) if range.contains(&value) => Ok(value),
+            Some(range) if range.contains(value) => Ok(value),
             Some(ref range) => Err(ValidationError::OutOfRange {
                 parameter: "contrast",
                 value: value as f64,
-                min: range.start as f64,
-                max: (range.end - 1) as f64,
+                min: range.min() as f64,
+                max: range.max() as f64,
             }),
             None => Err(ValidationError::NotSupported("contrast")),
         }
@@ -91,12 +89,12 @@ pub trait ImageProcessingExt: ImageProcessing {
     /// Validate sharpness value.
     fn validate_sharpness(&self, value: u8) -> Result<u8, ValidationError> {
         match Self::SHARPNESS_RANGE {
-            Some(ref range) if range.contains(&value) => Ok(value),
+            Some(range) if range.contains(value) => Ok(value),
             Some(ref range) => Err(ValidationError::OutOfRange {
                 parameter: "sharpness",
                 value: value as f64,
-                min: range.start as f64,
-                max: (range.end - 1) as f64,
+                min: range.min() as f64,
+                max: range.max() as f64,
             }),
             None => Err(ValidationError::NotSupported("sharpness")),
         }
@@ -105,12 +103,12 @@ pub trait ImageProcessingExt: ImageProcessing {
     /// Validate saturation value.
     fn validate_saturation(&self, value: u8) -> Result<u8, ValidationError> {
         match Self::SATURATION_RANGE {
-            Some(ref range) if range.contains(&value) => Ok(value),
+            Some(range) if range.contains(value) => Ok(value),
             Some(ref range) => Err(ValidationError::OutOfRange {
                 parameter: "saturation",
                 value: value as f64,
-                min: range.start as f64,
-                max: (range.end - 1) as f64,
+                min: range.min() as f64,
+                max: range.max() as f64,
             }),
             None => Err(ValidationError::NotSupported("saturation")),
         }
@@ -121,12 +119,12 @@ pub trait ImageProcessingExt: ImageProcessing {
     /// Returns `NotSupported` error if `HUE_RANGE` is `None`.
     fn validate_hue(&self, value: u8) -> Result<u8, ValidationError> {
         match Self::HUE_RANGE {
-            Some(ref range) if range.contains(&value) => Ok(value),
+            Some(range) if range.contains(value) => Ok(value),
             Some(ref range) => Err(ValidationError::OutOfRange {
                 parameter: "hue",
                 value: value as f64,
-                min: range.start as f64,
-                max: (range.end - 1) as f64,
+                min: range.min() as f64,
+                max: range.max() as f64,
             }),
             None => Err(ValidationError::NotSupported("hue")),
         }
@@ -137,12 +135,12 @@ pub trait ImageProcessingExt: ImageProcessing {
     /// Returns `NotSupported` error if `LUMINANCE_RANGE` is `None`.
     fn validate_luminance(&self, value: u8) -> Result<u8, ValidationError> {
         match Self::LUMINANCE_RANGE {
-            Some(ref range) if range.contains(&value) => Ok(value),
+            Some(range) if range.contains(value) => Ok(value),
             Some(ref range) => Err(ValidationError::OutOfRange {
                 parameter: "luminance",
                 value: value as f64,
-                min: range.start as f64,
-                max: (range.end - 1) as f64,
+                min: range.min() as f64,
+                max: range.max() as f64,
             }),
             None => Err(ValidationError::NotSupported("luminance")),
         }
@@ -153,12 +151,12 @@ pub trait ImageProcessingExt: ImageProcessing {
     /// Note: This method should only be called on profiles that support gamma.
     fn validate_gamma(&self, value: u8) -> Result<u8, ValidationError> {
         match Self::GAMMA_RANGE {
-            Some(ref range) if range.contains(&value) => Ok(value),
+            Some(range) if range.contains(value) => Ok(value),
             Some(ref range) => Err(ValidationError::OutOfRange {
                 parameter: "gamma",
                 value: value as f64,
-                min: range.start as f64,
-                max: (range.end - 1) as f64,
+                min: range.min() as f64,
+                max: range.max() as f64,
             }),
             None => Err(ValidationError::NotSupported("gamma")),
         }
@@ -198,13 +196,15 @@ mod tests {
     struct TestCamera;
 
     impl ImageProcessing for TestCamera {
-        const CONTRAST_RANGE: Option<Range<u8>> = Some(0..16);
-        const SHARPNESS_RANGE: Option<Range<u8>> = Some(0..16);
-        const SATURATION_RANGE: Option<Range<u8>> = Some(0..16);
+        const CONTRAST_RANGE: Option<CapabilityRange<u8>> = Some(CapabilityRange::<u8>::new(0, 15));
+        const SHARPNESS_RANGE: Option<CapabilityRange<u8>> =
+            Some(CapabilityRange::<u8>::new(0, 15));
+        const SATURATION_RANGE: Option<CapabilityRange<u8>> =
+            Some(CapabilityRange::<u8>::new(0, 15));
         const SUPPORTS_FLIP: bool = true;
         const SUPPORTS_MIRROR: bool = true;
         const SUPPORTS_HUE: bool = true;
-        const HUE_RANGE: Option<Range<u8>> = Some(0..15);
+        const HUE_RANGE: Option<CapabilityRange<u8>> = Some(CapabilityRange::<u8>::new(0, 14));
     }
 
     #[test]

--- a/src/capabilities/pan_tilt.rs
+++ b/src/capabilities/pan_tilt.rs
@@ -1,8 +1,8 @@
 //! Pan/Tilt capability trait and associated types.
 
-use std::{ops::Range, time::Duration};
+use std::time::Duration;
 
-use crate::capabilities::{CoordinateSystem, ValidationError};
+use crate::capabilities::{CapabilityRange, CoordinateSystem, ValidationError};
 
 /// Trait for cameras that support pan and tilt movement.
 ///
@@ -11,11 +11,11 @@ use crate::capabilities::{CoordinateSystem, ValidationError};
 pub trait PanTilt {
     /// Valid range for pan position in VISCA units.
     /// Typically maps to degrees based on camera model.
-    const PAN_RANGE: Range<i16>;
+    const PAN_RANGE: CapabilityRange<i16>;
 
     /// Valid range for tilt position in VISCA units.
     /// Typically maps to degrees based on camera model.
-    const TILT_RANGE: Range<i16>;
+    const TILT_RANGE: CapabilityRange<i16>;
 
     /// Maximum pan speed (0x01-0x18 for most cameras).
     const MAX_PAN_SPEED: u8;
@@ -48,28 +48,28 @@ pub trait PanTilt {
 pub trait PanTiltExt: PanTilt {
     /// Validate a pan position is within range.
     fn validate_pan(&self, pan: i16) -> Result<i16, ValidationError> {
-        if Self::PAN_RANGE.contains(&pan) {
+        if Self::PAN_RANGE.contains(pan) {
             Ok(pan)
         } else {
             Err(ValidationError::OutOfRange {
                 parameter: "pan",
                 value: pan as f64,
-                min: Self::PAN_RANGE.start as f64,
-                max: (Self::PAN_RANGE.end - 1) as f64,
+                min: Self::PAN_RANGE.min() as f64,
+                max: Self::PAN_RANGE.max() as f64,
             })
         }
     }
 
     /// Validate a tilt position is within range.
     fn validate_tilt(&self, tilt: i16) -> Result<i16, ValidationError> {
-        if Self::TILT_RANGE.contains(&tilt) {
+        if Self::TILT_RANGE.contains(tilt) {
             Ok(tilt)
         } else {
             Err(ValidationError::OutOfRange {
                 parameter: "tilt",
                 value: tilt as f64,
-                min: Self::TILT_RANGE.start as f64,
-                max: (Self::TILT_RANGE.end - 1) as f64,
+                min: Self::TILT_RANGE.min() as f64,
+                max: Self::TILT_RANGE.max() as f64,
             })
         }
     }
@@ -115,8 +115,8 @@ mod tests {
     struct TestCamera;
 
     impl PanTilt for TestCamera {
-        const PAN_RANGE: Range<i16> = -170..171;
-        const TILT_RANGE: Range<i16> = -30..91;
+        const PAN_RANGE: CapabilityRange<i16> = CapabilityRange::<i16>::new(-170, 170);
+        const TILT_RANGE: CapabilityRange<i16> = CapabilityRange::<i16>::new(-30, 90);
         const MAX_PAN_SPEED: u8 = 24;
         const MAX_TILT_SPEED: u8 = 24;
         const PAN_DEGREES_TO_UNITS: f32 = 100.0;

--- a/src/capabilities/presets.rs
+++ b/src/capabilities/presets.rs
@@ -1,8 +1,8 @@
 //! Preset capability trait and associated types.
 
-use std::{ops::Range, time::Duration};
+use std::time::Duration;
 
-use crate::capabilities::ValidationError;
+use crate::capabilities::{CapabilityRange, ValidationError};
 
 /// Trait for cameras that support preset positions.
 ///
@@ -13,7 +13,7 @@ pub trait Presets {
     const MAX_PRESETS: u8;
 
     /// Valid range for preset movement speed.
-    const PRESET_SPEED_RANGE: Range<u8>;
+    const PRESET_SPEED_RANGE: CapabilityRange<u8>;
 
     /// Whether camera supports preset tour functionality.
     const SUPPORTS_PRESET_TOUR: bool;
@@ -51,14 +51,14 @@ pub trait PresetsExt: Presets {
 
     /// Validate preset recall speed.
     fn validate_preset_speed(&self, speed: u8) -> Result<u8, ValidationError> {
-        if Self::PRESET_SPEED_RANGE.contains(&speed) {
+        if Self::PRESET_SPEED_RANGE.contains(speed) {
             Ok(speed)
         } else {
             Err(ValidationError::OutOfRange {
                 parameter: "preset speed",
                 value: speed as f64,
-                min: Self::PRESET_SPEED_RANGE.start as f64,
-                max: (Self::PRESET_SPEED_RANGE.end - 1) as f64,
+                min: Self::PRESET_SPEED_RANGE.min() as f64,
+                max: Self::PRESET_SPEED_RANGE.max() as f64,
             })
         }
     }
@@ -133,7 +133,7 @@ mod tests {
 
     impl Presets for TestCamera {
         const MAX_PRESETS: u8 = 89;
-        const PRESET_SPEED_RANGE: Range<u8> = 1..25;
+        const PRESET_SPEED_RANGE: CapabilityRange<u8> = CapabilityRange::<u8>::new(1, 24);
         const SUPPORTS_PRESET_TOUR: bool = true;
         const PRESET_RECALL_DELAY: Duration = Duration::from_millis(100);
     }

--- a/src/capabilities/types.rs
+++ b/src/capabilities/types.rs
@@ -1,7 +1,80 @@
 //! Supporting types used across capability traits.
 
+use std::ops::RangeInclusive;
+
 // Re-export types that are used by multiple capability traits
 pub use crate::capabilities::exposure::ShutterSpeed;
+
+/// Inclusive numeric bounds for profile capability metadata.
+///
+/// VISCA profile facts are closed ranges: both endpoints are supported values.
+/// This type keeps those protocol facts explicit in profile traits and registry
+/// literals while still exposing standard [`RangeInclusive`] values for runtime
+/// discovery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct CapabilityRange<T> {
+    min: T,
+    max: T,
+}
+
+macro_rules! impl_capability_range {
+    ($ty:ty) => {
+        impl CapabilityRange<$ty> {
+            /// Creates an inclusive capability range.
+            ///
+            /// # Panics
+            /// Panics when `min > max`.
+            #[must_use]
+            pub const fn new(min: $ty, max: $ty) -> Self {
+                assert!(min <= max, "capability range minimum exceeds maximum");
+                Self { min, max }
+            }
+
+            /// Returns the inclusive minimum value.
+            #[must_use]
+            pub const fn min(self) -> $ty {
+                self.min
+            }
+
+            /// Returns the inclusive maximum value.
+            #[must_use]
+            pub const fn max(self) -> $ty {
+                self.max
+            }
+
+            /// Returns true when `value` is within the closed bounds.
+            #[must_use]
+            pub const fn contains(self, value: $ty) -> bool {
+                value >= self.min && value <= self.max
+            }
+
+            /// Clamps `value` to the closed bounds.
+            #[must_use]
+            pub const fn clamp(self, value: $ty) -> $ty {
+                if value < self.min {
+                    self.min
+                } else if value > self.max {
+                    self.max
+                } else {
+                    value
+                }
+            }
+
+            /// Converts the closed bounds to a standard inclusive range.
+            #[must_use]
+            pub fn as_inclusive(self) -> RangeInclusive<$ty> {
+                self.min..=self.max
+            }
+        }
+    };
+}
+
+impl_capability_range!(u8);
+impl_capability_range!(u16);
+impl_capability_range!(i8);
+impl_capability_range!(i16);
 
 /// Coordinate system used by a camera for pan/tilt positions.
 ///
@@ -57,6 +130,85 @@ impl CoordinateSystem {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn capability_range_constructs_valid_signed_and_unsigned_ranges() {
+        assert_eq!(CapabilityRange::<u8>::new(1_u8, 3).as_inclusive(), 1..=3);
+        assert_eq!(
+            CapabilityRange::<u16>::new(0_u16, 10).as_inclusive(),
+            0..=10
+        );
+        assert_eq!(CapabilityRange::<i8>::new(-7_i8, 7).as_inclusive(), -7..=7);
+        assert_eq!(
+            CapabilityRange::<i16>::new(-170_i16, 170).as_inclusive(),
+            -170..=170
+        );
+    }
+
+    #[test]
+    fn capability_range_rejects_inverted_ranges() {
+        assert!(std::panic::catch_unwind(|| CapabilityRange::<u8>::new(2_u8, 1)).is_err());
+        assert!(std::panic::catch_unwind(|| CapabilityRange::<u16>::new(2_u16, 1)).is_err());
+        assert!(std::panic::catch_unwind(|| CapabilityRange::<i8>::new(2_i8, 1)).is_err());
+        assert!(std::panic::catch_unwind(|| CapabilityRange::<i16>::new(2_i16, 1)).is_err());
+    }
+
+    #[test]
+    fn capability_range_allows_single_value_ranges() {
+        let range = CapabilityRange::<u8>::new(5_u8, 5);
+
+        assert_eq!(range.min(), 5);
+        assert_eq!(range.max(), 5);
+        assert!(range.contains(5));
+        assert!(!range.contains(4));
+        assert_eq!(range.clamp(4), 5);
+        assert_eq!(range.clamp(6), 5);
+        assert_eq!(range.as_inclusive(), 5..=5);
+    }
+
+    #[test]
+    fn capability_range_represents_full_width_u8_ranges() {
+        let range = CapabilityRange::<u8>::new(0_u8, u8::MAX);
+
+        assert!(range.contains(0));
+        assert!(range.contains(u8::MAX));
+        assert_eq!(range.as_inclusive(), 0..=u8::MAX);
+    }
+
+    #[test]
+    fn capability_range_methods_work_for_supported_primitives() {
+        let u8_range = CapabilityRange::<u8>::new(1_u8, 3);
+        assert_eq!(u8_range.min(), 1);
+        assert_eq!(u8_range.max(), 3);
+        assert!(u8_range.contains(2));
+        assert_eq!(u8_range.clamp(0), 1);
+        assert_eq!(u8_range.clamp(4), 3);
+        assert_eq!(u8_range.as_inclusive(), 1..=3);
+
+        let u16_range = CapabilityRange::<u16>::new(10_u16, 12);
+        assert_eq!(u16_range.min(), 10);
+        assert_eq!(u16_range.max(), 12);
+        assert!(u16_range.contains(11));
+        assert_eq!(u16_range.clamp(9), 10);
+        assert_eq!(u16_range.clamp(13), 12);
+        assert_eq!(u16_range.as_inclusive(), 10..=12);
+
+        let i8_range = CapabilityRange::<i8>::new(-2_i8, 2);
+        assert_eq!(i8_range.min(), -2);
+        assert_eq!(i8_range.max(), 2);
+        assert!(i8_range.contains(0));
+        assert_eq!(i8_range.clamp(-3), -2);
+        assert_eq!(i8_range.clamp(3), 2);
+        assert_eq!(i8_range.as_inclusive(), -2..=2);
+
+        let i16_range = CapabilityRange::<i16>::new(-20_i16, 20);
+        assert_eq!(i16_range.min(), -20);
+        assert_eq!(i16_range.max(), 20);
+        assert!(i16_range.contains(0));
+        assert_eq!(i16_range.clamp(-21), -20);
+        assert_eq!(i16_range.clamp(21), 20);
+        assert_eq!(i16_range.as_inclusive(), -20..=20);
+    }
 
     #[test]
     fn test_signed_centered_coordinates() {

--- a/src/capabilities/white_balance.rs
+++ b/src/capabilities/white_balance.rs
@@ -1,8 +1,11 @@
 //! White balance capability trait and associated types.
 
-use std::{borrow::Cow, ops::Range};
+use std::borrow::Cow;
 
-use crate::{capabilities::ValidationError, WhiteBalanceMode};
+use crate::{
+    capabilities::{CapabilityRange, ValidationError},
+    WhiteBalanceMode,
+};
 
 /// Trait for cameras that support white balance control.
 ///
@@ -18,26 +21,26 @@ pub trait WhiteBalance {
 
     /// Red/Green tuning range for manual adjustment.
     /// None if not supported.
-    const RG_TUNING_RANGE: Option<Range<i8>>;
+    const RG_TUNING_RANGE: Option<CapabilityRange<i8>>;
 
     /// Blue/Green tuning range for manual adjustment.
     /// None if not supported.
-    const BG_TUNING_RANGE: Option<Range<i8>>;
+    const BG_TUNING_RANGE: Option<CapabilityRange<i8>>;
 
     /// Whether camera supports direct color temperature setting.
     const SUPPORTS_COLOR_TEMP: bool = false;
 
     /// Color temperature range in Kelvin if supported.
-    const COLOR_TEMP_RANGE: Option<Range<u16>> = None;
+    const COLOR_TEMP_RANGE: Option<CapabilityRange<u16>> = None;
 
     /// Whether camera supports manual RGB gain control.
     const SUPPORTS_RGB_GAIN: bool = false;
 
     /// Red gain range if supported.
-    const RED_GAIN_RANGE: Option<Range<u8>> = None;
+    const RED_GAIN_RANGE: Option<CapabilityRange<u8>> = None;
 
     /// Blue gain range if supported.
-    const BLUE_GAIN_RANGE: Option<Range<u8>> = None;
+    const BLUE_GAIN_RANGE: Option<CapabilityRange<u8>> = None;
 }
 
 /// Extension trait that adds validation methods to cameras with white balance support.
@@ -65,12 +68,12 @@ pub trait WhiteBalanceExt: WhiteBalance {
     /// Validate RG tuning value.
     fn validate_rg_tuning(&self, value: i8) -> Result<i8, ValidationError> {
         match Self::RG_TUNING_RANGE {
-            Some(ref range) if range.contains(&value) => Ok(value),
+            Some(range) if range.contains(value) => Ok(value),
             Some(ref range) => Err(ValidationError::OutOfRange {
                 parameter: "RG tuning",
                 value: value as f64,
-                min: range.start as f64,
-                max: (range.end - 1) as f64,
+                min: range.min() as f64,
+                max: range.max() as f64,
             }),
             None => Err(ValidationError::NotSupported("RG tuning")),
         }
@@ -79,12 +82,12 @@ pub trait WhiteBalanceExt: WhiteBalance {
     /// Validate BG tuning value.
     fn validate_bg_tuning(&self, value: i8) -> Result<i8, ValidationError> {
         match Self::BG_TUNING_RANGE {
-            Some(ref range) if range.contains(&value) => Ok(value),
+            Some(range) if range.contains(value) => Ok(value),
             Some(ref range) => Err(ValidationError::OutOfRange {
                 parameter: "BG tuning",
                 value: value as f64,
-                min: range.start as f64,
-                max: (range.end - 1) as f64,
+                min: range.min() as f64,
+                max: range.max() as f64,
             }),
             None => Err(ValidationError::NotSupported("BG tuning")),
         }
@@ -95,12 +98,12 @@ pub trait WhiteBalanceExt: WhiteBalance {
     /// Returns `NotSupported` error if `COLOR_TEMP_RANGE` is `None`.
     fn validate_color_temp(&self, kelvin: u16) -> Result<u16, ValidationError> {
         match Self::COLOR_TEMP_RANGE {
-            Some(ref range) if range.contains(&kelvin) => Ok(kelvin),
+            Some(range) if range.contains(kelvin) => Ok(kelvin),
             Some(ref range) => Err(ValidationError::OutOfRange {
                 parameter: "color temperature",
                 value: kelvin as f64,
-                min: range.start as f64,
-                max: (range.end - 1) as f64,
+                min: range.min() as f64,
+                max: range.max() as f64,
             }),
             None => Err(ValidationError::NotSupported("color temperature")),
         }
@@ -111,12 +114,12 @@ pub trait WhiteBalanceExt: WhiteBalance {
     /// Returns `NotSupported` error if `RED_GAIN_RANGE` is `None`.
     fn validate_red_gain(&self, gain: u8) -> Result<u8, ValidationError> {
         match Self::RED_GAIN_RANGE {
-            Some(ref range) if range.contains(&gain) => Ok(gain),
+            Some(range) if range.contains(gain) => Ok(gain),
             Some(ref range) => Err(ValidationError::OutOfRange {
                 parameter: "red gain",
                 value: gain as f64,
-                min: range.start as f64,
-                max: (range.end - 1) as f64,
+                min: range.min() as f64,
+                max: range.max() as f64,
             }),
             None => Err(ValidationError::NotSupported("red gain")),
         }
@@ -127,12 +130,12 @@ pub trait WhiteBalanceExt: WhiteBalance {
     /// Returns `NotSupported` error if `BLUE_GAIN_RANGE` is `None`.
     fn validate_blue_gain(&self, gain: u8) -> Result<u8, ValidationError> {
         match Self::BLUE_GAIN_RANGE {
-            Some(ref range) if range.contains(&gain) => Ok(gain),
+            Some(range) if range.contains(gain) => Ok(gain),
             Some(ref range) => Err(ValidationError::OutOfRange {
                 parameter: "blue gain",
                 value: gain as f64,
-                min: range.start as f64,
-                max: (range.end - 1) as f64,
+                min: range.min() as f64,
+                max: range.max() as f64,
             }),
             None => Err(ValidationError::NotSupported("blue gain")),
         }
@@ -162,10 +165,18 @@ mod tests {
     impl WhiteBalance for TestCamera {
         const WB_MODES: &'static [WhiteBalanceMode] = TEST_WB_MODES;
         const SUPPORTS_ONE_PUSH_WB: bool = true;
-        const RG_TUNING_RANGE: Option<Range<i8>> = Some(-7..8);
-        const BG_TUNING_RANGE: Option<Range<i8>> = Some(-7..8);
+        const RG_TUNING_RANGE: Option<CapabilityRange<i8>> =
+            Some(CapabilityRange::<i8>::new(-7, 7));
+        const BG_TUNING_RANGE: Option<CapabilityRange<i8>> =
+            Some(CapabilityRange::<i8>::new(-7, 7));
         const SUPPORTS_COLOR_TEMP: bool = true;
-        const COLOR_TEMP_RANGE: Option<Range<u16>> = Some(2800..7500);
+        const COLOR_TEMP_RANGE: Option<CapabilityRange<u16>> =
+            Some(CapabilityRange::<u16>::new(2800, 7499));
+        const SUPPORTS_RGB_GAIN: bool = true;
+        const RED_GAIN_RANGE: Option<CapabilityRange<u8>> =
+            Some(CapabilityRange::<u8>::new(0x00, 0xFF));
+        const BLUE_GAIN_RANGE: Option<CapabilityRange<u8>> =
+            Some(CapabilityRange::<u8>::new(0x00, 0xFF));
     }
 
     #[test]
@@ -199,5 +210,15 @@ mod tests {
         assert!(camera.validate_color_temp(5600).is_ok());
         assert!(camera.validate_color_temp(2799).is_err());
         assert!(camera.validate_color_temp(7500).is_err());
+    }
+
+    #[test]
+    fn test_full_width_rgb_gain_validation() {
+        let camera = TestCamera;
+
+        assert!(camera.validate_red_gain(0x00).is_ok());
+        assert!(camera.validate_red_gain(0xFF).is_ok());
+        assert!(camera.validate_blue_gain(0x00).is_ok());
+        assert!(camera.validate_blue_gain(0xFF).is_ok());
     }
 }

--- a/src/capabilities/zoom.rs
+++ b/src/capabilities/zoom.rs
@@ -1,8 +1,8 @@
 //! Zoom capability trait and associated types.
 
-use std::{borrow::Cow, ops::Range};
+use std::borrow::Cow;
 
-use crate::capabilities::ValidationError;
+use crate::capabilities::{CapabilityRange, ValidationError};
 
 /// Trait for cameras that support zoom operations.
 ///
@@ -19,7 +19,7 @@ pub trait Zoom {
 
     /// Valid range for variable zoom speed.
     /// Usually 0-7 where 0 is slowest, 7 is fastest.
-    const ZOOM_SPEED_RANGE: Range<u8>;
+    const ZOOM_SPEED_RANGE: CapabilityRange<u8>;
 
     /// Whether camera supports direct zoom positioning.
     /// If false, zoom must be achieved through zoom in/out commands.
@@ -53,7 +53,7 @@ pub trait ZoomExt: Zoom {
 
     /// Validate and clamp zoom speed to valid range.
     fn validate_zoom_speed(&self, speed: u8) -> u8 {
-        speed.clamp(Self::ZOOM_SPEED_RANGE.start, Self::ZOOM_SPEED_RANGE.end - 1)
+        Self::ZOOM_SPEED_RANGE.clamp(speed)
     }
 
     /// Check if position is in digital zoom range.
@@ -100,7 +100,7 @@ mod tests {
     impl Zoom for TestCamera {
         const OPTICAL_ZOOM_MAX: u16 = 0x4000;
         const DIGITAL_ZOOM_MAX: Option<u16> = Some(0x7000);
-        const ZOOM_SPEED_RANGE: Range<u8> = 0..8;
+        const ZOOM_SPEED_RANGE: CapabilityRange<u8> = CapabilityRange::<u8>::new(0, 7);
         const ZOOM_MAGNIFICATION_TO_UNITS: f32 = 862.3; // (0x4000 - 1) / 19 for 20x zoom
     }
 

--- a/tests/common/profile_fixtures.rs
+++ b/tests/common/profile_fixtures.rs
@@ -2,9 +2,9 @@ use std::time::Duration;
 
 use grafton_visca::{
     capabilities::{
-        exposure::ShutterSpeed, Exposure, Focus, HasDirectZoom, ImageProcessing, InquirySupport,
-        MenuCapability, MotionSyncMetadata, NdFilterMetadata, PanTilt, Power, Presets,
-        ProfileMetadata, ProfileTypedSupport, Tally, TypedSupportSet, TypedSupportSurface,
+        exposure::ShutterSpeed, CapabilityRange, Exposure, Focus, HasDirectZoom, ImageProcessing,
+        InquirySupport, MenuCapability, MotionSyncMetadata, NdFilterMetadata, PanTilt, Power,
+        Presets, ProfileMetadata, ProfileTypedSupport, Tally, TypedSupportSet, TypedSupportSurface,
         VariableSpeedMetadata, WhiteBalance, Zoom,
     },
     command::ExposureMode,
@@ -37,8 +37,8 @@ macro_rules! synthetic_profile {
         }
 
         impl PanTilt for $profile {
-            const PAN_RANGE: std::ops::Range<i16> = -1700..1701;
-            const TILT_RANGE: std::ops::Range<i16> = -300..901;
+            const PAN_RANGE: CapabilityRange<i16> = CapabilityRange::<i16>::new(-1700, 1700);
+            const TILT_RANGE: CapabilityRange<i16> = CapabilityRange::<i16>::new(-300, 900);
             const MAX_PAN_SPEED: u8 = 24;
             const MAX_TILT_SPEED: u8 = 20;
             const PAN_DEGREES_TO_UNITS: f32 = 10.0;
@@ -48,7 +48,7 @@ macro_rules! synthetic_profile {
         impl Zoom for $profile {
             const OPTICAL_ZOOM_MAX: u16 = 0x4000;
             const DIGITAL_ZOOM_MAX: Option<u16> = Some(0x7000);
-            const ZOOM_SPEED_RANGE: std::ops::Range<u8> = 0..8;
+            const ZOOM_SPEED_RANGE: CapabilityRange<u8> = CapabilityRange::<u8>::new(0, 7);
             const SUPPORTS_DIRECT_ZOOM: bool = true;
             const ZOOM_MAGNIFICATION_TO_UNITS: f32 = 862.3;
         }
@@ -64,30 +64,30 @@ macro_rules! synthetic_profile {
 
         impl Exposure for $profile {
             const EXPOSURE_MODES: &'static [ExposureMode] = EXPOSURE_MODES;
-            const IRIS_RANGE: Option<std::ops::Range<u16>> = None;
+            const IRIS_RANGE: Option<CapabilityRange<u16>> = None;
             const SHUTTER_SPEEDS: &'static [ShutterSpeed] = SHUTTER_SPEEDS;
-            const GAIN_RANGE: std::ops::Range<u8> = 0..16;
+            const GAIN_RANGE: CapabilityRange<u8> = CapabilityRange::<u8>::new(0, 15);
             const SUPPORTS_BACKLIGHT_COMP: bool = false;
         }
 
         impl WhiteBalance for $profile {
             const WB_MODES: &'static [WhiteBalanceMode] = WB_MODES;
             const SUPPORTS_ONE_PUSH_WB: bool = false;
-            const RG_TUNING_RANGE: Option<std::ops::Range<i8>> = None;
-            const BG_TUNING_RANGE: Option<std::ops::Range<i8>> = None;
+            const RG_TUNING_RANGE: Option<CapabilityRange<i8>> = None;
+            const BG_TUNING_RANGE: Option<CapabilityRange<i8>> = None;
         }
 
         impl ImageProcessing for $profile {
-            const CONTRAST_RANGE: Option<std::ops::Range<u8>> = None;
-            const SHARPNESS_RANGE: Option<std::ops::Range<u8>> = None;
-            const SATURATION_RANGE: Option<std::ops::Range<u8>> = None;
+            const CONTRAST_RANGE: Option<CapabilityRange<u8>> = None;
+            const SHARPNESS_RANGE: Option<CapabilityRange<u8>> = None;
+            const SATURATION_RANGE: Option<CapabilityRange<u8>> = None;
             const SUPPORTS_FLIP: bool = false;
             const SUPPORTS_MIRROR: bool = false;
         }
 
         impl Presets for $profile {
             const MAX_PRESETS: u8 = 6;
-            const PRESET_SPEED_RANGE: std::ops::Range<u8> = 1..24;
+            const PRESET_SPEED_RANGE: CapabilityRange<u8> = CapabilityRange::<u8>::new(1, 23);
             const SUPPORTS_PRESET_TOUR: bool = false;
         }
 

--- a/tests/compile_time_safety.rs
+++ b/tests/compile_time_safety.rs
@@ -26,8 +26,8 @@ fn test_profile_constants() {
     assert_eq!(SonyFR7::MODEL_NAME, "Sony FR7");
     assert_eq!(GenericVisca::MODEL_NAME, "Generic VISCA Camera");
 
-    assert_eq!(PtzOpticsG2::ZOOM_SPEED_RANGE, 0..8);
-    assert_eq!(SonyFR7::ZOOM_SPEED_RANGE, 0..8);
+    assert_eq!(PtzOpticsG2::ZOOM_SPEED_RANGE.as_inclusive(), 0..=7);
+    assert_eq!(SonyFR7::ZOOM_SPEED_RANGE.as_inclusive(), 0..=7);
 
     assert_eq!(PtzOpticsG2::MAX_PAN_SPEED, 24);
     assert_eq!(SonyFR7::MAX_PAN_SPEED, 24);

--- a/tests/inquiry_integration_tests.rs
+++ b/tests/inquiry_integration_tests.rs
@@ -12,9 +12,9 @@ use std::time::Duration;
 use grafton_visca::{
     camera::{profiles::GenericVisca, CameraBuilder},
     capabilities::{
-        exposure::ShutterSpeed, Exposure, Focus, HasBacklightCompensation, HasBrightnessControl,
-        HasColorTemperature, HasContrastControl, HasExposureCompensation, HasHueControl,
-        HasImageFlip, HasIrisControl, HasLuminanceControl, HasNoiseReduction2D,
+        exposure::ShutterSpeed, CapabilityRange, Exposure, Focus, HasBacklightCompensation,
+        HasBrightnessControl, HasColorTemperature, HasContrastControl, HasExposureCompensation,
+        HasHueControl, HasImageFlip, HasIrisControl, HasLuminanceControl, HasNoiseReduction2D,
         HasNoiseReduction3D, HasSaturationControl, HasSharpnessControl, ImageProcessing,
         InquirySupport, MenuCapability, MotionSyncMetadata, NdFilterMetadata, PanTilt, Power,
         Presets, ProfileMetadata, ProfileTypedSupport, Tally, TypedSupportSet,
@@ -57,8 +57,8 @@ impl ProfileMetadata for SimulatorFullProfile {
 }
 
 impl PanTilt for SimulatorFullProfile {
-    const PAN_RANGE: std::ops::Range<i16> = -2880..2881;
-    const TILT_RANGE: std::ops::Range<i16> = -1440..1441;
+    const PAN_RANGE: CapabilityRange<i16> = CapabilityRange::<i16>::new(-2880, 2880);
+    const TILT_RANGE: CapabilityRange<i16> = CapabilityRange::<i16>::new(-1440, 1440);
     const MAX_PAN_SPEED: u8 = 24;
     const MAX_TILT_SPEED: u8 = 24;
     const PAN_DEGREES_TO_UNITS: f32 = 16.0;
@@ -68,7 +68,7 @@ impl PanTilt for SimulatorFullProfile {
 impl Zoom for SimulatorFullProfile {
     const OPTICAL_ZOOM_MAX: u16 = 0xFFFF;
     const DIGITAL_ZOOM_MAX: Option<u16> = None;
-    const ZOOM_SPEED_RANGE: std::ops::Range<u8> = 0..8;
+    const ZOOM_SPEED_RANGE: CapabilityRange<u8> = CapabilityRange::<u8>::new(0, 7);
     const SUPPORTS_DIRECT_ZOOM: bool = false;
     const ZOOM_MAGNIFICATION_TO_UNITS: f32 = 1000.0;
 }
@@ -82,10 +82,10 @@ impl MenuCapability for SimulatorFullProfile {}
 
 impl Exposure for SimulatorFullProfile {
     const EXPOSURE_MODES: &'static [ExposureMode] = SIM_EXPOSURE_MODES;
-    const IRIS_RANGE: Option<std::ops::Range<u16>> = Some(0x00..0x1D);
+    const IRIS_RANGE: Option<CapabilityRange<u16>> = Some(CapabilityRange::<u16>::new(0x00, 0x1C));
     const SHUTTER_SPEEDS: &'static [ShutterSpeed] = SIM_SHUTTER_SPEEDS;
-    const GAIN_RANGE: std::ops::Range<u8> = 0..16;
-    const BRIGHTNESS_RANGE: Option<std::ops::Range<u16>> = Some(0..18);
+    const GAIN_RANGE: CapabilityRange<u8> = CapabilityRange::<u8>::new(0, 15);
+    const BRIGHTNESS_RANGE: Option<CapabilityRange<u16>> = Some(CapabilityRange::<u16>::new(0, 17));
     const SUPPORTS_BACKLIGHT_COMP: bool = true;
     const SUPPORTS_EXPOSURE_COMP: bool = true;
     const SUPPORTS_WDR: bool = true;
@@ -94,13 +94,16 @@ impl Exposure for SimulatorFullProfile {
 impl WhiteBalance for SimulatorFullProfile {
     const WB_MODES: &'static [WhiteBalanceMode] = SIM_WB_MODES;
     const SUPPORTS_ONE_PUSH_WB: bool = true;
-    const RG_TUNING_RANGE: Option<std::ops::Range<i8>> = Some(-7..8);
-    const BG_TUNING_RANGE: Option<std::ops::Range<i8>> = Some(-7..8);
+    const RG_TUNING_RANGE: Option<CapabilityRange<i8>> = Some(CapabilityRange::<i8>::new(-7, 7));
+    const BG_TUNING_RANGE: Option<CapabilityRange<i8>> = Some(CapabilityRange::<i8>::new(-7, 7));
     const SUPPORTS_COLOR_TEMP: bool = true;
-    const COLOR_TEMP_RANGE: Option<std::ops::Range<u16>> = Some(2800..7500);
+    const COLOR_TEMP_RANGE: Option<CapabilityRange<u16>> =
+        Some(CapabilityRange::<u16>::new(2800, 7499));
     const SUPPORTS_RGB_GAIN: bool = true;
-    const RED_GAIN_RANGE: Option<std::ops::Range<u8>> = Some(0..255);
-    const BLUE_GAIN_RANGE: Option<std::ops::Range<u8>> = Some(0..255);
+    const RED_GAIN_RANGE: Option<CapabilityRange<u8>> =
+        Some(CapabilityRange::<u8>::new(0x00, 0xFF));
+    const BLUE_GAIN_RANGE: Option<CapabilityRange<u8>> =
+        Some(CapabilityRange::<u8>::new(0x00, 0xFF));
 }
 
 impl Focus for SimulatorFullProfile {
@@ -111,23 +114,23 @@ impl Focus for SimulatorFullProfile {
 }
 
 impl ImageProcessing for SimulatorFullProfile {
-    const CONTRAST_RANGE: Option<std::ops::Range<u8>> = Some(0..15);
-    const SHARPNESS_RANGE: Option<std::ops::Range<u8>> = Some(0..15);
-    const SATURATION_RANGE: Option<std::ops::Range<u8>> = Some(0..15);
+    const CONTRAST_RANGE: Option<CapabilityRange<u8>> = Some(CapabilityRange::<u8>::new(0, 14));
+    const SHARPNESS_RANGE: Option<CapabilityRange<u8>> = Some(CapabilityRange::<u8>::new(0, 14));
+    const SATURATION_RANGE: Option<CapabilityRange<u8>> = Some(CapabilityRange::<u8>::new(0, 14));
     const SUPPORTS_FLIP: bool = true;
     const SUPPORTS_MIRROR: bool = true;
     const SUPPORTS_HUE: bool = true;
-    const HUE_RANGE: Option<std::ops::Range<u8>> = Some(0..15);
+    const HUE_RANGE: Option<CapabilityRange<u8>> = Some(CapabilityRange::<u8>::new(0, 14));
     const SUPPORTS_NOISE_REDUCTION: bool = true;
     const SUPPORTS_2D_NR: bool = true;
     const SUPPORTS_3D_NR: bool = true;
     const SUPPORTS_LUMINANCE: bool = true;
-    const LUMINANCE_RANGE: Option<std::ops::Range<u8>> = Some(0..15);
+    const LUMINANCE_RANGE: Option<CapabilityRange<u8>> = Some(CapabilityRange::<u8>::new(0, 14));
 }
 
 impl Presets for SimulatorFullProfile {
     const MAX_PRESETS: u8 = 6;
-    const PRESET_SPEED_RANGE: std::ops::Range<u8> = 1..24;
+    const PRESET_SPEED_RANGE: CapabilityRange<u8> = CapabilityRange::<u8>::new(1, 23);
     const SUPPORTS_PRESET_TOUR: bool = false;
     const SUPPORTS_PRESET_THUMBNAIL: bool = false;
 }


### PR DESCRIPTION
## Summary
- add public validated CapabilityRange<T> and migrate profile capability bounds to inclusive min/max ranges
- update discovery, registry, validation helpers, controls, tests, and examples to use inclusive capability metadata
- expose missing discovered ranges and derive focus speed from profile metadata

## Verification
- cargo clippy --all-targets --all-features -- -D warnings
- bash .github/scripts/test-all-features.sh
- git diff --check

Closes #532