### PR TITLE
Fix ambiguous endpoint parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+#### Unambiguous Network Endpoint Parsing (#534)
+- **BREAKING**: Bare IPv6 literals are no longer interpreted as host-plus-port endpoints. `2001:db8::1:5678` is treated as the IPv6 host `2001:db8::1:5678`; with a profile/default port it canonicalizes to `[2001:db8::1:5678]:<default>`.
+- Explicit IPv6 ports now require brackets, for example `[2001:db8::1]:5678`. Missing ports without a profile/default port now return `Error::InvalidAddress` before DNS or socket work.
+- Low-level TCP/UDP transport constructors and runtime adapter connectors now use the same endpoint grammar as camera-first connection paths. IPv6 zone identifiers are rejected explicitly.
+
 #### Profile-Aware Direct Zoom Positioning (#529)
 - **BREAKING**: Direct zoom setters now distinguish raw and normalized command paths. `set_zoom` accepts only a checked raw `ZoomPosition`; use `set_zoom_normalized(UnitInterval)` for optical normalized zoom and `set_zoom_normalized_in_domain(UnitInterval, ZoomDomain)` for documented optical-plus-digital ranges.
 - **BREAKING**: Profile-independent `ZoomPosition` conversions from `f32`, `UnitInterval`, `Percentage`, and `Magnification` were removed. `Raw<u16>` conversion is now checked through `TryFrom<Raw<u16>>` and invalid raw values return an error instead of falling back to minimum zoom.

--- a/src/camera/config.rs
+++ b/src/camera/config.rs
@@ -244,16 +244,17 @@ where
 
     /// Set the connection address.
     ///
-    /// For TCP/UDP, this should be a host:port string like "192.168.0.110:5678".
-    /// If no port is specified, the profile's default port will be used.
+    /// For TCP/UDP, this may be a host:port string like `"192.168.0.110:5678"`
+    /// or a host-only address when a profile/default port is available.
     ///
-    /// This method properly handles IPv6 addresses with and without brackets.
-    /// Unbracketed IPv6 addresses with ports (e.g., `2001:db8::1:5678`) are automatically
-    /// canonicalized to the bracketed form (`[2001:db8::1]:5678`).
+    /// Bare IPv6 may be used only when the port comes from the profile/default
+    /// port. Explicit IPv6 ports require brackets, so `2001:db8::1:5678` is a
+    /// bare IPv6 literal and `[2001:db8::1]:5678` is an IPv6 address with port
+    /// `5678`.
     ///
     /// Examples:
     /// - IPv4: `"192.168.1.1"`, `"192.168.1.1:5678"`
-    /// - IPv6: `"::1"`, `"[::1]:5678"`, `"2001:db8::1"`, `"2001:db8::1:5678"`
+    /// - IPv6: `"::1"`, `"2001:db8::1"`, `"[::1]:5678"`
     /// - Hostnames: `"localhost"`, `"camera.local:5678"`
     pub fn address(mut self, address: impl Into<String>) -> Self {
         let addr = address.into();

--- a/src/camera/convenience.rs
+++ b/src/camera/convenience.rs
@@ -167,7 +167,7 @@ impl Connect {
     /// Returns a camera using BlockingTransportHandle for zero-cost operation.
     ///
     /// If no port is specified in the address, the profile's TCP default will be used.
-    /// IPv6 addresses are properly canonicalized (e.g., `2001:db8::1:5678` becomes `[2001:db8::1]:5678`).
+    /// Bare IPv6 may use that default port; explicit IPv6 ports require brackets.
     ///
     /// # Example
     ///
@@ -180,7 +180,7 @@ impl Connect {
     /// // Without port - uses PtzOpticsG2's TCP default (5678)
     /// let cam = Connect::open_tcp_blocking::<PtzOpticsG2>("192.168.0.110")?;
     ///
-    /// // IPv6 with explicit port (canonicalized automatically)
+    /// // IPv6 with explicit port
     /// let cam = Connect::open_tcp_blocking::<PtzOpticsG2>("[::1]:5678")?;
     /// ```
     pub fn open_tcp_blocking<P>(
@@ -207,7 +207,7 @@ impl Connect {
     /// Returns a camera using BlockingTransportHandle for zero-cost operation.
     ///
     /// If no port is specified in the address, the profile's UDP default will be used.
-    /// IPv6 addresses are properly canonicalized (e.g., `2001:db8::1:1259` becomes `[2001:db8::1]:1259`).
+    /// Bare IPv6 may use that default port; explicit IPv6 ports require brackets.
     ///
     /// # Example
     ///
@@ -220,7 +220,7 @@ impl Connect {
     /// // Without port - uses GenericVisca's UDP default (1259)
     /// let cam = Connect::open_udp_blocking::<GenericVisca>("192.168.0.110")?;
     ///
-    /// // IPv6 with explicit port (canonicalized automatically)
+    /// // IPv6 with explicit port
     /// let cam = Connect::open_udp_blocking::<GenericVisca>("[::1]:1259")?;
     /// ```
     pub fn open_udp_blocking<P>(

--- a/src/runtime/traits.rs
+++ b/src/runtime/traits.rs
@@ -47,6 +47,8 @@ pub trait Runtime: Executor + Clone + Send + Sync + 'static {
     ///
     /// This method creates a TCP transport using the runtime's specific
     /// implementation. The transport is configured with the provided settings.
+    /// Runtime connectors have no profile default port, so `addr` must include
+    /// an explicit port. Explicit IPv6 ports require brackets.
     async fn connect_tcp(
         &self,
         addr: &str,
@@ -57,6 +59,8 @@ pub trait Runtime: Executor + Clone + Send + Sync + 'static {
     ///
     /// This method creates a UDP transport using the runtime's specific
     /// implementation. The transport is configured with the provided settings.
+    /// Runtime connectors have no profile default port, so `addr` must include
+    /// an explicit port. Explicit IPv6 ports require brackets.
     async fn connect_udp(
         &self,
         addr: &str,

--- a/src/transport/address.rs
+++ b/src/transport/address.rs
@@ -3,326 +3,180 @@
 //! This module provides a unified way to resolve network addresses across
 //! different transport types, eliminating code duplication.
 
-#[cfg(test)]
 use std::borrow::Cow;
-#[cfg(any(
-    not(feature = "mode-async"),
-    feature = "runtime-tokio",
-    feature = "runtime-smol",
-    test
-))]
-use std::net::SocketAddr;
 #[cfg(any(not(feature = "mode-async"), test))]
 use std::net::ToSocketAddrs;
+use std::{
+    net::{IpAddr, Ipv6Addr, SocketAddr},
+    num::NonZeroU16,
+};
 
 use crate::Error;
 
-/// Represents a parsed host:port combination that handles IPv6 addresses correctly.
-///
-/// This enum properly distinguishes between IPv6 address colons and port separators,
-/// solving common parsing issues where `host.contains(':')` or `host.rfind(':')`
-/// fail with IPv6 addresses.
+/// Endpoint parsed from caller input before a default port is applied.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum HostPort {
-    /// IPv4 address with optional port
-    Ipv4 {
-        /// IPv4 host address string
-        host: String,
-        /// Optional port number
-        port: Option<u16>,
-    },
-    /// IPv6 address with optional port (brackets handled automatically)
-    Ipv6 {
-        /// IPv6 host address string (without brackets)
-        host: String,
-        /// Optional port number
-        port: Option<u16>,
-    },
-    /// Hostname with optional port
-    Hostname {
-        /// Hostname string
-        host: String,
-        /// Optional port number
-        port: Option<u16>,
-    },
+struct ParsedEndpoint {
+    host: Host,
+    port: Option<NonZeroU16>,
 }
 
-impl HostPort {
-    /// Parse a host:port string, correctly handling IPv6 addresses.
-    ///
-    /// This function correctly handles:
-    /// - IPv4: `192.168.1.1`, `192.168.1.1:5678`
-    /// - IPv6: `::1`, `[::1]`, `[::1]:5678`, `2001:db8::1`, `[2001:db8::1]:5678`
-    /// - IPv6 with zone: `[fe80::1%eth0]:5678`
-    /// - Hostnames: `localhost`, `camera.local:5678`
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use grafton_visca::transport::address::HostPort;
-    ///
-    /// // IPv4 examples
-    /// let parsed = HostPort::parse("192.168.1.1:5678").unwrap();
-    /// assert_eq!(parsed.host(), "192.168.1.1");
-    /// assert_eq!(parsed.port(), Some(5678));
-    ///
-    /// // IPv6 examples
-    /// let parsed = HostPort::parse("[::1]:5678").unwrap();
-    /// assert_eq!(parsed.host(), "::1");
-    /// assert_eq!(parsed.port(), Some(5678));
-    ///
-    /// let parsed = HostPort::parse("::1").unwrap();
-    /// assert_eq!(parsed.host(), "::1");
-    /// assert_eq!(parsed.port(), None);
-    /// ```
-    pub fn parse(address: &str) -> Result<Self, Error> {
+/// Host value separated from the optional port.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Host {
+    Ip(IpAddr),
+    Dns(Box<str>),
+}
+
+/// Fully specified endpoint ready for DNS resolution or socket APIs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NetworkEndpoint {
+    host: Host,
+    port: NonZeroU16,
+}
+
+impl ParsedEndpoint {
+    fn parse(address: &str) -> Result<Self, Error> {
         let address = address.trim();
 
         if address.is_empty() {
-            return Err(Error::InvalidAddress {
-                reason: "Empty address".into(),
-            });
+            return Err(invalid_address("Empty address"));
         }
 
-        // Check for IPv6 with brackets first: [::1]:5678 or [::1]
         if address.starts_with('[') {
-            if let Some(bracket_end) = address.find(']') {
-                if bracket_end == 1 {
-                    return Err(Error::InvalidAddress {
-                        reason: "Empty IPv6 address in brackets".into(),
-                    });
-                }
-
-                let ipv6_part = &address[1..bracket_end];
-                let remainder = &address[bracket_end + 1..];
-
-                if remainder.is_empty() {
-                    // Just [::1]
-                    return Ok(HostPort::Ipv6 {
-                        host: ipv6_part.to_string(),
-                        port: None,
-                    });
-                } else if let Some(port_str) = remainder.strip_prefix(':') {
-                    // [::1]:5678
-                    if port_str.is_empty() {
-                        return Err(Error::InvalidAddress {
-                            reason: "Empty port after colon".into(),
-                        });
-                    }
-                    let port = port_str.parse::<u16>().map_err(|_| Error::InvalidAddress {
-                        reason: format!("Invalid port number: {}", port_str).into(),
-                    })?;
-                    return Ok(HostPort::Ipv6 {
-                        host: ipv6_part.to_string(),
-                        port: Some(port),
-                    });
-                } else {
-                    return Err(Error::InvalidAddress {
-                        reason: "Invalid characters after IPv6 bracket".into(),
-                    });
-                }
-            } else {
-                return Err(Error::InvalidAddress {
-                    reason: "Unclosed IPv6 bracket".into(),
-                });
-            }
+            return parse_bracketed_ipv6(address);
         }
 
-        // Check if this looks like a bare IPv6 address (contains :: or multiple colons)
-        let colon_count = address.chars().filter(|&c| c == ':').count();
-        if colon_count > 1 && (address.contains("::") || colon_count >= 2) {
-            // Likely IPv6 without brackets, e.g., "::1" or "2001:db8::1"
-            // We need to be careful here - check if the last part could be a port
-            if let Some(last_colon) = address.rfind(':') {
-                let potential_port = &address[last_colon + 1..];
+        if address.contains('[') || address.contains(']') {
+            return Err(invalid_address("Malformed IPv6 brackets"));
+        }
 
-                // Only treat it as a port if:
-                // 1. It's a valid port number (1-65535)
-                // 2. The rest looks like a valid IPv6 address
-                if let Ok(port) = potential_port.parse::<u16>() {
-                    if port > 0 {
-                        let ipv6_part = &address[..last_colon];
-                        // Simple validation: IPv6 should contain :: or have exactly the right number of colons
-                        if ipv6_part.contains("::")
-                            || ipv6_part.chars().filter(|&c| c == ':').count() == 7
-                        {
-                            return Ok(HostPort::Ipv6 {
-                                host: ipv6_part.to_string(),
-                                port: Some(port),
-                            });
-                        }
-                    }
-                }
-            }
-
-            // If we reach here, treat the whole thing as an IPv6 address without port
-            return Ok(HostPort::Ipv6 {
-                host: address.to_string(),
+        if let Ok(ip) = address.parse::<IpAddr>() {
+            return Ok(Self {
+                host: Host::Ip(ip),
                 port: None,
             });
         }
 
-        // Not IPv6, so check for IPv4 or hostname with port
-        if let Some(last_colon) = address.rfind(':') {
-            let host_part = &address[..last_colon];
-            let port_part = &address[last_colon + 1..];
+        if let Ok(socket_addr) = address.parse::<SocketAddr>() {
+            return Ok(Self {
+                host: Host::Ip(socket_addr.ip()),
+                port: Some(nonzero_port(socket_addr.port())?),
+            });
+        }
 
-            if host_part.is_empty() {
-                return Err(Error::InvalidAddress {
-                    reason: "Empty host part".into(),
-                });
-            }
+        match address.chars().filter(|&c| c == ':').count() {
+            0 => Ok(Self {
+                host: parse_dns_host(address)?,
+                port: None,
+            }),
+            1 => {
+                let (host_part, port_part) = address
+                    .split_once(':')
+                    .ok_or_else(|| invalid_address("Missing port separator"))?;
 
-            if port_part.is_empty() {
-                return Err(Error::InvalidAddress {
-                    reason: "Empty port after colon".into(),
-                });
-            }
-
-            let port = port_part
-                .parse::<u16>()
-                .map_err(|_| Error::InvalidAddress {
-                    reason: format!("Invalid port number: {}", port_part).into(),
-                })?;
-
-            // Determine if this is IPv4 or hostname
-            if is_ipv4_address(host_part) {
-                Ok(HostPort::Ipv4 {
-                    host: host_part.to_string(),
-                    port: Some(port),
-                })
-            } else {
-                Ok(HostPort::Hostname {
-                    host: host_part.to_string(),
-                    port: Some(port),
+                Ok(Self {
+                    host: parse_dns_host(host_part)?,
+                    port: Some(parse_port(port_part)?),
                 })
             }
-        } else {
-            // No port specified
-            if is_ipv4_address(address) {
-                Ok(HostPort::Ipv4 {
-                    host: address.to_string(),
-                    port: None,
-                })
-            } else {
-                Ok(HostPort::Hostname {
-                    host: address.to_string(),
-                    port: None,
-                })
-            }
+            _ => Err(invalid_address(
+                "Multi-colon input is not a valid bare IPv6 literal or bracketed IPv6 endpoint",
+            )),
         }
     }
 
-    /// Get the host part of the address (without brackets for IPv6).
-    #[cfg(test)]
-    pub fn host(&self) -> &str {
-        match self {
-            HostPort::Ipv4 { host, .. } => host,
-            HostPort::Ipv6 { host, .. } => host,
-            HostPort::Hostname { host, .. } => host,
-        }
-    }
+    fn with_default_port(self, default_port: Option<u16>) -> Result<NetworkEndpoint, Error> {
+        let port = match (self.port, default_port) {
+            (Some(port), _) => port,
+            (None, Some(port)) => nonzero_port(port)?,
+            (None, None) => {
+                return Err(invalid_address(
+                    "Missing port and no default port is available",
+                ));
+            }
+        };
 
-    /// Get the port if specified.
-    #[cfg(test)]
-    pub fn port(&self) -> Option<u16> {
-        match self {
-            HostPort::Ipv4 { port, .. } => *port,
-            HostPort::Ipv6 { port, .. } => *port,
-            HostPort::Hostname { port, .. } => *port,
-        }
+        Ok(NetworkEndpoint {
+            host: self.host,
+            port,
+        })
     }
+}
 
-    /// Check if this is an IPv6 address.
-    #[cfg(test)]
-    pub fn is_ipv6(&self) -> bool {
-        matches!(self, HostPort::Ipv6 { .. })
-    }
-
-    /// Format as a proper socket address string suitable for `ToSocketAddrs`.
-    ///
-    /// This ensures IPv6 addresses are properly bracketed when a port is present.
-    pub fn format_socket_addr(&self, default_port: Option<u16>) -> String {
-        match self {
-            HostPort::Ipv4 { host, port } => match (port, default_port) {
-                (Some(p), _) => format!("{}:{}", host, p),
-                (None, Some(dp)) => format!("{}:{}", host, dp),
-                (None, None) => host.clone(),
-            },
-            HostPort::Ipv6 { host, port } => match (port, default_port) {
-                (Some(p), _) => format!("[{}]:{}", host, p),
-                (None, Some(dp)) => format!("[{}]:{}", host, dp),
-                (None, None) => host.clone(),
-            },
-            HostPort::Hostname { host, port } => match (port, default_port) {
-                (Some(p), _) => format!("{}:{}", host, p),
-                (None, Some(dp)) => format!("{}:{}", host, dp),
-                (None, None) => host.clone(),
-            },
+impl NetworkEndpoint {
+    fn format_socket_addr(&self) -> String {
+        match &self.host {
+            Host::Ip(IpAddr::V4(host)) => format!("{}:{}", host, self.port),
+            Host::Ip(IpAddr::V6(host)) => format!("[{}]:{}", host, self.port),
+            Host::Dns(host) => format!("{}:{}", host, self.port),
         }
     }
 }
 
-/// Check if a string looks like an IPv4 address (simple heuristic).
-fn is_ipv4_address(s: &str) -> bool {
-    let parts: Vec<&str> = s.split('.').collect();
-    if parts.len() != 4 {
-        return false;
+fn parse_bracketed_ipv6(address: &str) -> Result<ParsedEndpoint, Error> {
+    let bracket_end = address
+        .find(']')
+        .ok_or_else(|| invalid_address("Unclosed IPv6 bracket"))?;
+
+    if bracket_end == 1 {
+        return Err(invalid_address("Empty IPv6 address in brackets"));
     }
 
-    parts.iter().all(|part| {
-        if let Ok(_num) = part.parse::<u8>() {
-            // Valid if it parses as u8 and doesn't have leading zeros (except for "0")
-            *part == "0" || !part.starts_with('0')
-        } else {
-            false
-        }
+    let ipv6_part = &address[1..bracket_end];
+    let host = ipv6_part
+        .parse::<Ipv6Addr>()
+        .map_err(|_| invalid_address(format!("Invalid bracketed IPv6 address: {ipv6_part}")))?;
+    let remainder = &address[bracket_end + 1..];
+
+    let port = if remainder.is_empty() {
+        None
+    } else if let Some(port_str) = remainder.strip_prefix(':') {
+        Some(parse_port(port_str)?)
+    } else {
+        return Err(invalid_address("Invalid characters after IPv6 bracket"));
+    };
+
+    Ok(ParsedEndpoint {
+        host: Host::Ip(IpAddr::V6(host)),
+        port,
     })
 }
 
-/// Normalize a host with an optional default port, handling IPv6 correctly.
-///
-/// This function takes a host string (which may or may not include a port)
-/// and ensures it's formatted correctly for use with `ToSocketAddrs`.
-/// IPv6 addresses are properly bracketed when needed.
-///
-/// # Arguments
-///
-/// * `host` - The host string to normalize (e.g., `"::1"`, `"[::1]:5678"`, `"192.168.1.1:5678"`)
-/// * `default_port` - Port to use if none is specified in the host string
-///
-/// # Examples
-///
-/// ```ignore
-/// use grafton_visca::transport::address::normalize_host_with_default_port;
-///
-/// // IPv6 examples
-/// assert_eq!(
-///     normalize_host_with_default_port("::1", Some(5678)).unwrap(),
-///     "[::1]:5678"
-/// );
-/// assert_eq!(
-///     normalize_host_with_default_port("[::1]:1234", Some(5678)).unwrap(),
-///     "[::1]:1234"
-/// );
-///
-/// // IPv4 examples
-/// assert_eq!(
-///     normalize_host_with_default_port("192.168.1.1", Some(5678)).unwrap(),
-///     "192.168.1.1:5678"
-/// );
-/// assert_eq!(
-///     normalize_host_with_default_port("192.168.1.1:1234", Some(5678)).unwrap(),
-///     "192.168.1.1:1234"
-/// );
-/// ```
-#[cfg(test)]
-pub fn normalize_host_with_default_port(
-    host: &str,
-    default_port: Option<u16>,
-) -> Result<String, Error> {
-    let parsed = HostPort::parse(host)?;
-    Ok(parsed.format_socket_addr(default_port))
+fn parse_dns_host(host: &str) -> Result<Host, Error> {
+    if host.is_empty() {
+        return Err(invalid_address("Empty host part"));
+    }
+
+    if host.contains('[') || host.contains(']') || host.contains(':') {
+        return Err(invalid_address("Invalid host syntax"));
+    }
+
+    if host.chars().any(char::is_whitespace) {
+        return Err(invalid_address("Host contains whitespace"));
+    }
+
+    Ok(Host::Dns(host.into()))
+}
+
+fn parse_port(port: &str) -> Result<NonZeroU16, Error> {
+    if port.is_empty() {
+        return Err(invalid_address("Empty port after colon"));
+    }
+
+    let port = port
+        .parse::<u16>()
+        .map_err(|_| invalid_address(format!("Invalid port number: {port}")))?;
+    nonzero_port(port)
+}
+
+fn nonzero_port(port: u16) -> Result<NonZeroU16, Error> {
+    NonZeroU16::new(port).ok_or_else(|| invalid_address("Port must be non-zero"))
+}
+
+fn invalid_address(reason: impl Into<Cow<'static, str>>) -> Error {
+    Error::InvalidAddress {
+        reason: reason.into(),
+    }
 }
 
 /// Canonicalize a network endpoint address for TCP/UDP connections.
@@ -331,9 +185,14 @@ pub fn normalize_host_with_default_port(
 /// at connection boundaries. It ensures:
 ///
 /// 1. The address is parsed and validated
-/// 2. IPv6 addresses are properly bracketed when a port is present
-/// 3. Default ports are applied when the parsed port is missing
-/// 4. The output is always a canonical `host:port` string suitable for `ToSocketAddrs`
+/// 2. Bare IPv6 literals are always treated as hosts, never split at the final hextet
+/// 3. Bracketed IPv6 is required when an explicit IPv6 port is supplied
+/// 4. Default ports are applied when the parsed port is missing
+/// 5. A missing final port without a default returns `Error::InvalidAddress`
+/// 6. The output is always a canonical `host:port` string suitable for `ToSocketAddrs`
+///
+/// IPv6 zone identifiers are intentionally rejected because the internal endpoint
+/// model uses `std::net::IpAddr`, which does not represent scope identifiers.
 ///
 /// This should be called at all TCP/UDP connection entry points to ensure consistent
 /// address handling across the entire API surface.
@@ -355,6 +214,7 @@ pub fn normalize_host_with_default_port(
 /// Returns `Error::InvalidAddress` if:
 /// - The address cannot be parsed
 /// - The address format is invalid
+/// - The endpoint has no explicit or default port
 ///
 /// # Invariant
 ///
@@ -366,10 +226,10 @@ pub fn normalize_host_with_default_port(
 /// ```ignore
 /// use grafton_visca::transport::address::canonicalize_endpoint;
 ///
-/// // Unbracketed IPv6 with port is canonicalized to bracketed form
+/// // Bare IPv6 always remains the host and receives the default port
 /// assert_eq!(
 ///     canonicalize_endpoint("2001:db8::1:5678", Some(1234)).unwrap(),
-///     "[2001:db8::1]:5678"
+///     "[2001:db8::1:5678]:1234"
 /// );
 ///
 /// // IPv6 without port gets default port added
@@ -409,8 +269,9 @@ pub fn normalize_host_with_default_port(
 /// );
 /// ```
 pub fn canonicalize_endpoint(address: &str, default_port: Option<u16>) -> Result<String, Error> {
-    let parsed = HostPort::parse(address)?;
-    Ok(parsed.format_socket_addr(default_port))
+    let parsed = ParsedEndpoint::parse(address)?;
+    let endpoint = parsed.with_default_port(default_port)?;
+    Ok(endpoint.format_socket_addr())
 }
 
 /// A utility for resolving network addresses.
@@ -662,289 +523,121 @@ mod tests {
         assert!(addr.is_ipv4());
     }
 
-    #[test]
-    fn test_hostport_parse_ipv4() {
-        let parsed = HostPort::parse("192.168.1.1:5678").unwrap();
-        assert_eq!(parsed.host(), "192.168.1.1");
-        assert_eq!(parsed.port(), Some(5678));
-        assert!(!parsed.is_ipv6());
-
-        let parsed = HostPort::parse("192.168.1.1").unwrap();
-        assert_eq!(parsed.host(), "192.168.1.1");
-        assert_eq!(parsed.port(), None);
-        assert!(!parsed.is_ipv6());
-    }
-
-    #[test]
-    fn test_hostport_parse_ipv6_with_brackets() {
-        let parsed = HostPort::parse("[::1]:5678").unwrap();
-        assert_eq!(parsed.host(), "::1");
-        assert_eq!(parsed.port(), Some(5678));
-        assert!(parsed.is_ipv6());
-
-        let parsed = HostPort::parse("[::1]").unwrap();
-        assert_eq!(parsed.host(), "::1");
-        assert_eq!(parsed.port(), None);
-        assert!(parsed.is_ipv6());
-
-        let parsed = HostPort::parse("[2001:db8::1]:8080").unwrap();
-        assert_eq!(parsed.host(), "2001:db8::1");
-        assert_eq!(parsed.port(), Some(8080));
-        assert!(parsed.is_ipv6());
-    }
-
-    #[test]
-    fn test_hostport_parse_ipv6_without_brackets() {
-        let parsed = HostPort::parse("::1").unwrap();
-        assert_eq!(parsed.host(), "::1");
-        assert_eq!(parsed.port(), None);
-        assert!(parsed.is_ipv6());
-
-        let parsed = HostPort::parse("2001:db8::1").unwrap();
-        assert_eq!(parsed.host(), "2001:db8::1");
-        assert_eq!(parsed.port(), None);
-        assert!(parsed.is_ipv6());
-
-        // IPv6 with port (tricky case)
-        let parsed = HostPort::parse("2001:db8::1:5678").unwrap();
-        assert_eq!(parsed.host(), "2001:db8::1");
-        assert_eq!(parsed.port(), Some(5678));
-        assert!(parsed.is_ipv6());
-    }
-
-    #[test]
-    fn test_hostport_parse_hostname() {
-        let parsed = HostPort::parse("localhost:8080").unwrap();
-        assert_eq!(parsed.host(), "localhost");
-        assert_eq!(parsed.port(), Some(8080));
-        assert!(!parsed.is_ipv6());
-
-        let parsed = HostPort::parse("camera.local").unwrap();
-        assert_eq!(parsed.host(), "camera.local");
-        assert_eq!(parsed.port(), None);
-        assert!(!parsed.is_ipv6());
-    }
-
-    #[test]
-    fn test_hostport_parse_errors() {
-        assert!(HostPort::parse("").is_err());
-        assert!(HostPort::parse("   ").is_err());
-        assert!(HostPort::parse("[]:5678").is_err());
-        assert!(HostPort::parse("[::1").is_err());
-        assert!(HostPort::parse("[::1]invalid").is_err());
-        assert!(HostPort::parse("host:").is_err());
-        assert!(HostPort::parse(":5678").is_err());
-        assert!(HostPort::parse("host:99999").is_err());
-    }
-
-    #[test]
-    fn test_hostport_format_socket_addr() {
-        // IPv4
-        let hp = HostPort::Ipv4 {
-            host: "192.168.1.1".to_string(),
-            port: Some(5678),
-        };
-        assert_eq!(hp.format_socket_addr(None), "192.168.1.1:5678");
-        assert_eq!(hp.format_socket_addr(Some(8080)), "192.168.1.1:5678");
-
-        let hp = HostPort::Ipv4 {
-            host: "192.168.1.1".to_string(),
-            port: None,
-        };
-        assert_eq!(hp.format_socket_addr(Some(8080)), "192.168.1.1:8080");
-        assert_eq!(hp.format_socket_addr(None), "192.168.1.1");
-
-        // IPv6
-        let hp = HostPort::Ipv6 {
-            host: "::1".to_string(),
-            port: Some(5678),
-        };
-        assert_eq!(hp.format_socket_addr(None), "[::1]:5678");
-        assert_eq!(hp.format_socket_addr(Some(8080)), "[::1]:5678");
-
-        let hp = HostPort::Ipv6 {
-            host: "::1".to_string(),
-            port: None,
-        };
-        assert_eq!(hp.format_socket_addr(Some(8080)), "[::1]:8080");
-        assert_eq!(hp.format_socket_addr(None), "::1");
-
-        // Hostname
-        let hp = HostPort::Hostname {
-            host: "localhost".to_string(),
-            port: Some(5678),
-        };
-        assert_eq!(hp.format_socket_addr(None), "localhost:5678");
-        assert_eq!(hp.format_socket_addr(Some(8080)), "localhost:5678");
-
-        let hp = HostPort::Hostname {
-            host: "localhost".to_string(),
-            port: None,
-        };
-        assert_eq!(hp.format_socket_addr(Some(8080)), "localhost:8080");
-        assert_eq!(hp.format_socket_addr(None), "localhost");
-    }
-
-    #[test]
-    fn test_normalize_host_with_default_port() {
-        // IPv4 cases
-        assert_eq!(
-            normalize_host_with_default_port("192.168.1.1", Some(5678)).unwrap(),
-            "192.168.1.1:5678"
-        );
-        assert_eq!(
-            normalize_host_with_default_port("192.168.1.1:1234", Some(5678)).unwrap(),
-            "192.168.1.1:1234"
-        );
-
-        // IPv6 cases
-        assert_eq!(
-            normalize_host_with_default_port("::1", Some(5678)).unwrap(),
-            "[::1]:5678"
-        );
-        assert_eq!(
-            normalize_host_with_default_port("[::1]:1234", Some(5678)).unwrap(),
-            "[::1]:1234"
-        );
-        assert_eq!(
-            normalize_host_with_default_port("2001:db8::1", Some(5678)).unwrap(),
-            "[2001:db8::1]:5678"
-        );
-
-        // Hostname cases
-        assert_eq!(
-            normalize_host_with_default_port("localhost", Some(5678)).unwrap(),
-            "localhost:5678"
-        );
-        assert_eq!(
-            normalize_host_with_default_port("camera.local:1234", Some(5678)).unwrap(),
-            "camera.local:1234"
+    fn assert_invalid(result: Result<String, Error>) {
+        assert!(
+            matches!(result, Err(Error::InvalidAddress { .. })),
+            "expected Error::InvalidAddress, got {result:?}"
         );
     }
 
     #[test]
-    fn test_is_ipv4_address() {
-        assert!(is_ipv4_address("192.168.1.1"));
-        assert!(is_ipv4_address("0.0.0.0"));
-        assert!(is_ipv4_address("255.255.255.255"));
-        assert!(!is_ipv4_address("192.168.1"));
-        assert!(!is_ipv4_address("192.168.1.1.1"));
-        assert!(!is_ipv4_address("256.1.1.1"));
-        assert!(!is_ipv4_address("192.168.01.1")); // leading zero
-        assert!(!is_ipv4_address("localhost"));
-        assert!(!is_ipv4_address("::1"));
-    }
-
-    #[test]
-    fn test_ipv6_edge_cases() {
-        // Zone identifiers (link-local)
-        let parsed = HostPort::parse("[fe80::1%eth0]:5678").unwrap();
-        assert_eq!(parsed.host(), "fe80::1%eth0");
-        assert_eq!(parsed.port(), Some(5678));
-        assert!(parsed.is_ipv6());
-
-        // Full IPv6 address
-        let parsed = HostPort::parse("[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443").unwrap();
-        assert_eq!(parsed.host(), "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
-        assert_eq!(parsed.port(), Some(443));
-        assert!(parsed.is_ipv6());
-
-        // Compressed IPv6
-        let parsed = HostPort::parse("[2001:db8:85a3::8a2e:370:7334]:80").unwrap();
-        assert_eq!(parsed.host(), "2001:db8:85a3::8a2e:370:7334");
-        assert_eq!(parsed.port(), Some(80));
-        assert!(parsed.is_ipv6());
-    }
-
-    #[test]
-    fn test_canonicalize_endpoint_ipv6_unbracketed_with_port() {
-        // This is the key test case from the issue: unbracketed IPv6 with port
-        // should be canonicalized to bracketed form
+    fn test_bare_ipv6_with_numeric_final_hextet_is_not_split() {
         assert_eq!(
             canonicalize_endpoint("2001:db8::1:5678", Some(1234)).unwrap(),
-            "[2001:db8::1]:5678"
+            "[2001:db8::1:5678]:1234"
         );
+
+        assert_invalid(canonicalize_endpoint("2001:db8::1:5678", None));
     }
 
     #[test]
-    fn test_canonicalize_endpoint_ipv6() {
-        // IPv6 without port gets default port added
+    fn test_bracketed_ipv6_explicit_and_default_ports() {
+        assert_eq!(
+            canonicalize_endpoint("[2001:db8::1]:5678", Some(1234)).unwrap(),
+            "[2001:db8::1]:5678"
+        );
         assert_eq!(
             canonicalize_endpoint("::1", Some(5678)).unwrap(),
             "[::1]:5678"
         );
-
-        // Already bracketed IPv6 is preserved
-        assert_eq!(
-            canonicalize_endpoint("[::1]:1234", Some(5678)).unwrap(),
-            "[::1]:1234"
-        );
-
-        // IPv6 without brackets and no port
-        assert_eq!(
-            canonicalize_endpoint("2001:db8::1", Some(5678)).unwrap(),
-            "[2001:db8::1]:5678"
-        );
-
-        // Already bracketed without port
         assert_eq!(
             canonicalize_endpoint("[::1]", Some(5678)).unwrap(),
             "[::1]:5678"
         );
+
+        assert_invalid(canonicalize_endpoint("::1", None));
+        assert_invalid(canonicalize_endpoint("[::1]", None));
     }
 
     #[test]
-    fn test_canonicalize_endpoint_ipv4() {
-        // IPv4 with port is formatted correctly
+    fn test_ipv4_explicit_and_default_ports() {
         assert_eq!(
-            canonicalize_endpoint("192.168.1.1:5678", Some(1234)).unwrap(),
-            "192.168.1.1:5678"
+            canonicalize_endpoint("192.168.0.110:5678", Some(1234)).unwrap(),
+            "192.168.0.110:5678"
+        );
+        assert_eq!(
+            canonicalize_endpoint("192.168.0.110", Some(5678)).unwrap(),
+            "192.168.0.110:5678"
         );
 
-        // IPv4 without port gets default port added
-        assert_eq!(
-            canonicalize_endpoint("192.168.1.1", Some(5678)).unwrap(),
-            "192.168.1.1:5678"
-        );
+        assert_invalid(canonicalize_endpoint("192.168.0.110", None));
     }
 
     #[test]
-    fn test_canonicalize_endpoint_hostname() {
-        // Hostname with port is formatted correctly
+    fn test_dns_explicit_and_default_ports() {
         assert_eq!(
             canonicalize_endpoint("camera.local:5678", Some(1234)).unwrap(),
             "camera.local:5678"
         );
-
-        // Hostname without port gets default port added
         assert_eq!(
-            canonicalize_endpoint("localhost", Some(5678)).unwrap(),
-            "localhost:5678"
+            canonicalize_endpoint("camera.local", Some(5678)).unwrap(),
+            "camera.local:5678"
         );
+
+        assert_invalid(canonicalize_endpoint("camera.local", None));
     }
 
     #[test]
-    fn test_canonicalize_endpoint_errors() {
-        // Empty address
-        assert!(canonicalize_endpoint("", Some(5678)).is_err());
+    fn test_port_rejections_are_consistent() {
+        for address in [
+            "host:",
+            "[::1]:",
+            "host:0",
+            "[::1]:0",
+            "host:99999",
+            "[::1]:99999",
+        ] {
+            assert_invalid(canonicalize_endpoint(address, Some(5678)));
+        }
 
-        // Invalid port
-        assert!(canonicalize_endpoint("localhost:", Some(5678)).is_err());
-
-        // Empty host
-        assert!(canonicalize_endpoint(":5678", Some(5678)).is_err());
+        assert_invalid(canonicalize_endpoint("host", Some(0)));
     }
 
     #[test]
-    fn test_canonicalize_endpoint_no_default_port() {
-        // When no default port is provided and address has no port,
-        // the result should be just the host (for later error at resolution time)
-        assert_eq!(
-            canonicalize_endpoint("192.168.1.1", None).unwrap(),
-            "192.168.1.1"
-        );
+    fn test_malformed_address_rejections() {
+        for address in [
+            "",
+            "   ",
+            ":5678",
+            "[]:5678",
+            "[::1",
+            "[::1]junk",
+            "2001:db8:::1",
+            "host:name:5678",
+            "[fe80::1%eth0]:5678",
+            "fe80::1%eth0",
+        ] {
+            assert_invalid(canonicalize_endpoint(address, Some(5678)));
+        }
+    }
 
-        // IPv6 without port and no default should return just the host
-        assert_eq!(canonicalize_endpoint("::1", None).unwrap(), "::1");
+    #[test]
+    fn test_valid_bare_ipv6_literals_are_never_split() {
+        for literal in [
+            "::",
+            "::1",
+            "2001:db8::1",
+            "2001:db8::1:80",
+            "2001:db8::1:5678",
+            "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+            "::ffff:192.0.2.128",
+        ] {
+            let ipv6: Ipv6Addr = literal.parse().unwrap();
+            assert_eq!(
+                canonicalize_endpoint(literal, Some(1234)).unwrap(),
+                format!("[{ipv6}]:1234")
+            );
+            assert_invalid(canonicalize_endpoint(literal, None));
+        }
     }
 }

--- a/src/transport/blocking/tcp.rs
+++ b/src/transport/blocking/tcp.rs
@@ -9,7 +9,7 @@ use std::{
 use crate::{
     command::CommandKind,
     transport::{
-        address::AddressResolver,
+        address::{canonicalize_endpoint, AddressResolver},
         builder::{AddressingMode, TransportConfig},
         socket_options::apply_tcp_socket_options,
         BlockingTransport, HasTransportConfig,
@@ -41,6 +41,8 @@ impl Tcp {
     /// Connect to a TCP endpoint.
     ///
     /// This method resolves hostnames and supports both IPv4 and IPv6 addresses.
+    /// The address must include an explicit port; explicit IPv6 ports require
+    /// brackets.
     pub fn connect(address: &str) -> Result<Self, Error> {
         Self::connect_timeout(address, Duration::from_secs(5))
     }
@@ -49,7 +51,7 @@ impl Tcp {
     ///
     /// This method resolves hostnames and supports both IPv4 and IPv6 addresses.
     /// It will try each resolved address in order until one succeeds or the
-    /// overall timeout is reached.
+    /// overall timeout is reached. The address must include an explicit port.
     pub fn connect_timeout(address: &str, timeout: Duration) -> Result<Self, Error> {
         let config = TransportConfig {
             connect_timeout: timeout,
@@ -65,12 +67,14 @@ impl Tcp {
     /// Connect with a full configuration.
     ///
     /// This method provides full control over connection and socket parameters.
+    /// The address must include an explicit port.
     pub fn connect_with_config(address: &str, config: TransportConfig) -> Result<Self, Error> {
+        let canonical_addr = canonicalize_endpoint(address, None)?;
         let deadline = Instant::now() + config.connect_timeout;
 
         // Use the common address resolver
         let resolver = AddressResolver::new();
-        let addrs = resolver.resolve(address)?;
+        let addrs = resolver.resolve(&canonical_addr)?;
 
         let mut last_error = None;
 

--- a/src/transport/blocking/udp.rs
+++ b/src/transport/blocking/udp.rs
@@ -5,7 +5,7 @@ use std::{net::UdpSocket, time::Duration};
 use crate::{
     command::CommandKind,
     transport::{
-        address::AddressResolver,
+        address::{canonicalize_endpoint, AddressResolver},
         buffer::BufferConfig,
         builder::{AddressingMode, TransportConfig},
         BlockingTransport, HasTransportConfig, SendSemantics,
@@ -28,7 +28,8 @@ impl Udp {
     ///
     /// This method resolves hostnames and supports both IPv4 and IPv6 addresses.
     /// The socket will bind to the appropriate unspecified address based on the
-    /// target address family.
+    /// target address family. The address must include an explicit port; explicit
+    /// IPv6 ports require brackets.
     pub fn connect(address: &str) -> Result<Self, Error> {
         let config = TransportConfig {
             read_timeout: Duration::from_secs(5),
@@ -43,10 +44,13 @@ impl Udp {
     /// Connect with a full configuration.
     ///
     /// This method provides full control over connection and socket parameters.
+    /// The address must include an explicit port.
     pub fn connect_with_config(address: &str, config: TransportConfig) -> Result<Self, Error> {
+        let canonical_addr = canonicalize_endpoint(address, None)?;
+
         // Use the common address resolver
         let resolver = AddressResolver::new();
-        let target_addr = resolver.resolve_first(address)?;
+        let target_addr = resolver.resolve_first(&canonical_addr)?;
 
         // Bind to the appropriate unspecified address based on target family
         let bind_addr = resolver.bind_address_for(&target_addr);

--- a/src/transport/builder.rs
+++ b/src/transport/builder.rs
@@ -321,8 +321,10 @@ impl NetTransportBuilder {
 
     /// Set the address to connect to.
     ///
-    /// This can be a hostname with port (e.g., "camera.local:5678")
-    /// or an IP address with port (e.g., "192.168.0.110:5678").
+    /// This builder has no profile default port, so the address must include an
+    /// explicit port. Use a hostname with port (e.g., `"camera.local:5678"`), an
+    /// IPv4 address with port (e.g., `"192.168.0.110:5678"`), or bracketed IPv6
+    /// with port (e.g., `"[::1]:5678"`).
     pub fn address(mut self, address: impl Into<String>) -> Self {
         self.address = Some(address.into());
         self

--- a/src/transport/runtime_common.rs
+++ b/src/transport/runtime_common.rs
@@ -103,7 +103,9 @@ macro_rules! declare_net_transport {
                     config: TransportConfig,
                 ) -> Result<Self, Error> {
                     let tcp_config = TcpConnectionConfig::from(config);
-                    let stream = $tcp_connect(address, tcp_config).await?;
+                    let canonical_addr =
+                        $crate::transport::address::canonicalize_endpoint(address, None)?;
+                    let stream = $tcp_connect(&canonical_addr, tcp_config).await?;
 
                     Ok(Self::new(stream, config))
                 }
@@ -237,7 +239,9 @@ macro_rules! declare_net_transport {
                     config: TransportConfig,
                 ) -> Result<Self, Error> {
                     let udp_config = UdpSocketConfig::from(config);
-                    let socket = $udp_connect(address, udp_config).await?;
+                    let canonical_addr =
+                        $crate::transport::address::canonicalize_endpoint(address, None)?;
+                    let socket = $udp_connect(&canonical_addr, udp_config).await?;
 
                     Ok(Self::new(socket, config))
                 }
@@ -307,7 +311,9 @@ macro_rules! declare_net_transport {
                     config: TransportConfig,
                 ) -> Result<Self, Error> {
                     let tcp_config = TcpConnectionConfig::from(config);
-                    let stream = $tcp_connect(address, tcp_config).await?;
+                    let canonical_addr =
+                        $crate::transport::address::canonicalize_endpoint(address, None)?;
+                    let stream = $tcp_connect(&canonical_addr, tcp_config).await?;
                     Ok(Self::new(stream, config))
                 }
 
@@ -441,7 +447,9 @@ macro_rules! declare_net_transport {
                     config: TransportConfig,
                 ) -> Result<Self, Error> {
                     let udp_config = UdpSocketConfig::from(config);
-                    let socket = $udp_connect(address, udp_config).await?;
+                    let canonical_addr =
+                        $crate::transport::address::canonicalize_endpoint(address, None)?;
+                    let socket = $udp_connect(&canonical_addr, udp_config).await?;
 
                     Ok(Self::new(socket, config))
                 }

--- a/tests/runtime_trait_test.rs
+++ b/tests/runtime_trait_test.rs
@@ -163,7 +163,7 @@ mod smol_runtime_tests {
 mod tokio_transport_connect_tests {
     use std::time::Duration;
 
-    use grafton_visca::{runtime_adapters::tokio::UdpTransport, transport::TransportConfig};
+    use grafton_visca::{runtime_adapters::tokio::UdpTransport, transport::TransportConfig, Error};
 
     /// Test that UDP transport connection completes successfully with a local address.
     ///
@@ -219,13 +219,21 @@ mod tokio_transport_connect_tests {
             // Expected - the address is non-routable
         }
     }
+
+    #[tokio::test]
+    async fn test_udp_transport_connect_with_config_rejects_missing_port() {
+        let result =
+            UdpTransport::connect_with_config("127.0.0.1", TransportConfig::default()).await;
+
+        assert!(matches!(result, Err(Error::InvalidAddress { .. })));
+    }
 }
 
 #[cfg(all(feature = "runtime-smol", not(feature = "runtime-tokio")))]
 mod smol_transport_connect_tests {
     use std::time::Duration;
 
-    use grafton_visca::{runtime_adapters::smol::UdpTransport, transport::TransportConfig};
+    use grafton_visca::{runtime_adapters::smol::UdpTransport, transport::TransportConfig, Error};
 
     fn run_smol<F: std::future::Future>(f: F) -> F::Output {
         smol::block_on(f)
@@ -249,6 +257,16 @@ mod smol_transport_connect_tests {
                 result.is_ok(),
                 "UDP transport should connect successfully to local address"
             );
+        });
+    }
+
+    #[test]
+    fn test_udp_transport_connect_with_config_rejects_missing_port() {
+        run_smol(async {
+            let result =
+                UdpTransport::connect_with_config("127.0.0.1", TransportConfig::default()).await;
+
+            assert!(matches!(result, Err(Error::InvalidAddress { .. })));
         });
     }
 }

--- a/tests/transport_builder_integration.rs
+++ b/tests/transport_builder_integration.rs
@@ -15,7 +15,7 @@ use std::{
 use grafton_visca::{
     camera::{profiles::PtzOpticsG2, CameraConfig, Connect},
     transport::{Transport, TransportConfig},
-    CameraBuilder,
+    CameraBuilder, Error,
 };
 
 /// Test that the camera-first API creates a TCP camera with proper configuration
@@ -92,6 +92,43 @@ fn test_camera_creates_configured_udp_camera() {
 
     // Test basic camera creation is working
     // Note: More detailed communication testing would require protocol-aware mock server
+}
+
+/// Test that CameraConfig uses the same explicit endpoint grammar at open time.
+#[test]
+fn test_camera_config_opens_configured_tcp_camera() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    thread::spawn(move || {
+        let _ = listener.accept();
+    });
+
+    thread::sleep(Duration::from_millis(50));
+
+    let camera_result = CameraConfig::<PtzOpticsG2>::tcp(addr.to_string()).open_blocking();
+
+    assert!(
+        camera_result.is_ok(),
+        "CameraConfig should open TCP cameras with explicit endpoints"
+    );
+}
+
+/// Test that low-level public transport builders reject missing ports before I/O.
+#[test]
+fn test_low_level_transport_builders_require_explicit_ports() {
+    fn is_invalid_address<T>(result: &Result<T, Error>) -> bool {
+        matches!(result, Err(Error::InvalidAddress { .. }))
+    }
+
+    let tcp_result = Transport::tcp().address("127.0.0.1").build_blocking();
+    assert!(is_invalid_address(&tcp_result));
+
+    let udp_result = Transport::udp().address("127.0.0.1").build_blocking();
+    assert!(is_invalid_address(&udp_result));
+
+    let bare_ipv6_result = Transport::udp().address("::1").build_blocking();
+    assert!(is_invalid_address(&bare_ipv6_result));
 }
 
 /// Test advanced camera construction through CameraBuilder.


### PR DESCRIPTION
Summary
- replace ambiguous host/port parsing with typed endpoint canonicalization
- treat bare IPv6 literals as hosts only and require brackets for explicit IPv6 ports
- reject missing ports before DNS/socket resolution in low-level builders and runtime adapters
- update docs, changelog, and tests for the new endpoint grammar

Verification
- cargo test --no-default-features
- cargo test --no-default-features --features runtime-tokio
- cargo test --no-default-features --features runtime-smol
- cargo test --no-default-features --features transport-serial
- cargo test --no-default-features --features runtime-tokio,transport-serial-tokio
- cargo check --no-default-features --features runtime-tokio,runtime-smol
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --check
- git diff --check

Closes #534