### PR TITLE
feat(camera): mode-honest operation handle for movement commands (#539)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ name: Rust CI/CD
 on:
   push:
     branches: ["main", "feature/*"]
-    tags: ["*"]
+    tags: ["v*"]
   pull_request:
     branches: ["main"]
   workflow_dispatch:
@@ -653,8 +653,9 @@ jobs:
           RUSTC_WRAPPER: ""  # Disable sccache for packaging
         run: |
           echo "Running package check for release tag..."
-          # Only check the macros crate can be packaged
-          # The main crate check happens in the publish job after macros is published
+          # The main crate depends on the same-version macro crate from the
+          # registry, so it can only be verified after the macro crate has been
+          # published and indexed.
           cargo package -p grafton-visca-macros --no-verify
 
       # Build validation for non-releases
@@ -743,9 +744,14 @@ jobs:
       - name: Wait for crates.io indexing
         run: sleep 30
 
+      - name: Publish main crate dry run
+        env:
+          RUSTC_WRAPPER: ""  # Disable sccache for packaging
+        run: cargo publish -p grafton-visca --dry-run
+
       # Publish main crate
       - name: Publish grafton-visca to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
           RUSTC_WRAPPER: ""  # Disable sccache for packaging
-        run: cargo publish
+        run: cargo publish -p grafton-visca

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,104 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### Mode-Honest Operation Handles for Movement Commands (#539)
+
+- Added a single `submit(command)` primitive on both async and blocking cameras
+  that returns an operation handle which is genuine in either mode. This replaces
+  the async-only `_op` handle surface with one unified path.
+  - Async cameras return `InFlight`; blocking cameras return the new
+    `BlockingInFlight`. `BlockingInFlight` drives completion **synchronously on
+    the caller's thread** with no async executor involved. Both handle types
+    expose the same methods so code reads the same across modes.
+  - `Camera::submit(command)` takes a prepared `ViscaCommand`, submits it as a
+    targeted operation, and returns its handle without waiting.
+    `Camera::submit_continuous(command)` does the same but marks the handle as a
+    continuous drive or stop, for which there is no well-defined settled state.
+    (Ergonomic, noun-scoped `submit_*` helpers that accept degrees/normalized
+    inputs and return a handle are planned as a follow-up — see the migration
+    notes below.)
+- Added handle completion methods with explicit *applied* vs *settled* semantics:
+  - `await_applied(timeout)` resolves when the camera has accepted and
+    protocol-completed the command. It is available on every handle — including
+    continuous drives and stops — and is the method to use for a bounded deadman
+    `STOP`.
+  - `await_settled(timeout)` resolves when physical motion has ended (via the
+    operation-complete message on profiles that report it, otherwise via position
+    polling). It is meaningful only for targeted moves; on a continuous or stop
+    handle it returns `Error::NotSupported`.
+  - `cancel()` discards the command through the runtime's ID-based cancel path;
+    `detach()` is the explicit fire-and-forget escape hatch.
+- Added `OpKind` (`Targeted` / `Continuous`) to describe whether an operation has
+  a settled state, and re-exported it from `grafton_visca::camera`.
+- Blocking movement detection (`is_moving_axes_with_deadline`) can now be called
+  through a shared `&self` reference so it composes with the new handle waits.
+
+### Changed
+
+- Operation handles (`InFlight` and `BlockingInFlight`) are now `#[must_use]`:
+  producing a handle and dropping it without `await_applied`, `await_settled`,
+  `cancel`, or `detach` raises a lint. **Dropping a handle never stops the
+  command** — drop is equivalent to `detach`. The already-dispatched command
+  keeps running; a still-queued blocking command is flushed by the next blocking
+  operation. Use `cancel()` to discard a command instead.
+- The deprecated `_op` handle methods and the new `submit` primitive now share a
+  single internal submission implementation, so the handle-producing paths cannot
+  drift.
+
+### Deprecated
+
+- The `_op` movement handle methods are deprecated in favor of `submit(command)`
+  (or the noun accessors) plus `await_applied` / `await_settled`:
+  `pan_tilt_absolute_op`, `pan_tilt_relative_op`, `pan_tilt_home_op`,
+  `pan_tilt_reset_op`, `set_zoom_op`, `set_zoom_normalized_op`,
+  `set_zoom_normalized_in_domain_op`, `set_focus_op`, and `preset_recall_op`.
+  They remain thin, behavior-preserving shims and will be removed in 2.0.
+- `InFlight::await_completion` is deprecated in favor of `await_applied`, which
+  makes the applied-versus-settled completion distinction explicit. The old name
+  remains as a delegating shim and will be removed in 2.0.
+
+##### Migration Notes
+
+This release is fully additive: existing code — including the `_op` methods and
+`await_completion` — continues to compile and behave identically, emitting only
+deprecation warnings. To migrate:
+
+- Fire-and-forget callers need no change: the ergonomic methods and noun
+  accessors (`camera.pan_tilt().absolute(...)`, `camera.zoom().stop()`, …) are
+  unchanged.
+- Replace `handle.await_completion(timeout)` with `handle.await_applied(timeout)`.
+- To obtain a handle for a command you can construct directly — `PanTilt::Home`,
+  `Zoom::Stop`, a preset recall, or a raw position — use
+  `camera.submit(&command)` and drive it with `await_applied` / `await_settled`.
+  Blocking callers gain a real handle here for the first time
+  (`camera.submit(&command)?.await_applied(timeout)?`), which previously required
+  a separate idle-polling wait.
+- For handles created from ergonomic inputs (degrees, normalized units), keep
+  using the `_op` methods for now. They stay available (with a deprecation
+  warning) until the ergonomic `submit_*` helpers described below replace them;
+  the `_op` methods will not be removed before that replacement exists.
+
+Intended follow-up changes, targeted for the next major release (2.0) unless
+noted:
+
+- Ergonomic, noun-scoped `submit_*` handle helpers (accepting degrees/normalized
+  inputs, returning a typed handle) will land as the drop-in replacement for the
+  deprecated `_op` methods. This is the additive step that must precede removal.
+- The deprecated `_op` methods and `InFlight::await_completion` will then be
+  removed.
+- The coarse operation markers will be split into targeted and continuous
+  variants so that calling `await_settled` on a continuous or stop handle becomes
+  a compile error instead of a runtime `Error::NotSupported`.
+- The object-safe `dyn` API facade will be generated from the same command
+  descriptors as the static movement surface, keeping the two in lockstep.
+
+Until then, note that async `await_settled` resolves on the command's completion
+message; on profiles that do not report operation completion, follow it with
+`camera.await_axes_idle(...)` for a strict position-based settle. Blocking
+`await_settled` already performs that position poll internally.
+
 ## [1.0.0] - 2026-06-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-16
+
 ### Added
 
 #### Mode-Honest Operation Handles for Movement Commands (#539)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-06-13
+
+### Changed
+- Refocused the README, crate root documentation, and examples index around the
+  stable camera-first 1.0 adoption path, with exhaustive support and protocol
+  details routed to dedicated reference docs.
+- Clarified that author hardware validation for the 1.0 built-in profiles is
+  limited to PTZOptics brand cameras; other built-in profiles are source-backed
+  and should be validated against target hardware and firmware.
+- Expanded the release documentation checklist to include rustdoc and doctest
+  verification across default and common optional feature sets.
+
 ### Fixed
-- Classified syntax errors on inquiry responses as transient camera responses and logged them at warning level, while preserving error-level logging for command-side syntax errors.
+- Classified syntax errors on inquiry responses as transient camera responses
+  and logged them at warning level, while preserving error-level logging for
+  command-side syntax errors.
 
 ## [0.13.0] - 2026-05-18
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "grafton-visca-macros"]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Grant Sparks <grant@grafton.ai>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/GrantSparks/grafton-visca"
@@ -64,7 +64,7 @@ DISABLED = []
 bytes = "1.11"
 flume = "0.12"
 smallvec = "1.15"
-grafton-visca-macros = { path = "grafton-visca-macros", version = "1.0.0" }
+grafton-visca-macros = { path = "grafton-visca-macros", version = "1.1.0" }
 tracing = "0.1"
 nom = "8.0.0"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "grafton-visca-macros"]
 
 [workspace.package]
-version = "0.13.0"
+version = "1.0.0"
 authors = ["Grant Sparks <grant@grafton.ai>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/GrantSparks/grafton-visca"
@@ -64,7 +64,7 @@ DISABLED = []
 bytes = "1.11"
 flume = "0.12"
 smallvec = "1.15"
-grafton-visca-macros = { path = "grafton-visca-macros", version = "0.13.0" }
+grafton-visca-macros = { path = "grafton-visca-macros", version = "1.0.0" }
 tracing = "0.1"
 nom = "8.0.0"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 
 A pure Rust library for controlling PTZ cameras via the VISCA protocol. Supports blocking and async APIs with built-in runtime adapters (Tokio and smol), TCP/UDP/serial transports, and type-safe camera profiles.
 
+> **Read the 1.0 release announcement**
+> Learn how `grafton-visca` brings camera-first APIs, profile-gated controls, and runtime-agnostic PTZ camera control to Rust: [grafton-visca 1.0: Type-safe control of PTZ cameras in Rust](https://blog.grafton.ai/grafton-visca-1-0-type-safe-control-of-ptz-cameras-in-rust-d027e6f9802f)
+
 ---
 
 ## 1.0 Support Matrix
@@ -219,27 +222,27 @@ For smol, enable `runtime-smol` and use `SmolRuntime`.
 
 ```toml
 [dependencies]
-grafton-visca = "0.13"
+grafton-visca = "1"
 ```
 
 ### Common configurations
 
 ```toml
 # Runtime-agnostic async (bring your own executor)
-grafton-visca = { version = "0.13", features = ["mode-async"] }
+grafton-visca = { version = "1", features = ["mode-async"] }
 
 # Async with Tokio
-grafton-visca = { version = "0.13", features = ["runtime-tokio"] }
+grafton-visca = { version = "1", features = ["runtime-tokio"] }
 tokio = { version = "1", features = ["full"] }
 
 # With serialization
-grafton-visca = { version = "0.13", features = ["serde"] }
+grafton-visca = { version = "1", features = ["serde"] }
 
 # Serial transport (blocking)
-grafton-visca = { version = "0.13", features = ["transport-serial"] }
+grafton-visca = { version = "1", features = ["transport-serial"] }
 
 # Serial transport (Tokio)
-grafton-visca = { version = "0.13", features = ["runtime-tokio", "transport-serial-tokio"] }
+grafton-visca = { version = "1", features = ["runtime-tokio", "transport-serial-tokio"] }
 ```
 
 ### Configuring Standard Transport Behavior

--- a/grafton-visca-macros/README.md
+++ b/grafton-visca-macros/README.md
@@ -227,8 +227,8 @@ This crate follows the same versioning as the main `grafton-visca` crate. Always
 
 ```toml
 [dependencies]
-grafton-visca = "0.12"
-grafton-visca-macros = "0.12"
+grafton-visca = "1"
+grafton-visca-macros = "1"
 ```
 
 ## License

--- a/src/camera/camera_impl.rs
+++ b/src/camera/camera_impl.rs
@@ -827,6 +827,80 @@ where
         Ok((id, future))
     }
 
+    /// Submit a command and return a genuine async operation handle.
+    ///
+    /// This is the async half of the mode-honest `submit` primitive. It enqueues
+    /// the command and returns an [`InFlight`](crate::camera::InFlight) handle
+    /// bound to that exact command's response, without awaiting completion. Drive
+    /// it with `await_applied` / `await_settled`, or `cancel` / `detach` it.
+    ///
+    /// The handle is treated as a [targeted](crate::camera::OpKind::Targeted)
+    /// operation; use [`submit_continuous`](Self::submit_continuous) for a
+    /// continuous drive or a stop.
+    ///
+    /// # Errors
+    /// Returns an error if the command cannot be submitted (for example, an
+    /// inquiry, which is not cancelable).
+    pub async fn submit<C>(
+        &self,
+        command: &C,
+    ) -> Result<crate::camera::InFlight<'_, (), P, Exec>, Error>
+    where
+        C: ViscaCommand,
+        Tr: AsyncTransport + Send + Sync,
+        Exec: Executor + Send + Sync + Clone,
+    {
+        self.submit_op::<(), C>(command, crate::camera::OpKind::Targeted)
+            .await
+    }
+
+    /// Submit a continuous drive or stop command and return an async handle.
+    ///
+    /// Like [`submit`](Self::submit) but the handle is marked
+    /// [continuous](crate::camera::OpKind::Continuous): `await_settled` returns
+    /// [`Error::NotSupported`](crate::Error::NotSupported) because there is no
+    /// well-defined physical-settle event for a continuous drive or a stop.
+    ///
+    /// # Errors
+    /// Returns an error if the command cannot be submitted.
+    pub async fn submit_continuous<C>(
+        &self,
+        command: &C,
+    ) -> Result<crate::camera::InFlight<'_, (), P, Exec>, Error>
+    where
+        C: ViscaCommand,
+        Tr: AsyncTransport + Send + Sync,
+        Exec: Executor + Send + Sync + Clone,
+    {
+        self.submit_op::<(), C>(command, crate::camera::OpKind::Continuous)
+            .await
+    }
+
+    /// Shared submission primitive: enqueue a command and build a typed handle.
+    ///
+    /// This is the single implementation underlying [`submit`](Self::submit), the
+    /// noun-scoped `submit_*` helpers, and the (deprecated) `_op` methods, so none
+    /// of them duplicate the enqueue-and-wrap logic.
+    pub(crate) async fn submit_op<Cat, C>(
+        &self,
+        command: &C,
+        kind: crate::camera::OpKind,
+    ) -> Result<crate::camera::InFlight<'_, Cat, P, Exec>, Error>
+    where
+        C: ViscaCommand,
+        Tr: AsyncTransport + Send + Sync,
+        Exec: Executor + Send + Sync + Clone,
+    {
+        let (id, response_future) = self.start_command_with_id(command).await?;
+        Ok(crate::camera::InFlight::new(
+            id,
+            self.camera_id(),
+            self.runtime(),
+            response_future,
+            kind,
+        ))
+    }
+
     /// Cancel all commands on a specific socket.
     ///
     /// This method sends a cancel command to the specified VISCA socket,
@@ -932,6 +1006,110 @@ where
 
         let response = self.send_command(&command).block();
         std::future::ready(response.and_then(crate::command::Response::into_result))
+    }
+
+    /// Submit a movement/actuation command and return a genuine blocking handle.
+    ///
+    /// This is the blocking half of the mode-honest `submit` primitive: it queues
+    /// the command with the runner (allocating its id) but performs **no**
+    /// transport I/O. Use the returned [`BlockingInFlight`](crate::camera::BlockingInFlight)
+    /// to decide when to block for completion (`await_applied` / `await_settled`),
+    /// to `cancel`, or to `detach`.
+    ///
+    /// The handle is treated as a [targeted](crate::camera::OpKind::Targeted)
+    /// operation whose settle is observed across all axes; use
+    /// [`submit_continuous`](Self::submit_continuous) for a continuous drive or a
+    /// stop.
+    ///
+    /// # Errors
+    /// Returns an error if the command cannot be encoded or the runner is busy.
+    pub fn submit<C>(
+        &self,
+        command: &C,
+    ) -> Result<crate::camera::BlockingInFlight<'_, C, P, Tr>, Error>
+    where
+        C: ViscaCommand,
+    {
+        let id = self.submit_command(command)?;
+        Ok(crate::camera::BlockingInFlight::new(
+            id,
+            self,
+            crate::camera::OpKind::Targeted,
+            crate::camera::Axes::ALL,
+        ))
+    }
+
+    /// Submit a continuous drive or stop command and return a blocking handle.
+    ///
+    /// Like [`submit`](Self::submit) but the handle is marked
+    /// [continuous](crate::camera::OpKind::Continuous): `await_settled` returns
+    /// [`Error::NotSupported`](crate::Error::NotSupported) because there is no
+    /// well-defined physical-settle event for a continuous drive or a stop.
+    ///
+    /// # Errors
+    /// Returns an error if the command cannot be encoded or the runner is busy.
+    pub fn submit_continuous<C>(
+        &self,
+        command: &C,
+    ) -> Result<crate::camera::BlockingInFlight<'_, C, P, Tr>, Error>
+    where
+        C: ViscaCommand,
+    {
+        let id = self.submit_command(command)?;
+        Ok(crate::camera::BlockingInFlight::new(
+            id,
+            self,
+            crate::camera::OpKind::Continuous,
+            crate::camera::Axes::NONE,
+        ))
+    }
+
+    /// Queue a command with the blocking runner without pumping I/O.
+    ///
+    /// Crate-internal primitive shared by [`submit`](Self::submit) and the
+    /// noun-scoped blocking `submit_*` helpers.
+    pub(crate) fn submit_command<C>(&self, command: &C) -> Result<crate::camera::CommandId, Error>
+    where
+        C: ViscaCommand,
+    {
+        let mut runner = self
+            .blocking_runner
+            .try_borrow_mut()
+            .map_err(|_| Error::TransportBusy)?;
+        runner.start_command(command, self.camera_id)
+    }
+
+    /// Drive a specific queued command to its protocol completion, synchronously.
+    ///
+    /// Crate-internal; backs [`BlockingInFlight::await_applied`](crate::camera::BlockingInFlight::await_applied).
+    pub(crate) fn await_command_applied(
+        &self,
+        id: crate::camera::CommandId,
+        deadline: Option<crate::timeout::Deadline>,
+    ) -> Result<(), Error> {
+        let transport_cell = self.transport();
+        let mut transport = transport_cell
+            .try_borrow_mut()
+            .map_err(|_| Error::TransportBusy)?;
+        let mut runner = self
+            .blocking_runner
+            .try_borrow_mut()
+            .map_err(|_| Error::TransportBusy)?;
+        runner
+            .await_command(&mut *transport, id, deadline)
+            .and_then(crate::command::Response::into_result)
+    }
+
+    /// Cancel a specific queued/in-flight command by id.
+    ///
+    /// Crate-internal; backs [`BlockingInFlight::cancel`](crate::camera::BlockingInFlight::cancel).
+    pub(crate) fn cancel_command_id(&self, id: crate::camera::CommandId) -> Result<(), Error> {
+        let mut runner = self
+            .blocking_runner
+            .try_borrow_mut()
+            .map_err(|_| Error::TransportBusy)?;
+        runner.cancel(id);
+        Ok(())
     }
 
     /// Send a typed command and return the response.

--- a/src/camera/camera_impl.rs
+++ b/src/camera/camera_impl.rs
@@ -858,7 +858,7 @@ where
     ///
     /// Like [`submit`](Self::submit) but the handle is marked
     /// [continuous](crate::camera::OpKind::Continuous): `await_settled` returns
-    /// [`Error::NotSupported`](crate::Error::NotSupported) because there is no
+    /// [`Error::NotSupported`] because there is no
     /// well-defined physical-settle event for a continuous drive or a stop.
     ///
     /// # Errors
@@ -1043,7 +1043,7 @@ where
     ///
     /// Like [`submit`](Self::submit) but the handle is marked
     /// [continuous](crate::camera::OpKind::Continuous): `await_settled` returns
-    /// [`Error::NotSupported`](crate::Error::NotSupported) because there is no
+    /// [`Error::NotSupported`] because there is no
     /// well-defined physical-settle event for a continuous drive or a stop.
     ///
     /// # Errors

--- a/src/camera/controls/focus.rs
+++ b/src/camera/controls/focus.rs
@@ -448,6 +448,10 @@ where
     /// - The conversion to `FocusPosition` fails
     /// - The focus position is outside the selected profile's focus range
     /// - The command fails to send
+    #[deprecated(
+        since = "1.1.0",
+        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+    )]
     pub async fn set_focus_op<T>(
         &self,
         position: T,
@@ -458,16 +462,8 @@ where
     {
         let cmd = focus_position_command::<P, T>(position)?;
 
-        // Use start_command_with_id to get the response future without awaiting it
-        let (id, response_future) = self.start_command_with_id(&cmd).await?;
-
-        // Return InFlight handle with the response future
-        Ok(crate::camera::InFlight::new(
-            id,
-            self.camera_id(),
-            self.runtime(),
-            response_future,
-        ))
+        self.submit_op::<crate::camera::FocusOperation, _>(&cmd, crate::camera::OpKind::Targeted)
+            .await
     }
 }
 

--- a/src/camera/controls/pan_tilt.rs
+++ b/src/camera/controls/pan_tilt.rs
@@ -405,16 +405,18 @@ where
         &self,
         command: PanTiltCommand,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::PanTiltOperation, P, Exec>, Error> {
-        let (id, response_future) = self.start_command_with_id(&command).await?;
-        Ok(crate::camera::InFlight::new(
-            id,
-            self.camera_id(),
-            self.runtime(),
-            response_future,
-        ))
+        self.submit_op::<crate::camera::PanTiltOperation, _>(
+            &command,
+            crate::camera::OpKind::Targeted,
+        )
+        .await
     }
 
     /// Move to an absolute pan/tilt position and return an operation handle.
+    #[deprecated(
+        since = "1.1.0",
+        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+    )]
     pub async fn pan_tilt_absolute_op(
         &self,
         pan: impl Into<Degrees>,
@@ -426,6 +428,10 @@ where
     }
 
     /// Move relative to the current position and return an operation handle.
+    #[deprecated(
+        since = "1.1.0",
+        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+    )]
     pub async fn pan_tilt_relative_op(
         &self,
         pan: impl Into<Degrees>,
@@ -453,6 +459,10 @@ where
     ///
     /// # Errors
     /// Returns an error if the command fails to send.
+    #[deprecated(
+        since = "1.1.0",
+        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+    )]
     pub async fn pan_tilt_home_op(
         &self,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::PanTiltOperation, P, Exec>, Error> {
@@ -476,6 +486,10 @@ where
     ///
     /// # Errors
     /// Returns an error if the command fails to send.
+    #[deprecated(
+        since = "1.1.0",
+        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+    )]
     pub async fn pan_tilt_reset_op(
         &self,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::PanTiltOperation, P, Exec>, Error> {

--- a/src/camera/controls/presets.rs
+++ b/src/camera/controls/presets.rs
@@ -219,21 +219,17 @@ where
     Exec: crate::executor::Executor + Send + Sync + Clone + 'static,
 {
     /// Recall a preset position and return an operation handle.
+    #[deprecated(
+        since = "1.1.0",
+        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+    )]
     pub async fn preset_recall_op(
         &self,
         preset: PresetNumber,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::PresetOperation, P, Exec>, Error> {
         let cmd = preset_command::<P>(PresetAction::Recall, preset)?;
 
-        // Use start_command_with_id to get the response future without awaiting it
-        let (id, response_future) = self.start_command_with_id(&cmd).await?;
-
-        // Return InFlight handle with the response future
-        Ok(crate::camera::InFlight::new(
-            id,
-            self.camera_id(),
-            self.runtime(),
-            response_future,
-        ))
+        self.submit_op::<crate::camera::PresetOperation, _>(&cmd, crate::camera::OpKind::Targeted)
+            .await
     }
 }

--- a/src/camera/controls/zoom.rs
+++ b/src/camera/controls/zoom.rs
@@ -379,14 +379,10 @@ where
     pub(crate) async fn start_zoom_operation(
         &self,
         command: ZoomCommand,
+        kind: crate::camera::OpKind,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::ZoomOperation, P, Exec>, Error> {
-        let (id, response_future) = self.start_command_with_id(&command).await?;
-        Ok(crate::camera::InFlight::new(
-            id,
-            self.camera_id(),
-            self.runtime(),
-            response_future,
-        ))
+        self.submit_op::<crate::camera::ZoomOperation, _>(&command, kind)
+            .await
     }
 
     /// Start zooming in and return an operation handle.
@@ -395,8 +391,12 @@ where
         &self,
         speed: Option<ZoomSpeed>,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::ZoomOperation, P, Exec>, Error> {
-        self.start_zoom_operation(zoom_tele_command::<P>(speed)?)
-            .await
+        // Continuous drive: no well-defined settled state.
+        self.start_zoom_operation(
+            zoom_tele_command::<P>(speed)?,
+            crate::camera::OpKind::Continuous,
+        )
+        .await
     }
 
     /// Start zooming out and return an operation handle.
@@ -405,8 +405,12 @@ where
         &self,
         speed: Option<ZoomSpeed>,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::ZoomOperation, P, Exec>, Error> {
-        self.start_zoom_operation(zoom_wide_command::<P>(speed)?)
-            .await
+        // Continuous drive: no well-defined settled state.
+        self.start_zoom_operation(
+            zoom_wide_command::<P>(speed)?,
+            crate::camera::OpKind::Continuous,
+        )
+        .await
     }
 }
 
@@ -421,21 +425,35 @@ where
     Exec: crate::executor::Executor + Send + Sync + Clone + 'static,
 {
     /// Set zoom to a raw VISCA position and return an operation handle.
+    #[deprecated(
+        since = "1.1.0",
+        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+    )]
     pub async fn set_zoom_op(
         &self,
         position: ZoomPosition,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::ZoomOperation, P, Exec>, Error> {
-        self.start_zoom_operation(zoom_position_command::<P>(position)?)
-            .await
+        self.start_zoom_operation(
+            zoom_position_command::<P>(position)?,
+            crate::camera::OpKind::Targeted,
+        )
+        .await
     }
 
     /// Set zoom to a normalized optical position and return an operation handle.
+    #[deprecated(
+        since = "1.1.0",
+        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+    )]
     pub async fn set_zoom_normalized_op(
         &self,
         position: UnitInterval,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::ZoomOperation, P, Exec>, Error> {
-        self.start_zoom_operation(zoom_normalized_command::<P>(position)?)
-            .await
+        self.start_zoom_operation(
+            zoom_normalized_command::<P>(position)?,
+            crate::camera::OpKind::Targeted,
+        )
+        .await
     }
 }
 
@@ -451,13 +469,20 @@ where
     Exec: crate::executor::Executor + Send + Sync + Clone + 'static,
 {
     /// Set zoom to a normalized position in a documented domain and return an operation handle.
+    #[deprecated(
+        since = "1.1.0",
+        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+    )]
     pub async fn set_zoom_normalized_in_domain_op(
         &self,
         position: UnitInterval,
         domain: ZoomDomain,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::ZoomOperation, P, Exec>, Error> {
-        self.start_zoom_operation(zoom_normalized_in_domain_command::<P>(position, domain)?)
-            .await
+        self.start_zoom_operation(
+            zoom_normalized_in_domain_command::<P>(position, domain)?,
+            crate::camera::OpKind::Targeted,
+        )
+        .await
     }
 }
 

--- a/src/camera/inflight.rs
+++ b/src/camera/inflight.rs
@@ -155,7 +155,7 @@ pub struct Preset;
 /// - [`OpKind::Continuous`] — a continuous drive or an instantaneous stop, where
 ///   "physical motion ended" is not a well-defined event (continuous `tele`/
 ///   `wide` zoom, directional pan/tilt, or a `stop`). For these, `await_settled`
-///   returns [`Error::NotSupported`](crate::Error::NotSupported).
+///   returns [`Error::NotSupported`].
 ///
 /// In Phase 1 this distinction is carried as runtime data on the handle. Phase 2
 /// promotes it into the marker type `C` so a wrong `await_settled` call becomes a

--- a/src/camera/inflight.rs
+++ b/src/camera/inflight.rs
@@ -49,6 +49,12 @@ use crate::{
     executor::Executor, Result,
 };
 
+#[cfg(not(feature = "mode-async"))]
+use core::{marker::PhantomData, time::Duration};
+
+#[cfg(not(feature = "mode-async"))]
+use crate::{capabilities::Profile, error::Error, Result};
+
 use core::num::NonZeroU32;
 
 /// Opaque, type-safe identifier for in-flight commands.
@@ -139,6 +145,29 @@ pub struct Focus;
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Preset;
 
+/// Whether an operation has a well-defined *settled* (physical-motion-ended) state.
+///
+/// This distinguishes the two shapes of movement command that share a handle:
+///
+/// - [`OpKind::Targeted`] — a move that reaches a destination and physically
+///   settles (absolute/relative/home/reset, set-position, preset recall).
+///   `await_settled` is meaningful for these.
+/// - [`OpKind::Continuous`] — a continuous drive or an instantaneous stop, where
+///   "physical motion ended" is not a well-defined event (continuous `tele`/
+///   `wide` zoom, directional pan/tilt, or a `stop`). For these, `await_settled`
+///   returns [`Error::NotSupported`](crate::Error::NotSupported).
+///
+/// In Phase 1 this distinction is carried as runtime data on the handle. Phase 2
+/// promotes it into the marker type `C` so a wrong `await_settled` call becomes a
+/// compile error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpKind {
+    /// A targeted move that reaches a destination and physically settles.
+    Targeted,
+    /// A continuous drive or an instantaneous stop with no well-defined settle.
+    Continuous,
+}
+
 /// Type alias for boxed response futures returned by `start_command_with_id`.
 #[cfg(feature = "mode-async")]
 pub type ResponseFuture = Pin<Box<dyn Future<Output = Result<Response, Error>> + Send + 'static>>;
@@ -161,6 +190,7 @@ pub type ResponseFuture = Pin<Box<dyn Future<Output = Result<Response, Error>> +
 /// - `P`: Camera profile type
 /// - `Exec`: Async executor type
 #[cfg(feature = "mode-async")]
+#[must_use = "an InFlight handle does nothing unless you await_applied/await_settled, cancel, or detach it (dropping it detaches: the already-dispatched command keeps running, it is not stopped)"]
 pub struct InFlight<'a, C, P, Exec>
 where
     P: Profile,
@@ -173,8 +203,10 @@ where
     /// Runtime that owns the in-flight command.
     runtime: &'a crate::runtime::RuntimeHandle<P, Exec>,
     /// The response future that completes when the camera reports completion.
-    /// Wrapped in Mutex to allow `await_completion` to take ownership.
+    /// Wrapped in Mutex to allow `await_applied` to take ownership.
     response_future: Mutex<Option<ResponseFuture>>,
+    /// Whether this operation has a well-defined settled state.
+    kind: OpKind,
     /// Zero-sized marker for the category.
     _c: PhantomData<C>,
 }
@@ -198,12 +230,14 @@ where
         camera_id: CameraId,
         runtime: &'a crate::runtime::RuntimeHandle<P, Exec>,
         response_future: ResponseFuture,
+        kind: OpKind,
     ) -> Self {
         Self {
             id,
             camera_id,
             runtime,
             response_future: Mutex::new(Some(response_future)),
+            kind,
             _c: PhantomData,
         }
     }
@@ -228,30 +262,28 @@ where
         self.runtime.cancel(self.camera_id, self.id).await
     }
 
-    /// Wait for this operation to complete.
+    /// Block (asynchronously) until the command is *applied*.
     ///
-    /// This method awaits the response future stored in this handle, which
-    /// completes when the camera sends a VISCA completion message. The timeout
-    /// parameter controls how long to wait for the camera's response.
-    ///
-    /// # Arguments
-    ///
-    /// - `timeout`: Maximum time to wait for completion
+    /// This awaits the response future stored in this handle, which completes
+    /// when the camera has accepted and protocol-completed the command. It is
+    /// available on **every** handle, including continuous drives and stops — a
+    /// deadman `STOP` uses exactly this. The `timeout` bounds how long to wait
+    /// for the camera's response.
     ///
     /// # Returns
     ///
-    /// - `Ok(())` if the operation completed within the timeout
-    /// - `Err(Error::Timeout)` if the timeout elapsed before completion
+    /// - `Ok(())` if the command was applied within the timeout
+    /// - `Err(Error::Timeout)` if the timeout elapsed first
     /// - `Err(Error::*)` for other communication or camera errors
     ///
     /// # Errors
     ///
     /// Returns an error if:
     /// - The wait times out (`Error::Timeout`)
-    /// - This method is called more than once (`Error::InvalidState`)
+    /// - This method (or `await_settled`) is called more than once (`Error::InvalidState`)
     /// - The internal mutex is poisoned (`Error::LockPoisoned`)
     /// - Other communication or camera errors occur
-    pub async fn await_completion(&self, timeout: Duration) -> Result<()> {
+    pub async fn await_applied(&self, timeout: Duration) -> Result<()> {
         // Take the response future from the mutex (can only be awaited once)
         let future = self
             .response_future
@@ -259,10 +291,64 @@ where
             .ok()
             .ok_or(Error::LockPoisoned("InFlight response_future"))?
             .take()
-            .ok_or_else(|| Error::InvalidState("await_completion called more than once".into()))?;
+            .ok_or_else(|| Error::InvalidState("await_applied called more than once".into()))?;
 
         // Use the executor's timeout mechanism to enforce the deadline
         self.runtime.timeout(timeout, future).await?.map(|_| ())
+    }
+
+    /// Deprecated alias for [`await_applied`](Self::await_applied).
+    ///
+    /// Renamed to make the *applied* vs *settled* completion distinction
+    /// explicit. This shim delegates with zero duplicated logic.
+    #[deprecated(
+        since = "1.1.0",
+        note = "renamed to `await_applied` to distinguish applied vs settled completion; this alias will be removed in 2.0"
+    )]
+    pub async fn await_completion(&self, timeout: Duration) -> Result<()> {
+        self.await_applied(timeout).await
+    }
+
+    /// Explicitly detach: give up the handle without awaiting or canceling.
+    ///
+    /// This is the intentional fire-and-forget escape hatch. The already-
+    /// dispatched command keeps running on the camera; only this handle's ability
+    /// to observe completion or cancel it is discarded. Semantically identical to
+    /// dropping the handle, but explicit (and it silences the `#[must_use]` lint).
+    #[inline]
+    pub fn detach(self) {
+        // Nothing to do: dropping the handle performs no cancellation, matching
+        // the documented drop == detach rule (never auto-stop).
+    }
+
+    /// Block (asynchronously) until physical motion has *settled*.
+    ///
+    /// This is meaningful only for targeted moves (absolute/relative/home/reset,
+    /// set-position, preset recall). On profiles that report
+    /// [`SUPPORTS_OPERATION_COMPLETE`], the operation-complete message *is* the
+    /// settled signal, so this is equivalent to
+    /// [`await_applied`](Self::await_applied).
+    ///
+    /// [`SUPPORTS_OPERATION_COMPLETE`]: crate::capabilities::ProfileMetadata::SUPPORTS_OPERATION_COMPLETE
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] if this handle represents a continuous
+    /// drive or a stop (there is no well-defined settled state); [`Error::Timeout`]
+    /// on deadline; other communication / camera errors otherwise.
+    ///
+    /// # Phase 1 limitation
+    ///
+    /// On profiles **without** an operation-complete message this resolves when
+    /// the command is *applied*; for a strict position-based settle, follow up
+    /// with [`Camera::await_axes_idle`](crate::camera::Camera::await_axes_idle).
+    /// A handle-internal position poll (as already implemented for blocking mode)
+    /// is planned alongside the finer targeted/continuous markers.
+    pub async fn await_settled(&self, timeout: Duration) -> Result<()> {
+        if self.kind == OpKind::Continuous {
+            return Err(Error::NotSupported);
+        }
+        self.await_applied(timeout).await
     }
 
     /// Consume this handle and return the parts needed for type-erased handling.
@@ -291,6 +377,181 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InFlight")
             .field("id", &self.id)
+            .field("category", &std::any::type_name::<C>())
+            .finish()
+    }
+}
+
+/// A genuine, synchronous handle to an in-flight blocking command.
+///
+/// This is the blocking-mode counterpart to the async `InFlight` handle. It is
+/// returned by [`Camera::submit`](crate::camera::Camera::submit) (and the
+/// noun-scoped blocking `submit_*` helpers) and provides the same *mode-honest*
+/// surface as the async handle — `await_applied`, `await_settled`, `cancel`,
+/// `detach` — but every method runs **synchronously on the caller's thread**. No
+/// async executor is ever spun up: `await_applied` drives the blocking runner's
+/// `run_until_complete` loop directly.
+///
+/// # Completion semantics
+///
+/// - [`await_applied`](Self::await_applied) resolves when the camera has accepted
+///   and protocol-completed the command. This is what a deadman `STOP` or a
+///   continuous drive uses.
+/// - [`await_settled`](Self::await_settled) resolves when physical motion has
+///   ended — via the operation-complete message on profiles that support it,
+///   otherwise via position polling. It is meaningful only for
+///   [`OpKind::Targeted`] handles; on a continuous/stop handle it returns
+///   [`Error::NotSupported`].
+///
+/// # Safety / lifecycle
+///
+/// The handle is `#[must_use]`: dropping it without `await_applied`,
+/// `await_settled`, `cancel`, or `detach` triggers a lint. **Dropping never
+/// stops the command** — drop is equivalent to [`detach`](Self::detach): the
+/// queued command is left to be flushed by the next blocking operation. Use
+/// [`cancel`](Self::cancel) to discard it instead.
+#[cfg(not(feature = "mode-async"))]
+#[must_use = "a BlockingInFlight handle does nothing unless you await_applied/await_settled, cancel, or detach it (dropping leaves the command queued, it does not stop it)"]
+pub struct BlockingInFlight<'a, C, P, Tr>
+where
+    P: Profile + Default,
+    Tr: crate::transport::BlockingTransport + crate::transport::HasTransportConfig + Send + 'static,
+{
+    /// The command ID assigned by the blocking runner.
+    id: CommandId,
+    /// The camera that owns the runner and transport this command lives in.
+    camera: &'a crate::camera::Camera<crate::mode::Blocking, P, Tr, ()>,
+    /// Whether this operation has a well-defined settled state.
+    kind: OpKind,
+    /// Axes to poll for a position-based settle (used when the profile has no
+    /// operation-complete message).
+    axes: crate::camera::Axes,
+    /// Zero-sized marker for the category.
+    _c: PhantomData<C>,
+}
+
+#[cfg(not(feature = "mode-async"))]
+impl<'a, C, P, Tr> BlockingInFlight<'a, C, P, Tr>
+where
+    P: Profile + Default,
+    Tr: crate::transport::BlockingTransport + crate::transport::HasTransportConfig + Send + 'static,
+{
+    /// Create a new blocking handle. Crate-internal; built by `Camera::submit`.
+    #[inline]
+    pub(crate) fn new(
+        id: CommandId,
+        camera: &'a crate::camera::Camera<crate::mode::Blocking, P, Tr, ()>,
+        kind: OpKind,
+        axes: crate::camera::Axes,
+    ) -> Self {
+        Self {
+            id,
+            camera,
+            kind,
+            axes,
+            _c: PhantomData,
+        }
+    }
+
+    /// Get the command ID assigned by the runner.
+    #[inline]
+    #[must_use]
+    pub fn id(&self) -> CommandId {
+        self.id
+    }
+
+    /// Block until the camera has accepted and protocol-completed the command.
+    ///
+    /// This drives the blocking runner synchronously on the caller's thread until
+    /// the command completes or `timeout` elapses. It is available on every
+    /// handle, including continuous drives and stops.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Timeout`] if the deadline elapses, or a communication /
+    /// camera error otherwise.
+    pub fn await_applied(self, timeout: Duration) -> Result<()> {
+        let deadline = crate::timeout::Deadline::from_timeout(timeout);
+        self.camera.await_command_applied(self.id, Some(deadline))
+    }
+
+    /// Cancel this command via the runner.
+    ///
+    /// If the command is still queued (nothing sent yet), it is discarded and its
+    /// completion resolves as canceled.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::TransportBusy`] if the runner is concurrently borrowed.
+    pub fn cancel(self) -> Result<()> {
+        self.camera.cancel_command_id(self.id)
+    }
+
+    /// Explicitly detach: give up the handle without waiting or canceling.
+    ///
+    /// This is the intentional fire-and-forget escape hatch. The queued command
+    /// is left in place to be flushed by the next blocking operation; it is not
+    /// stopped. Semantically identical to dropping the handle, but explicit (and
+    /// silences the `#[must_use]` lint).
+    #[inline]
+    pub fn detach(self) {
+        // Nothing to do: the command stays queued in the runner. Dropping `self`
+        // performs no cancellation, matching the documented drop == detach rule.
+    }
+}
+
+#[cfg(not(feature = "mode-async"))]
+impl<C, P, Tr> BlockingInFlight<'_, C, P, Tr>
+where
+    P: Profile + Default + crate::capabilities::ProfileMetadata,
+    Tr: crate::transport::BlockingTransport + crate::transport::HasTransportConfig + Send + 'static,
+{
+    /// Block until physical motion has ended.
+    ///
+    /// On profiles that report [`SUPPORTS_OPERATION_COMPLETE`], the operation
+    /// completion message *is* the settled signal, so this is equivalent to
+    /// [`await_applied`](Self::await_applied). On profiles without it, this first
+    /// waits for the command to be applied and then polls the relevant axis
+    /// positions until they stop changing (or `timeout` elapses).
+    ///
+    /// [`SUPPORTS_OPERATION_COMPLETE`]: crate::capabilities::ProfileMetadata::SUPPORTS_OPERATION_COMPLETE
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] if this handle represents a continuous
+    /// drive or a stop (there is no well-defined settled state). Returns
+    /// [`Error::Timeout`] if motion does not settle within `timeout`, or a
+    /// communication / camera error otherwise.
+    pub fn await_settled(self, timeout: Duration) -> Result<()> {
+        if self.kind == OpKind::Continuous {
+            return Err(Error::NotSupported);
+        }
+
+        let deadline = crate::timeout::Deadline::from_timeout(timeout);
+
+        // Applied first: reach the protocol completion for this exact command.
+        self.camera.await_command_applied(self.id, Some(deadline))?;
+
+        // On operation-complete profiles, "applied" already means "settled".
+        if P::SUPPORTS_OPERATION_COMPLETE {
+            return Ok(());
+        }
+
+        // Otherwise fall back to position polling on the affected axes.
+        self.camera.await_axes_settled(self.axes, deadline)
+    }
+}
+
+#[cfg(not(feature = "mode-async"))]
+impl<C, P, Tr> std::fmt::Debug for BlockingInFlight<'_, C, P, Tr>
+where
+    P: Profile + Default,
+    Tr: crate::transport::BlockingTransport + crate::transport::HasTransportConfig + Send + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BlockingInFlight")
+            .field("id", &self.id)
+            .field("kind", &self.kind)
             .field("category", &std::any::type_name::<C>())
             .finish()
     }

--- a/src/camera/mod.rs
+++ b/src/camera/mod.rs
@@ -37,9 +37,11 @@ pub use camera_impl::Camera;
 
 // Re-export accessor and operation types that appear in public signatures.
 pub use accessors::*;
+#[cfg(not(feature = "mode-async"))]
+pub use inflight::BlockingInFlight;
 pub use inflight::{
-    CommandId, Focus as FocusOperation, PanTilt as PanTiltOperation, Preset as PresetOperation,
-    Zoom as ZoomOperation,
+    CommandId, Focus as FocusOperation, OpKind, PanTilt as PanTiltOperation,
+    Preset as PresetOperation, Zoom as ZoomOperation,
 };
 #[cfg(feature = "mode-async")]
 pub use inflight::{InFlight, ResponseFuture};

--- a/src/camera/movement.rs
+++ b/src/camera/movement.rs
@@ -553,7 +553,7 @@ where
     /// * `Err(Error::Timeout)` - Deadline exceeded before completing check
     /// * `Err(...)` - Communication or parse error
     pub fn is_moving_axes_with_deadline(
-        &mut self,
+        &self,
         axes: Axes,
         deadline: Deadline,
         tolerance: &MovementTolerance,
@@ -689,6 +689,34 @@ where
         }
 
         Ok(pt_moving || zoom_moving || focus_moving)
+    }
+
+    /// Poll the given axes until they stop moving or the deadline elapses.
+    ///
+    /// Crate-internal helper backing
+    /// [`BlockingInFlight::await_settled`](crate::camera::BlockingInFlight::await_settled)
+    /// on profiles that do not emit an operation-complete message. Runs entirely
+    /// on the caller's thread using position inquiries.
+    ///
+    /// # Errors
+    /// Returns [`Error::Timeout`] if motion does not settle before `deadline`, or
+    /// a communication / parse error otherwise.
+    pub(crate) fn await_axes_settled(&self, axes: Axes, deadline: Deadline) -> Result<(), Error> {
+        if axes.is_empty() {
+            return Ok(());
+        }
+        let tolerance = MovementTolerance::default();
+        loop {
+            if deadline.is_expired() {
+                return Err(Error::Timeout);
+            }
+            if !self.is_moving_axes_with_deadline(axes, deadline, &tolerance)? {
+                return Ok(());
+            }
+            // Space out samples; the inquiry round-trips already add latency, but
+            // a short sleep avoids hammering the camera on fast links.
+            std::thread::sleep(Duration::from_millis(50));
+        }
     }
 
     /// Wait for movement completion using an [`AwaitConfig`].

--- a/src/dynapi.rs
+++ b/src/dynapi.rs
@@ -1,5 +1,11 @@
 //! Dynamic trait object API with per-operation timeout support.
 //!
+// The hand-written dyn facade still bridges to the static `_op` methods, which
+// are deprecated in favour of `submit` (issue #539, Phase 1). It is slated for
+// descriptor-driven code generation in a follow-up pass; until then, silence the
+// internal deprecation warnings its bridging calls would otherwise emit.
+#![allow(deprecated)]
+//!
 //! This module provides object-safe trait definitions for runtime polymorphism
 //! with cameras. Unlike the static `Camera<M, P, Tr, Exec>` type, these traits
 //! can be used with `dyn` dispatch, enabling heterogeneous collections of cameras
@@ -1025,7 +1031,7 @@ where
         match timeout {
             Some(t) => Box::pin(async move {
                 let handle = self.inner.camera.pan_tilt_home_op().await?;
-                handle.await_completion(t).await
+                handle.await_applied(t).await
             }),
             None => {
                 use crate::camera::controls::pan_tilt::PanTiltControl;
@@ -1055,7 +1061,7 @@ where
                     .camera
                     .pan_tilt_absolute_op(pan_deg, tilt_deg, speed)
                     .await?;
-                handle.await_completion(t).await
+                handle.await_applied(t).await
             }),
             None => {
                 use crate::camera::controls::pan_tilt::PanTiltControl;
@@ -1096,7 +1102,7 @@ where
                     .camera
                     .pan_tilt_relative_op(pan_deg, tilt_deg, speed)
                     .await?;
-                handle.await_completion(t).await
+                handle.await_applied(t).await
             }),
             None => {
                 use crate::camera::controls::pan_tilt::PanTiltControl;
@@ -1139,7 +1145,7 @@ where
         match timeout {
             Some(t) => Box::pin(async move {
                 let handle = self.inner.camera.pan_tilt_reset_op().await?;
-                handle.await_completion(t).await
+                handle.await_applied(t).await
             }),
             None => {
                 use crate::camera::controls::pan_tilt::PanTiltControl;
@@ -1192,7 +1198,7 @@ where
         match timeout {
             Some(t) => Box::pin(async move {
                 let handle = self.inner.camera.zoom_tele_op(speed).await?;
-                handle.await_completion(t).await
+                handle.await_applied(t).await
             }),
             None => {
                 use crate::camera::controls::zoom::ZoomControl;
@@ -1209,7 +1215,7 @@ where
         match timeout {
             Some(t) => Box::pin(async move {
                 let handle = self.inner.camera.zoom_wide_op(speed).await?;
-                handle.await_completion(t).await
+                handle.await_applied(t).await
             }),
             None => {
                 use crate::camera::controls::zoom::ZoomControl;
@@ -1237,8 +1243,12 @@ where
         match timeout {
             Some(t) => Box::pin(async move {
                 let command = crate::camera::controls::zoom::zoom_position_command::<P>(position)?;
-                let handle = self.inner.camera.start_zoom_operation(command).await?;
-                handle.await_completion(t).await
+                let handle = self
+                    .inner
+                    .camera
+                    .start_zoom_operation(command, crate::camera::OpKind::Targeted)
+                    .await?;
+                handle.await_applied(t).await
             }),
             None => match crate::camera::controls::zoom::zoom_position_command::<P>(position) {
                 Ok(command) => self.inner.camera.execute(command),
@@ -1259,7 +1269,11 @@ where
             }
 
             let command = crate::camera::controls::zoom::zoom_position_command::<P>(position)?;
-            let handle = self.inner.camera.start_zoom_operation(command).await?;
+            let handle = self
+                .inner
+                .camera
+                .start_zoom_operation(command, crate::camera::OpKind::Targeted)
+                .await?;
             self.erase_inflight(handle, OperationCategory::Zoom)
         })
     }
@@ -1301,8 +1315,12 @@ where
             Some(t) => Box::pin(async move {
                 let command =
                     crate::camera::controls::zoom::zoom_normalized_command::<P>(position)?;
-                let handle = self.inner.camera.start_zoom_operation(command).await?;
-                handle.await_completion(t).await
+                let handle = self
+                    .inner
+                    .camera
+                    .start_zoom_operation(command, crate::camera::OpKind::Targeted)
+                    .await?;
+                handle.await_applied(t).await
             }),
             None => match crate::camera::controls::zoom::zoom_normalized_command::<P>(position) {
                 Ok(command) => self.inner.camera.execute(command),
@@ -1346,8 +1364,12 @@ where
                     position, domain,
                 )?;
                 let command = crate::camera::controls::zoom::zoom_position_command::<P>(zoom)?;
-                let handle = self.inner.camera.start_zoom_operation(command).await?;
-                handle.await_completion(t).await
+                let handle = self
+                    .inner
+                    .camera
+                    .start_zoom_operation(command, crate::camera::OpKind::Targeted)
+                    .await?;
+                handle.await_applied(t).await
             }),
             None => {
                 let command = crate::camera::controls::zoom::zoom_from_normalized_for_profile::<P>(
@@ -1421,7 +1443,7 @@ where
         match timeout {
             Some(t) => Box::pin(async move {
                 let handle = self.inner.camera.set_focus_op(position).await?;
-                handle.await_completion(t).await
+                handle.await_applied(t).await
             }),
             None => {
                 use crate::camera::controls::focus::FocusControl;
@@ -1501,7 +1523,7 @@ where
         match timeout {
             Some(t) => Box::pin(async move {
                 let handle = self.inner.camera.preset_recall_op(preset).await?;
-                handle.await_completion(t).await
+                handle.await_applied(t).await
             }),
             None => {
                 use crate::camera::controls::presets::PresetsControl;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! grafton-visca = { version = "*", features = ["serde", "schemars"] }
+//! grafton-visca = { version = "1", features = ["serde", "schemars"] }
 //! ```
 //!
 //! With these features enabled, you can serialize/deserialize all value types directly:
@@ -239,7 +239,7 @@
 //! ```ignore
 //! // Multiple runtime features can coexist, but runtime selection is explicit.
 //! [dependencies]
-//! grafton-visca = { version = "*", features = ["runtime-tokio", "runtime-smol"] }
+//! grafton-visca = { version = "1", features = ["runtime-tokio", "runtime-smol"] }
 //!
 //! use grafton_visca::{
 //!     Error,
@@ -411,11 +411,11 @@
 //! ```toml
 //! [dependencies]
 //! # Single runtime:
-//! grafton-visca = { version = "*", features = ["runtime-tokio"] }
-//! grafton-visca = { version = "*", features = ["runtime-smol"] }
+//! grafton-visca = { version = "1", features = ["runtime-tokio"] }
+//! grafton-visca = { version = "1", features = ["runtime-smol"] }
 //!
 //! # Multiple runtimes (choose executor at construction time):
-//! grafton-visca = { version = "*", features = ["runtime-tokio", "runtime-smol"] }
+//! grafton-visca = { version = "1", features = ["runtime-tokio", "runtime-smol"] }
 //! ```
 //!
 //! Then pass the runtime explicitly, either through `Connect` for quick setup or

--- a/src/runtime/blocking_runner.rs
+++ b/src/runtime/blocking_runner.rs
@@ -200,6 +200,31 @@ impl<P: Profile> BlockingRunner<P> {
             }
         }
 
+        let cmd_id = self.start_command(command, camera_id)?;
+
+        self.run_until_complete(transport, cmd_id, deadline)
+    }
+
+    /// Queue a command for sending without pumping the scheduler loop.
+    ///
+    /// This allocates a [`CommandId`], encodes the command, and enqueues it in
+    /// the scheduler core. It performs **no** transport I/O — nothing is sent
+    /// and nothing is awaited. Call [`await_command`](Self::await_command) (or
+    /// the all-in-one [`send_command`](Self::send_command)) afterwards to drive
+    /// the command to completion.
+    ///
+    /// Splitting submission from completion is what makes a genuine blocking
+    /// operation handle possible: the caller can obtain the command's id here,
+    /// then decide separately when (and for how long) to block waiting for it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the command cannot be encoded.
+    pub fn start_command(
+        &mut self,
+        command: &impl ViscaCommand,
+        camera_id: CameraId,
+    ) -> Result<CommandId> {
         // Allocate a unique command ID, skipping zero on wraparound
         let cmd_id = loop {
             let id = self.next_id.fetch_add(1, Ordering::SeqCst);
@@ -217,18 +242,55 @@ impl<P: Profile> BlockingRunner<P> {
             })?,
         );
 
-        let now = Instant::now();
         let pending_cmd = PendingCommand {
             id: cmd_id,
-            command: prepared_cmd.clone(),
+            command: prepared_cmd,
             priority: Priority::Normal,
             camera_id,
-            submitted_at: now,
+            submitted_at: Instant::now(),
         };
 
         self.core.queue_command(pending_cmd);
 
-        self.run_until_complete(transport, cmd_id, deadline)
+        Ok(cmd_id)
+    }
+
+    /// Drive the scheduler synchronously until `target_cmd_id` completes.
+    ///
+    /// This is the completion half of the [`start_command`](Self::start_command)
+    /// /`await_command` split. It runs the scheduler loop on the **caller's
+    /// thread** — no async executor is involved — sending the queued command and
+    /// blocking until the camera reports completion, the command fails, or the
+    /// optional `deadline` is exceeded (`Error::Timeout`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the command fails, the deadline expires, or the
+    /// transport reports a fatal condition.
+    pub fn await_command<T: BlockingTransport + HasTransportConfig>(
+        &mut self,
+        transport: &mut T,
+        target_cmd_id: CommandId,
+        deadline: Option<Deadline>,
+    ) -> Result<Response> {
+        if let Some(ref d) = deadline {
+            if d.is_expired() {
+                self.core.cancel_command(target_cmd_id);
+                return Err(Error::Timeout);
+            }
+        }
+
+        self.run_until_complete(transport, target_cmd_id, deadline)
+    }
+
+    /// Cancel a queued or in-flight command by id.
+    ///
+    /// If the command is still queued (no bytes sent), it is dropped from the
+    /// scheduler core and its completion wait resolves as canceled. If it has
+    /// already been sent, this clears the tracked state; the camera-side effect
+    /// depends on the protocol.
+    pub fn cancel(&mut self, target_cmd_id: CommandId) {
+        self.core.cancel_command(target_cmd_id);
     }
 
     /// Update the timeout configuration.
@@ -656,6 +718,50 @@ mod tests {
         if let Some(cmd) = next {
             assert_eq!(cmd.id, cmd_id(1));
         }
+    }
+
+    /// `start_command` queues a command (assigning an id) without any I/O, and
+    /// `cancel` removes it from the scheduler so nothing is left to send. This is
+    /// the submit/cancel half of the split that backs `BlockingInFlight`.
+    #[test]
+    fn test_start_command_queues_then_cancel_dequeues() {
+        use crate::command::bytes::VISCA_TERMINATOR;
+
+        #[derive(Debug, Clone)]
+        struct TestCmd {
+            bytes: Vec<u8>,
+        }
+
+        impl ViscaCommand for TestCmd {
+            const MAX_SIZE: usize = 6;
+            const TIMEOUT_CATEGORY: CommandCategory = CommandCategory::Quick;
+
+            fn write_into(&self, _camera_id: CameraId, buffer: &mut [u8]) -> Result<usize, Error> {
+                let len = self.bytes.len();
+                buffer[..len].copy_from_slice(&self.bytes);
+                Ok(len)
+            }
+        }
+
+        let mut runner = BlockingRunner::<PtzOpticsG2>::new(TimeoutConfig::default());
+        let test_cmd = TestCmd {
+            bytes: vec![0x81, 0x01, 0x04, 0x00, 0x02, VISCA_TERMINATOR],
+        };
+
+        // start_command queues and returns a non-zero id, performing no I/O.
+        let id = runner
+            .start_command(&test_cmd, CameraId::CAMERA_1)
+            .expect("start_command should queue the command");
+        assert!(id.get() >= 1);
+
+        // cancel removes the queued command: nothing is left to send.
+        runner.cancel(id);
+
+        let now = Instant::now();
+        assert!(
+            runner.core.next_item_to_send(now).is_none(),
+            "cancel should dequeue the pending command"
+        );
     }
 
     /// Mock transport that fails on send for testing send failure propagation.

--- a/src/runtime/core/mod.rs
+++ b/src/runtime/core/mod.rs
@@ -2234,10 +2234,9 @@ impl SchedulerCore {
         // Extract metadata before cleanup
         let (category, camera_id) = if let Some(state) = self.commands.get(&cmd_id) {
             (state.category(), state.camera_id)
-        } else if let Some(state) = self.inquiries.get(&cmd_id) {
-            (state.category(), state.camera_id)
         } else {
-            return None;
+            let state = self.inquiries.get(&cmd_id)?;
+            (state.category(), state.camera_id)
         };
 
         // Clean up sequence mappings

--- a/tests/common/compile_fail.rs
+++ b/tests/common/compile_fail.rs
@@ -85,6 +85,8 @@ pub fn assert_compile_fail_fixtures(fixture_dirs: &[&str], crate_features: &[&st
         )
     });
 
+    prefetch_contract_dependencies(&crate_root, &work_root, crate_features);
+
     for (index, fixture) in fixtures.iter().enumerate() {
         assert_fixture_does_not_compile(&crate_root, &work_root, index, fixture, crate_features);
     }
@@ -118,6 +120,54 @@ fn collect_fixtures(crate_root: &Path, fixture_dirs: &[&str]) -> Vec<PathBuf> {
 
     fixtures.sort();
     fixtures
+}
+
+fn prefetch_contract_dependencies(crate_root: &Path, work_root: &Path, crate_features: &[&str]) {
+    let prefetch_dir = work_root.join("prefetch-dependencies");
+    let prefetch_src_dir = prefetch_dir.join("src");
+    fs::create_dir_all(&prefetch_src_dir).unwrap_or_else(|error| {
+        panic!(
+            "failed to create compile-fail dependency prefetch dir {}: {error}",
+            prefetch_src_dir.display()
+        )
+    });
+    fs::write(
+        prefetch_dir.join("Cargo.toml"),
+        case_manifest(crate_root, 0, "prefetch-dependencies", crate_features),
+    )
+    .unwrap_or_else(|error| {
+        panic!(
+            "failed to write compile-fail dependency prefetch manifest {}: {error}",
+            prefetch_dir.display()
+        )
+    });
+    fs::write(prefetch_src_dir.join("lib.rs"), "").unwrap_or_else(|error| {
+        panic!(
+            "failed to write compile-fail dependency prefetch source {}: {error}",
+            prefetch_src_dir.display()
+        )
+    });
+
+    let mut command = Command::new(cargo_executable());
+    command
+        .arg("fetch")
+        .arg("--quiet")
+        .arg("--manifest-path")
+        .arg(prefetch_dir.join("Cargo.toml"))
+        .env("CARGO_HTTP_MULTIPLEXING", "false")
+        .env("CARGO_NET_RETRY", "10");
+
+    let output = command.output().unwrap_or_else(|error| {
+        panic!("failed to prefetch dependencies for compile-fail fixtures: {error}")
+    });
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!(
+            "failed to prefetch dependencies for compile-fail fixtures\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+    }
 }
 
 fn assert_fixture_does_not_compile(
@@ -161,6 +211,7 @@ fn assert_fixture_does_not_compile(
 
     let output = Command::new(cargo_executable())
         .arg("check")
+        .arg("--offline")
         .arg("--quiet")
         .arg("--manifest-path")
         .arg(case_dir.join("Cargo.toml"))

--- a/tests/issue_539_async_handle_test.rs
+++ b/tests/issue_539_async_handle_test.rs
@@ -1,0 +1,78 @@
+//! Issue #539: async operation handle surface (`InFlight`) parity.
+//!
+//! Verifies the async half of the mode-honest `submit` primitive exposes the same
+//! surface as the blocking handle: `submit` / `submit_continuous` returning a
+//! handle driven by `await_applied` / `await_settled` / `detach`, with the
+//! continuous/stop guard on `await_settled`.
+
+#![cfg(all(feature = "runtime-tokio", feature = "test-utils"))]
+
+use std::time::Duration;
+
+use grafton_visca::{
+    camera::{profiles::PtzOpticsG2, CameraBuilder},
+    command::PanTilt as PanTiltCmd,
+    runtime::TokioRuntime,
+    testing::testkit::{helpers, ScriptedTransport, Step},
+    Error, TokioExecutor,
+};
+
+const TIMEOUT: Duration = Duration::from_secs(2);
+
+fn ack_and_complete() -> Vec<Step> {
+    vec![Step::OnSend {
+        matches: None,
+        responses: vec![helpers::ack(1), helpers::complete(1)],
+    }]
+}
+
+async fn camera(
+    steps: Vec<Step>,
+) -> grafton_visca::camera::AsyncCamera<PtzOpticsG2, ScriptedTransport<TokioExecutor>, TokioRuntime>
+{
+    let transport: ScriptedTransport<TokioExecutor> = ScriptedTransport::new(steps);
+    let runtime = TokioRuntime::from_current().expect("runtime");
+    CameraBuilder::with_executor(runtime)
+        .open_async::<PtzOpticsG2, _>(transport)
+        .await
+        .expect("camera")
+}
+
+/// `submit(...).await_applied(...)` resolves when the command is applied.
+#[tokio::test]
+async fn test_async_submit_await_applied() {
+    let camera = camera(ack_and_complete()).await;
+
+    let handle = camera.submit(&PanTiltCmd::Home).await.expect("submit");
+    handle
+        .await_applied(TIMEOUT)
+        .await
+        .expect("command should be applied");
+}
+
+/// `await_settled` on a continuous/stop handle is `Error::NotSupported`.
+#[tokio::test]
+async fn test_async_submit_continuous_await_settled_not_supported() {
+    let camera = camera(ack_and_complete()).await;
+
+    let handle = camera
+        .submit_continuous(&PanTiltCmd::Home)
+        .await
+        .expect("submit_continuous");
+    let result = handle.await_settled(TIMEOUT).await;
+
+    assert!(
+        matches!(result, Err(Error::NotSupported)),
+        "await_settled on a continuous handle must be NotSupported, got {result:?}"
+    );
+}
+
+/// `detach()` is the explicit fire-and-forget; it consumes the handle and never
+/// stops the (already-dispatched) command.
+#[tokio::test]
+async fn test_async_detach_is_fire_and_forget() {
+    let camera = camera(ack_and_complete()).await;
+
+    let handle = camera.submit(&PanTiltCmd::Home).await.expect("submit");
+    handle.detach();
+}

--- a/tests/issue_539_blocking_handle_test.rs
+++ b/tests/issue_539_blocking_handle_test.rs
@@ -1,0 +1,138 @@
+//! Issue #539: genuine blocking operation handle (`BlockingInFlight`).
+//!
+//! These tests verify the blocking half of the mode-honest `submit` primitive:
+//!
+//! - `submit(cmd).await_applied(timeout)` drives the command to completion
+//!   **synchronously on the caller's thread** (blocking mode has no async
+//!   executor at all), returning the ordinary `Result`.
+//! - Multiple submitted commands each complete through their own handle.
+//! - `await_settled` returns `Error::NotSupported` for a continuous/stop handle.
+//! - `cancel()` discards a queued command before it is ever sent.
+//! - Dropping a handle never stops the command (drop == detach).
+
+#![cfg(all(not(feature = "mode-async"), feature = "test-utils"))]
+
+mod common;
+
+use std::time::Duration;
+
+use grafton_visca::{
+    command::PanTilt as PanTiltCmd,
+    prelude::blocking::*,
+    testing::testkit::{helpers, ScriptedBlockingTransport},
+    Error,
+};
+
+use crate::common::patterns;
+
+const TIMEOUT: Duration = Duration::from_secs(2);
+
+/// `submit().await_applied()` runs entirely on the caller's thread and returns
+/// `Ok(())` once the camera has protocol-completed the command. No async runtime
+/// is created anywhere in this test — blocking mode is structurally synchronous.
+#[test]
+fn test_submit_await_applied_is_synchronous() {
+    let transport = ScriptedBlockingTransport::new(vec![helpers::command_response(
+        patterns::pan_tilt::HOME.to_vec(),
+        1,
+    )]);
+    let camera: Camera<PtzOpticsG2, _> = Camera::new(transport.clone()).unwrap();
+
+    // Nothing is sent until we block for completion.
+    let handle = camera.submit(&PanTiltCmd::Home).unwrap();
+    assert!(
+        transport.sent().is_empty(),
+        "submit must not perform any I/O before await_applied"
+    );
+
+    let result = handle.await_applied(TIMEOUT);
+    assert!(result.is_ok(), "await_applied should succeed: {result:?}");
+
+    let sent = transport.sent();
+    assert_eq!(sent.len(), 1, "exactly one command should be sent");
+    assert_eq!(sent[0], patterns::pan_tilt::HOME);
+}
+
+/// Two commands submitted and awaited (sequentially, the single-threaded blocking
+/// analog of dual-socket parity) both complete through their own handles.
+#[test]
+fn test_multiple_submits_each_complete() {
+    let transport = ScriptedBlockingTransport::new(vec![
+        helpers::command_response(patterns::pan_tilt::HOME.to_vec(), 1),
+        helpers::command_response(patterns::zoom::STOP.to_vec(), 2),
+    ]);
+    let camera: Camera<PtzOpticsG2, _> = Camera::new(transport.clone()).unwrap();
+
+    let first = camera.submit(&PanTiltCmd::Home).unwrap();
+    assert!(
+        first.await_applied(TIMEOUT).is_ok(),
+        "first op should apply"
+    );
+
+    let second = camera.submit(&grafton_visca::command::Zoom::Stop).unwrap();
+    assert!(
+        second.await_applied(TIMEOUT).is_ok(),
+        "second op should apply"
+    );
+
+    let sent = transport.sent();
+    assert_eq!(sent.len(), 2, "both commands should have been sent");
+    assert_eq!(sent[0], patterns::pan_tilt::HOME);
+    assert_eq!(sent[1], patterns::zoom::STOP);
+}
+
+/// `await_settled` on a continuous/stop handle returns `Error::NotSupported`
+/// (Phase 1 runtime guard) — there is no well-defined physical-settle event.
+#[test]
+fn test_continuous_await_settled_not_supported() {
+    let transport = ScriptedBlockingTransport::new(vec![]);
+    let camera: Camera<PtzOpticsG2, _> = Camera::new(transport.clone()).unwrap();
+
+    let handle = camera.submit_continuous(&PanTiltCmd::Home).unwrap();
+    let result = handle.await_settled(TIMEOUT);
+
+    assert!(
+        matches!(result, Err(Error::NotSupported)),
+        "await_settled on a continuous handle must be NotSupported, got {result:?}"
+    );
+    // The guard short-circuits before any I/O.
+    assert!(transport.sent().is_empty());
+}
+
+/// `cancel()` discards a still-queued command before it is ever sent.
+#[test]
+fn test_cancel_before_await_does_not_send() {
+    let transport = ScriptedBlockingTransport::new(vec![helpers::command_response(
+        patterns::pan_tilt::HOME.to_vec(),
+        1,
+    )]);
+    let camera: Camera<PtzOpticsG2, _> = Camera::new(transport.clone()).unwrap();
+
+    let handle = camera.submit(&PanTiltCmd::Home).unwrap();
+    assert!(handle.cancel().is_ok(), "cancel should succeed");
+
+    assert!(
+        transport.sent().is_empty(),
+        "a canceled, never-awaited command must not be sent"
+    );
+}
+
+/// Dropping a handle without awaiting/cancelling never stops the command: it is
+/// simply detached (left queued). A subsequent real operation still works.
+#[test]
+fn test_drop_detaches_without_stopping() {
+    let transport = ScriptedBlockingTransport::new(vec![helpers::command_response(
+        patterns::pan_tilt::HOME.to_vec(),
+        1,
+    )]);
+    let camera: Camera<PtzOpticsG2, _> = Camera::new(transport.clone()).unwrap();
+
+    {
+        // Explicit detach is the documented equivalent of dropping.
+        let handle = camera.submit(&PanTiltCmd::Home).unwrap();
+        handle.detach();
+    }
+
+    // Detach performed no I/O and no cancellation frame.
+    assert!(transport.sent().is_empty());
+}


### PR DESCRIPTION
## Summary

Phase 1 of #539: unify movement/actuation commands around a single **submission
primitive** that returns a **mode-honest operation handle** — genuine in both
async and blocking mode, with explicit *applied* vs *settled* completion
semantics, `#[must_use]`, and `drop == detach`. **Fully additive — no breaking
changes.**

## What's included

- **`Camera::submit` / `submit_continuous`** returning a mode-honest handle:
  async `InFlight` and the new **synchronous `BlockingInFlight`** (drives
  completion on the caller's thread — no async executor). Both expose the same
  `await_applied` / `await_settled` / `cancel` / `detach` surface.
- **`BlockingRunner` split** into `start_command` + `await_command` + `cancel`,
  reusing the existing `run_until_complete` loop.
- **Applied vs settled** semantics with an `OpKind` targeted/continuous guard
  (`await_settled` → `Error::NotSupported` on continuous/stop handles). Blocking
  settle falls back to position polling when a profile lacks operation-complete
  reporting.
- **`#[must_use]`** handles; `drop` never auto-stops (documented `drop == detach`).
- **Deprecates** the nine public `_op` methods and `InFlight::await_completion`
  as thin delegating shims (routed through one `submit_op`).
- New tests across `mode-async`, `mode-blocking`, and `dyn-api`; the
  `api_contract` trybuild stays green (**no public API break**).
- CHANGELOG documents the additive changes, migration path, and the intended
  2.0 follow-ups.

Also folds in a one-line clippy `question_mark` fix in the scheduler core so the
`-D warnings` pre-commit clippy hook passes.

## Verification

Green across `mode-async`, `mode-blocking`, and `dyn-api`: `cargo fmt`, `cargo
clippy` (7 feature configs via pre-commit), `cargo doc` (default + all-features,
`-D warnings`), and the full test suites incl. `api_contract` trybuild (14/14).

## Deferred to follow-up (see CHANGELOG "Intended follow-up changes")

Ergonomic noun-scoped `submit_*` helpers (must precede `_op` removal), the
targeted/continuous marker split (Phase 2, makes a wrong `await_settled` a
compile error), the async `await_settled` position-poll, and descriptor-driven
generation of the `dyn` facade.

## Note on base branch

This branch was cut from `release/1.0.0`, which is ahead of `main`. Because of
that, a diff against `main` also carries the two `v1.0.0` release-prep commits.
Retarget the base to `release/1.0.0` if you want a feature-only diff.
