### PR TITLE
feat(scheduler): bounded contextual retry for transient inquiry 0x02 (#536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+#### Bounded Contextual Retry for Transient Inquiry Syntax Errors (#536)
+
+- A VISCA `0x02` Syntax Error attributed to an **active built-in inquiry** is now
+  treated as a transient camera-overload signal and retried by the scheduler with
+  bounded backoff, reusing the existing per-category retry budget, backoff, and
+  `RetryConfig::max_retry_duration`. Previously such inquiries failed immediately.
+  This is a **narrow, contextual** retry — not general syntax-error retryability:
+  - Command-side `0x02` remains terminal and fails immediately with
+    `Error::SyntaxError`, with no retry queued.
+  - Raw custom inquiries (`InquiryResponseSpec::Raw`) remain terminal by default,
+    so malformed custom bytes are not hidden by silent retries.
+  - `Error::SyntaxError.is_retryable()` is unchanged (still `false`); the decision
+    lives in a single scheduler-owned classifier keyed on the raw error code plus
+    live entry context (entry kind, response spec, lifecycle phase).
+  - When the retry budget or max retry duration is exhausted, the operation fails
+    with `SyntaxError` (wrapped in context), never a generic `Timeout`.
+- Retry dispatch now re-enters the scheduler's normal send path instead of being
+  sent directly by the runtime loops, so ready retries honor profile send pacing
+  (`MIN_COMMAND_SPACING`, `MIN_INQUIRY_SPACING`), the max in-flight inquiry limit,
+  and command socket capacity — for **all** retries, not just syntax-error retries.
+- A retryable inquiry `0x02` also applies an inquiry-class cooldown, delaying the
+  failed inquiry's resend and any other queued inquiry for the backoff window
+  without pausing command traffic.
+
 ## [1.1.0] - 2026-07-16
 
 ### Added

--- a/src/runtime/async_adapter.rs
+++ b/src/runtime/async_adapter.rs
@@ -16,8 +16,8 @@ use crate::{
     error::{Error, Result},
     executor::Executor,
     runtime::core::{
-        CancelOutcome, PendingCommand, Priority, RetryCommand, SchedulerAction, SchedulerCore,
-        SchedulerEvent, TimeoutKind,
+        CancelOutcome, PendingCommand, Priority, SchedulerAction, SchedulerCore, SchedulerEvent,
+        TimeoutKind,
     },
     runtime::driver::{receive_one, IgnoreReason, ReceiveDisposition},
     timeout::{CommandCategory, TimeoutConfig},
@@ -572,38 +572,17 @@ impl<P: Profile, E: Executor> AsyncAdapter<P, E> {
                         _ => self.metrics.protocol_errors += 1,
                     }
 
-                    // Log errors appropriately based on severity. A Syntax
-                    // Error on an inquiry can be a transient camera response
-                    // while the camera is busy moving; command-side syntax
-                    // errors are stronger evidence of an unsupported command.
-                    if *code == 0x02 || *code == 0x41 {
-                        let response_spec = cmd_id
-                            .and_then(|id| self.core.get_inquiry_response_spec(id))
-                            .map(|ty| format!("{:?}", ty));
-
-                        let message = if *code == 0x02 && response_spec.is_some() {
-                            "Syntax Error on inquiry - transient camera response; caller may retry"
-                        } else if *code == 0x02 {
-                            "Syntax Error - command likely unsupported by camera"
-                        } else {
+                    // Syntax-error (0x02) diagnostics — transient inquiry retry
+                    // vs. terminal command syntax error — are emitted
+                    // authoritatively by the scheduler core so the blocking and
+                    // async paths log identically. Only the contextual 0x41 note
+                    // is logged here.
+                    if *code == 0x41 {
+                        tracing::error!(
+                            ?cmd_id,
+                            code = "0x41",
                             "Command Not Executable in current state"
-                        };
-
-                        if *code == 0x02 && response_spec.is_some() {
-                            tracing::warn!(
-                                ?cmd_id,
-                                response_spec,
-                                code = format!("0x{:02x}", code),
-                                message
-                            );
-                        } else {
-                            tracing::error!(
-                                ?cmd_id,
-                                response_spec,
-                                code = format!("0x{:02x}", code),
-                                message
-                            );
-                        }
+                        );
                     }
                 }
                 event
@@ -754,10 +733,12 @@ impl<P: Profile, E: Executor> AsyncAdapter<P, E> {
         Ok(())
     }
 
-    /// Get retries that are ready to send.
-    pub fn get_ready_retries(&mut self) -> Vec<RetryCommand> {
+    /// Promote retries whose backoff has elapsed back onto the send queues so
+    /// they are dispatched through `next_item_to_send` (pacing/capacity gated),
+    /// rather than sent directly. Returns the number of retries promoted.
+    pub fn promote_ready_retries(&mut self) -> usize {
         let now = self.executor.now();
-        self.core.get_ready_retries(now)
+        self.core.promote_ready_retries(now)
     }
 
     /// Get the next deadline for time-based operations.

--- a/src/runtime/blocking_runner.rs
+++ b/src/runtime/blocking_runner.rs
@@ -17,7 +17,7 @@ use crate::{
     camera::CommandId,
     camera_id::CameraId,
     capabilities::Profile,
-    command::{response::Response, CommandKind, ViscaCommand},
+    command::{response::Response, ViscaCommand},
     error::{Error, Result},
     protocol::framer::ProtocolFramer,
     runtime::{
@@ -400,7 +400,21 @@ impl<P: Profile> BlockingRunner<P> {
 
             let now = Instant::now();
 
-            if let Some(cmd) = self.core.next_item_to_send(now) {
+            // Promote any retries whose backoff has elapsed back onto the send
+            // queues so they are dispatched through the same pacing/capacity
+            // gates as fresh sends (profile spacing, socket/in-flight limits,
+            // inquiry cooldown) rather than bypassing them.
+            self.core.promote_ready_retries(now);
+
+            // Drain everything currently sendable (fresh sends and promoted
+            // retries alike). `next_item_to_send` returns `None` as soon as a
+            // pacing or capacity gate blocks, so this naturally stops at the
+            // profile's spacing boundaries.
+            loop {
+                let Some(cmd) = self.core.next_item_to_send(now) else {
+                    break;
+                };
+
                 let mut scheduler = BlockingScheduler {
                     core: &mut self.core,
                     now,
@@ -446,72 +460,9 @@ impl<P: Profile> BlockingRunner<P> {
                                 return Err(error);
                             }
                         }
-                        continue;
-                    }
-                }
-            }
-
-            let ready_retries = self.core.get_ready_retries(now);
-            for retry in ready_retries {
-                let kind = retry.kind();
-
-                let mut scheduler = BlockingScheduler {
-                    core: &mut self.core,
-                    now,
-                };
-
-                let write_timeout = transport.transport_config().write_timeout;
-
-                let pending_cmd = PendingCommand {
-                    id: retry.id,
-                    command: retry.command.clone(),
-                    priority: retry.priority,
-                    camera_id: retry.camera_id,
-                    submitted_at: now,
-                };
-
-                match send_one(
-                    transport,
-                    &mut scheduler,
-                    pending_cmd,
-                    &self.envelope,
-                    &mut send_buf,
-                    write_timeout,
-                ) {
-                    SendResult::Ok => {
-                        debug!(
-                            "Sent retry for {} {retry_id} (attempt {attempt})",
-                            if kind == CommandKind::Inquiry {
-                                "inquiry"
-                            } else {
-                                "command"
-                            },
-                            retry_id = retry.id,
-                            attempt = retry.attempt
-                        );
-                    }
-                    SendResult::Err { error, action } => {
-                        debug!("Send retry operation failed: {error:?}");
-                        // For stream transports, a send failure poisons the transport
-                        if transport.send_semantics() == SendSemantics::Stream {
-                            let reason = format!("Send failed during retry: {error}");
-                            tracing::error!(
-                                send_semantics = ?transport.send_semantics(),
-                                reason = %reason,
-                                "Stream transport poisoned - failing command and exiting"
-                            );
-                            self.core.clear_all();
-                            return Err(Error::StreamPoisoned {
-                                reason: reason.into(),
-                            });
-                        }
-                        // For datagram transports, check if this failure is for our target command
-                        if let Some(SchedulerAction::CommandFailed { id, error }) = action {
-                            if id == target_cmd_id {
-                                return Err(error);
-                            }
-                        }
-                        continue;
+                        // Stop draining and fall through to timeout/receive
+                        // handling; remaining sendable items are retried next loop.
+                        break;
                     }
                 }
             }
@@ -643,6 +594,7 @@ mod tests {
     use super::*;
     use crate::camera::profiles::PtzOpticsG2;
     use crate::command::encode::ViscaCommand;
+    use crate::command::CommandKind;
     use crate::timeout::CommandCategory;
     use crate::transport::builder::TransportConfig;
     use std::collections::VecDeque;

--- a/src/runtime/core/mod.rs
+++ b/src/runtime/core/mod.rs
@@ -5,7 +5,7 @@
 //! on async runtimes or channels.
 
 use smallvec::SmallVec;
-use tracing::{debug, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 use std::{
     cell::Cell,
@@ -353,7 +353,7 @@ pub struct RetryCommand {
 
 impl RetryCommand {
     /// Get the command kind (Command or Inquiry).
-    #[cfg(any(not(feature = "mode-async"), test))]
+    #[cfg(test)]
     #[inline]
     pub fn kind(&self) -> CommandKind {
         self.command.kind()
@@ -412,6 +412,21 @@ struct RetryState {
     attempt: u32,
     transport_error: bool,
     category: CommandCategory,
+}
+
+/// Outcome of the scheduler's contextual retry classification for a VISCA
+/// protocol error attributed to an active command or inquiry.
+enum RetryDecision {
+    /// Queue a bounded retry through the existing retry/backoff machinery.
+    ///
+    /// `inquiry_syntax` is `true` only for the narrow transient inquiry-side
+    /// `0x02` case, which additionally arms the inquiry-class cooldown.
+    Retry {
+        /// Whether this is a transient inquiry-side syntax error.
+        inquiry_syntax: bool,
+    },
+    /// Fail terminally with this error; no retry is queued.
+    Fail(Error),
 }
 
 /// Priority queue item wrapper for commands.
@@ -932,6 +947,10 @@ pub struct SchedulerCore {
     min_command_spacing: Duration,
     /// When the last command (of any kind) was sent (for spacing enforcement).
     last_command_sent: Option<Instant>,
+    /// Deadline until which inquiry sends are held back after a transient
+    /// inquiry-side syntax error, letting an overloaded camera recover before
+    /// the failed inquiry is resent or another queued inquiry is dispatched.
+    inquiry_cooldown_until: Option<Instant>,
     /// Counter for ignored unmatched sequenced replies.
     ///
     /// Tracks the number of times a sequenced reply (ACK, Completion, Error, InquiryReply)
@@ -977,6 +996,7 @@ impl SchedulerCore {
             last_inquiry_sent: None,
             min_command_spacing: Duration::ZERO,
             last_command_sent: None,
+            inquiry_cooldown_until: None,
             ignored_unmatched_sequenced_replies: 0,
         }
     }
@@ -1110,6 +1130,15 @@ impl SchedulerCore {
         // Check command spacing requirement (applies to all send types)
         if !self.check_command_spacing(now) {
             return false;
+        }
+
+        // Honor the inquiry-class cooldown armed after a transient inquiry
+        // syntax error. This backs off the whole inquiry class (the failed
+        // inquiry and any other queued inquiries) without pausing commands.
+        if let Some(until) = self.inquiry_cooldown_until {
+            if now < until {
+                return false;
+            }
         }
 
         // Count inquiry entries by phase.
@@ -1771,36 +1800,51 @@ impl SchedulerCore {
                 }
             }
             SchedulerEvent::Error { source, code } => {
-                let error = ViscaError::from_byte(code);
-
                 // Resolve which command this error belongs to using ReplySource
                 let resolved_cmd_id = self.resolve_command_for_error(&source, code);
 
                 if let Some(cmd_id) = resolved_cmd_id {
-                    // Check if this is an inquiry via phase
-                    let is_inquiry = self.is_awaiting_inquiry_reply(cmd_id);
-
-                    if is_inquiry {
-                        // Remove from inquiry FIFO order
+                    // An attributed inquiry error leaves the FIFO attribution
+                    // order; a queued retry re-adds it exactly once on resend.
+                    if self.is_awaiting_inquiry_reply(cmd_id) {
                         self.inquiries_order.retain(|&id| id != cmd_id);
                     }
 
-                    let should_retry = self.should_retry_command(cmd_id, &error, now);
-
-                    if should_retry {
-                        if let Some(retry_action) = self.queue_retry_for_command(cmd_id, now, None)
-                        {
-                            actions.push(retry_action);
+                    match self.classify_error_retry(cmd_id, code, now) {
+                        RetryDecision::Retry { inquiry_syntax } => {
+                            if let Some(retry_action) =
+                                self.queue_retry_for_command(cmd_id, now, None)
+                            {
+                                if inquiry_syntax {
+                                    // Bounded transient inquiry-side syntax error:
+                                    // arm the inquiry-class cooldown for the backoff
+                                    // window and log at warning level.
+                                    let attempt = self.active_attempt(cmd_id).unwrap_or(0);
+                                    let delay = self.retry_delay_for(attempt, None);
+                                    self.arm_inquiry_cooldown(now + delay);
+                                    warn!(
+                                        %cmd_id,
+                                        response_spec = ?self.get_inquiry_response_spec(cmd_id),
+                                        attempt,
+                                        ?delay,
+                                        "Transient inquiry syntax error (0x02); scheduler will retry with backoff"
+                                    );
+                                }
+                                actions.push(retry_action);
+                            }
                         }
-                    } else {
-                        // Clean up and fail the command
-                        self.finish_sequence(cmd_id);
-                        self.commands.remove(&cmd_id);
-                        self.inquiries.remove(&cmd_id);
-                        actions.push(SchedulerAction::CommandFailed {
-                            id: cmd_id,
-                            error: Error::from_code(code),
-                        });
+                        RetryDecision::Fail(error) => {
+                            // Command-side and exhausted-inquiry syntax errors are
+                            // terminal; log 0x02 at error level to distinguish an
+                            // unsupported command from a transient inquiry response.
+                            if code == 0x02 {
+                                error!(%cmd_id, code = "0x02", "Terminal syntax error: {error}");
+                            }
+                            self.finish_sequence(cmd_id);
+                            self.commands.remove(&cmd_id);
+                            self.inquiries.remove(&cmd_id);
+                            actions.push(SchedulerAction::CommandFailed { id: cmd_id, error });
+                        }
                     }
                 } else if source.allows_heuristic_fallback() {
                     // Raw VISCA: as a last resort, never drop protocol errors on the floor.
@@ -2120,6 +2164,45 @@ impl SchedulerCore {
         ready
     }
 
+    /// Move retries whose backoff has elapsed back onto the normal send queues
+    /// so they are dispatched through [`next_item_to_send`](Self::next_item_to_send),
+    /// subjecting them to the same profile pacing and capacity gates as fresh
+    /// sends (command/inquiry spacing, socket and in-flight limits, and the
+    /// inquiry cooldown). This prevents ready retries from bypassing pacing.
+    ///
+    /// Returns the number of retries promoted. Stale retries (command completed,
+    /// superseded attempt, or no longer in `Queued` phase) are dropped by
+    /// [`get_ready_retries`](Self::get_ready_retries) and never promoted. The
+    /// promoted entry keeps its incremented `attempt` and original `submitted_at`;
+    /// resend re-adds it to the inquiry FIFO order exactly once.
+    pub fn promote_ready_retries(&mut self, now: Instant) -> usize {
+        let ready = self.get_ready_retries(now);
+        let promoted = ready.len();
+        for retry in ready {
+            let submitted_at = self.active_submitted_at(retry.id).unwrap_or(retry.retry_at);
+            let pending = PendingCommand {
+                id: retry.id,
+                command: retry.command,
+                priority: retry.priority,
+                camera_id: retry.camera_id,
+                submitted_at,
+            };
+            match pending.command.behavior {
+                crate::command::CommandBehavior::Inquiry(_) => self.inquiry_queue.push(pending),
+                crate::command::CommandBehavior::Command => self.command_queue.push(pending),
+            }
+        }
+        promoted
+    }
+
+    /// Original submission time of an active command or inquiry, if tracked.
+    fn active_submitted_at(&self, cmd_id: CommandId) -> Option<Instant> {
+        self.commands
+            .get(&cmd_id)
+            .map(|state| state.submitted_at)
+            .or_else(|| self.inquiries.get(&cmd_id).map(|state| state.submitted_at))
+    }
+
     /// Get the next deadline for time-based operations.
     ///
     /// Uses active command and inquiry state to find the earliest deadline among:
@@ -2165,6 +2248,14 @@ impl SchedulerCore {
             if let Some(last_sent) = self.last_inquiry_sent {
                 let next_inquiry_eligible = last_sent + self.min_inquiry_spacing;
                 Self::update_earliest(&mut earliest, next_inquiry_eligible);
+            }
+        }
+
+        // Inquiry cooldown deadline (when the inquiry class is released after a
+        // transient syntax error). Only relevant while inquiries are waiting.
+        if !self.inquiry_queue.is_empty() {
+            if let Some(until) = self.inquiry_cooldown_until {
+                Self::update_earliest(&mut earliest, until);
             }
         }
 
@@ -2622,28 +2713,103 @@ impl SchedulerCore {
         (true, None, None)
     }
 
-    fn should_retry_command(&self, cmd_id: CommandId, error: &ViscaError, now: Instant) -> bool {
+    /// Returns `true` if another retry is permitted by both the category retry
+    /// budget and `RetryConfig::max_retry_duration` (measured from original
+    /// submission).
+    fn within_retry_bounds(
+        &self,
+        attempt: u32,
+        category: CommandCategory,
+        submitted_at: Instant,
+        now: Instant,
+    ) -> bool {
+        let max_retries = self.retry_budget.for_category(category);
+        let within_duration =
+            now.duration_since(submitted_at) < self.retry_config.max_retry_duration;
+        attempt < max_retries && within_duration
+    }
+
+    /// Contextual, scheduler-owned retry classification for an attributed VISCA
+    /// protocol error.
+    ///
+    /// This is the single decision point for whether a protocol error retries
+    /// or fails terminally, and which error to surface when it fails. It keeps
+    /// `Error::SyntaxError.is_retryable()` `false`: the narrow transient
+    /// inquiry-side `0x02` case is recognised here from the raw code plus live
+    /// entry context (entry kind, response spec, lifecycle phase), never by
+    /// broadening public error retryability.
+    ///
+    /// Rules:
+    /// - Command-side errors: only the standard retryable codes (buffer full,
+    ///   and `0x41` for movement/preset) retry; everything else — including
+    ///   `0x02` — is terminal and diagnostic.
+    /// - Inquiry-side errors: standard retryable codes retry as usual; a `0x02`
+    ///   on a `Builtin` inquiry still awaiting its reply is treated as a
+    ///   transient overload signal and retried within budget, then fails as a
+    ///   contextual `SyntaxError` once exhausted. `Raw` inquiries stay terminal
+    ///   so genuine malformed-byte bugs are not hidden.
+    fn classify_error_retry(&self, cmd_id: CommandId, code: u8, now: Instant) -> RetryDecision {
+        let error = ViscaError::from_byte(code);
+
         if let Some(state) = self.commands.get(&cmd_id) {
-            if error.is_retryable(Some(state.category())) {
-                let max_retries = self.retry_budget.for_category(state.category());
-                let within_duration =
-                    now.duration_since(state.submitted_at) < self.retry_config.max_retry_duration;
-                state.attempt < max_retries && within_duration
-            } else {
-                false
+            let category = state.category();
+            if error.is_retryable(Some(category))
+                && self.within_retry_bounds(state.attempt, category, state.submitted_at, now)
+            {
+                return RetryDecision::Retry {
+                    inquiry_syntax: false,
+                };
             }
-        } else {
-            self.inquiries.get(&cmd_id).is_some_and(|state| {
-                if error.is_retryable(Some(state.category())) {
-                    let max_retries = self.retry_budget.for_category(state.category());
-                    let within_duration = now.duration_since(state.submitted_at)
-                        < self.retry_config.max_retry_duration;
-                    state.attempt < max_retries && within_duration
-                } else {
-                    false
-                }
-            })
+            return RetryDecision::Fail(Error::from_code(code));
         }
+
+        if let Some(state) = self.inquiries.get(&cmd_id) {
+            let category = state.category();
+            let within_bounds =
+                self.within_retry_bounds(state.attempt, category, state.submitted_at, now);
+
+            if error.is_retryable(Some(category)) {
+                return if within_bounds {
+                    RetryDecision::Retry {
+                        inquiry_syntax: false,
+                    }
+                } else {
+                    RetryDecision::Fail(Error::from_code(code))
+                };
+            }
+
+            if code == 0x02
+                && matches!(state.response_spec, InquiryResponseSpec::Builtin(_))
+                && state.phase.is_awaiting_reply()
+            {
+                return if within_bounds {
+                    RetryDecision::Retry {
+                        inquiry_syntax: true,
+                    }
+                } else {
+                    // Exhausted by count or duration: surface a syntax error
+                    // with context so retry exhaustion is distinguishable from a
+                    // first-attempt syntax error, while staying non-retryable.
+                    RetryDecision::Fail(
+                        Error::SyntaxError
+                            .with_context("inquiry syntax-error retry budget exhausted"),
+                    )
+                };
+            }
+
+            return RetryDecision::Fail(Error::from_code(code));
+        }
+
+        // No active entry (already cleaned up): nothing to retry.
+        RetryDecision::Fail(Error::from_code(code))
+    }
+
+    /// Extend the inquiry-class cooldown so it lasts at least until `until`.
+    fn arm_inquiry_cooldown(&mut self, until: Instant) {
+        self.inquiry_cooldown_until = Some(match self.inquiry_cooldown_until {
+            Some(existing) => existing.max(until),
+            None => until,
+        });
     }
 
     /// Handle a send failure by immediately failing the command.
@@ -2711,6 +2877,21 @@ impl SchedulerCore {
         }
     }
 
+    /// Compute the backoff delay for a given (1-based) retry attempt.
+    ///
+    /// When `delay_exponent_cap` is `Some(cap)`, the attempt number used for the
+    /// delay calculation is capped at `cap + 1` so the backoff exponent does not
+    /// exceed `cap`. Shared by the retry queue and the inquiry cooldown so both
+    /// derive identical timings from a single source.
+    fn retry_delay_for(&self, new_attempt: u32, delay_exponent_cap: Option<u32>) -> Duration {
+        let delay_attempt = match delay_exponent_cap {
+            Some(cap) => new_attempt.min(cap + 1),
+            None => new_attempt,
+        };
+        let retry_attempt = RetryAttempt::new(delay_attempt).unwrap_or(RetryAttempt::FIRST);
+        self.retry_config.calculate_delay(retry_attempt, None)
+    }
+
     /// Queue a command for retry based on the retry configuration.
     ///
     /// If `delay_exponent_cap` is `Some(cap)`, the backoff exponent is capped at `cap`
@@ -2755,16 +2936,8 @@ impl SchedulerCore {
         // Update retry count in active state
         self.set_active_attempt(cmd_id, new_attempt);
 
-        // Calculate backoff delay using RetryConfig
-        // new_attempt is 1-based (state.attempt starts at 0, we added 1 above)
-        // When delay_exponent_cap is set, cap the attempt number used for delay
-        // calculation so the exponent doesn't exceed the cap.
-        let delay_attempt = match delay_exponent_cap {
-            Some(cap) => new_attempt.min(cap + 1),
-            None => new_attempt,
-        };
-        let retry_attempt = RetryAttempt::new(delay_attempt).unwrap_or(RetryAttempt::FIRST);
-        let delay = self.retry_config.calculate_delay(retry_attempt, None);
+        // Calculate backoff delay using RetryConfig (new_attempt is 1-based).
+        let delay = self.retry_delay_for(new_attempt, delay_exponent_cap);
 
         let retry_cmd = RetryCommand {
             id: cmd_id,
@@ -2919,6 +3092,7 @@ impl SchedulerCore {
         self.last_logged_idle.set(false);
         self.last_inquiry_sent = None;
         self.last_command_sent = None;
+        self.inquiry_cooldown_until = None;
     }
 
     /// Check if a command is in the AwaitingAck phase.

--- a/src/runtime/core/tests.rs
+++ b/src/runtime/core/tests.rs
@@ -2467,8 +2467,8 @@ fn test_max_retry_duration_queue_retry_for_command() {
 }
 
 #[test]
-fn test_max_retry_duration_should_retry_command() {
-    // Test that should_retry_command respects max_retry_duration
+fn test_max_retry_duration_classify_error_retry() {
+    // Test that classify_error_retry respects max_retry_duration
     let timeout_config = TimeoutConfig::default();
     let retry_config = RetryConfig {
         max_retries: 10,
@@ -2484,19 +2484,23 @@ fn test_max_retry_duration_should_retry_command() {
     // Register a command
     core.register_pending_ack(cmd_id(1), cmd, Priority::Normal, CameraId::CAMERA_1, start);
 
-    // Create a retryable error (0x41 = CommandNotExecutable, retryable for Movement)
-    let error = ViscaError::from_byte(0x41);
-
-    // Should retry within duration
+    // 0x41 = CommandNotExecutable, retryable for Movement.
+    // Should retry within duration.
     assert!(
-        core.should_retry_command(cmd_id(1), &error, start + Duration::from_millis(50)),
-        "Expected should_retry_command=true within duration"
+        matches!(
+            core.classify_error_retry(cmd_id(1), 0x41, start + Duration::from_millis(50)),
+            RetryDecision::Retry { .. }
+        ),
+        "Expected Retry within duration"
     );
 
-    // Should NOT retry after duration exceeded
+    // Should NOT retry after duration exceeded.
     assert!(
-        !core.should_retry_command(cmd_id(1), &error, start + Duration::from_millis(150)),
-        "Expected should_retry_command=false after duration exceeded"
+        matches!(
+            core.classify_error_retry(cmd_id(1), 0x41, start + Duration::from_millis(150)),
+            RetryDecision::Fail(_)
+        ),
+        "Expected Fail after duration exceeded"
     );
 }
 
@@ -2664,12 +2668,14 @@ fn test_retry_config_should_retry_method_parity() {
     let cmd = make_duration_test_cmd(CommandCategory::Movement);
     core.register_pending_ack(cmd_id(1), cmd, Priority::Normal, CameraId::CAMERA_1, start);
 
-    let error = ViscaError::from_byte(0x41); // Retryable for Movement
-
+    // 0x41 is retryable for Movement.
     // Note: SchedulerCore uses category-based budgets which differ from raw max_retries
     // Movement category uses base max_retries (3), so behavior should align
     assert!(
-        core.should_retry_command(cmd_id(1), &error, start),
+        matches!(
+            core.classify_error_retry(cmd_id(1), 0x41, start),
+            RetryDecision::Retry { .. }
+        ),
         "SchedulerCore should align with RetryConfig at start"
     );
 }
@@ -5186,4 +5192,546 @@ fn test_exponent_cap_parameter_in_queue_retry() {
         }
         other => panic!("Expected RetryCommand action, got {:?}", other),
     }
+}
+
+// ============================================================================
+// Issue #536: Bounded contextual retry for transient inquiry-side 0x02 errors
+// ============================================================================
+//
+// These tests exercise the scheduler-owned retry classification and the
+// inquiry-class cooldown. They assert that a *built-in* inquiry `0x02` retries
+// with bounded backoff while command-side and raw-inquiry `0x02` stay terminal,
+// that retry exhaustion surfaces syntax-error semantics (never a generic
+// `Timeout`), and that retry dispatch honors profile pacing/capacity.
+
+/// Build an inquiry `EncodedCommand` with an explicit response spec and category.
+fn make_issue536_inquiry(
+    spec: InquiryResponseSpec,
+    category: CommandCategory,
+) -> Arc<EncodedCommand> {
+    Arc::new(EncodedCommand {
+        payload: SmallVec::from_slice(&[0x81, 0x09, 0x00, 0x02, VISCA_TERMINATOR]),
+        behavior: CommandBehavior::Inquiry(spec),
+        category,
+    })
+}
+
+/// Build a plain command `EncodedCommand`.
+fn make_issue536_command(category: CommandCategory) -> Arc<EncodedCommand> {
+    Arc::new(EncodedCommand {
+        payload: SmallVec::from_slice(&[0x81, 0x01, 0x04, 0x00, 0x02, VISCA_TERMINATOR]),
+        behavior: CommandBehavior::Command,
+        category,
+    })
+}
+
+/// An attributed VISCA `0x02` syntax error for the given command id.
+fn syntax_error_for(id: CommandId) -> SchedulerEvent {
+    SchedulerEvent::Error {
+        source: ReplySource::from_fields(Some(id), None, None),
+        code: 0x02,
+    }
+}
+
+/// True if `err` is `SyntaxError`, including when wrapped in context.
+fn is_syntax_error(err: &Error) -> bool {
+    match err {
+        Error::SyntaxError => true,
+        Error::WithContext { source, .. } => is_syntax_error(source),
+        _ => false,
+    }
+}
+
+/// Drive one retry resend (promote the ready retry and start it), as the
+/// runtime loop would, returning the resend timestamp used.
+fn resend_ready_inquiry(core: &mut SchedulerCore, id: CommandId, at: Instant) {
+    assert_eq!(
+        core.promote_ready_retries(at),
+        1,
+        "expected exactly one ready retry to promote"
+    );
+    let pending = core
+        .next_item_to_send(at)
+        .expect("promoted retry should be sendable");
+    assert_eq!(pending.id, id);
+    core.start_inquiry(
+        id,
+        pending.command.clone(),
+        pending.priority,
+        pending.camera_id,
+        at,
+    );
+}
+
+fn issue536_config(max_retries: u32, base: Duration, max_dur: Duration) -> RetryConfig {
+    RetryConfig {
+        max_retries,
+        base_retry_delay: base,
+        max_retry_duration: max_dur,
+        backoff_strategy: BackoffStrategy::Constant,
+    }
+}
+
+#[test]
+fn test_builtin_inquiry_syntax_error_queues_retry() {
+    let mut core = SchedulerCore::with_retry_config(
+        TimeoutConfig::default(),
+        issue536_config(3, Duration::from_millis(10), Duration::from_secs(30)),
+    );
+    let now = Instant::now();
+    let inq = make_issue536_inquiry(
+        InquiryResponseSpec::Builtin(InquiryKind::Power),
+        CommandCategory::Quick,
+    );
+    core.start_inquiry(cmd_id(1), inq, Priority::Normal, CameraId::CAMERA_1, now);
+    assert!(core.inquiries_order.contains(&cmd_id(1)));
+
+    let actions = core.process_event(syntax_error_for(cmd_id(1)), now);
+    assert_eq!(actions.len(), 1);
+    assert!(
+        matches!(actions[0], SchedulerAction::RetryCommand { .. }),
+        "built-in inquiry 0x02 should queue a retry, got {:?}",
+        actions[0]
+    );
+
+    let state = core.inquiries.get(&cmd_id(1)).expect("inquiry retained");
+    assert_eq!(state.attempt, 1, "attempt incremented exactly once");
+    assert!(matches!(state.phase, InquiryPhase::Queued));
+    assert!(
+        !core.inquiries_order.contains(&cmd_id(1)),
+        "removed from FIFO order while queued for retry"
+    );
+    assert_eq!(core.retry_queue_depth(), 1);
+
+    // The public error contract must be unchanged.
+    assert!(!Error::SyntaxError.is_retryable());
+}
+
+#[test]
+fn test_builtin_inquiry_syntax_retry_then_reply_completes() {
+    let mut core = SchedulerCore::with_retry_config(
+        TimeoutConfig::default(),
+        issue536_config(3, Duration::from_millis(10), Duration::from_secs(30)),
+    );
+    let now = Instant::now();
+    let inq = make_issue536_inquiry(
+        InquiryResponseSpec::Builtin(InquiryKind::Power),
+        CommandCategory::Quick,
+    );
+    core.start_inquiry(cmd_id(1), inq, Priority::Normal, CameraId::CAMERA_1, now);
+
+    // Transient 0x02 -> retry queued.
+    let actions = core.process_event(syntax_error_for(cmd_id(1)), now);
+    assert!(matches!(actions[0], SchedulerAction::RetryCommand { .. }));
+
+    // Backoff elapses; the retry re-enters the send path and is resent.
+    let resend_at = now + Duration::from_millis(20);
+    resend_ready_inquiry(&mut core, cmd_id(1), resend_at);
+    assert!(core.is_awaiting_inquiry_reply(cmd_id(1)));
+    assert!(core.inquiries_order.contains(&cmd_id(1)));
+
+    // A valid reply now completes the SAME command id.
+    let reply = SchedulerEvent::InquiryReply {
+        source: ReplySource::from_fields(Some(cmd_id(1)), None, None),
+        response: Response::Inquiry(crate::command::InquiryData::Power { on: true }),
+    };
+    let actions = core.process_event(reply, resend_at);
+    assert_eq!(actions.len(), 1);
+    match &actions[0] {
+        SchedulerAction::CommandComplete { id, .. } => assert_eq!(*id, cmd_id(1)),
+        other => panic!("expected CommandComplete, got {other:?}"),
+    }
+    assert!(!core.is_command_pending(cmd_id(1)));
+    assert!(!core.inquiries_order.contains(&cmd_id(1)));
+}
+
+#[test]
+fn test_command_side_syntax_error_fails_terminally() {
+    let mut core = SchedulerCore::with_retry_config(
+        TimeoutConfig::default(),
+        issue536_config(3, Duration::from_millis(10), Duration::from_secs(30)),
+    );
+    let now = Instant::now();
+    let cmd = make_issue536_command(CommandCategory::Quick);
+    core.register_pending_ack(cmd_id(1), cmd, Priority::Normal, CameraId::CAMERA_1, now);
+
+    let actions = core.process_event(syntax_error_for(cmd_id(1)), now);
+    assert_eq!(actions.len(), 1);
+    match &actions[0] {
+        SchedulerAction::CommandFailed { id, error } => {
+            assert_eq!(*id, cmd_id(1));
+            assert!(matches!(error, Error::SyntaxError), "got {error:?}");
+        }
+        other => panic!("expected terminal CommandFailed, got {other:?}"),
+    }
+    assert_eq!(
+        core.retry_queue_depth(),
+        0,
+        "command 0x02 must not queue a retry"
+    );
+    assert!(!core.is_command_pending(cmd_id(1)));
+}
+
+#[test]
+fn test_raw_inquiry_syntax_error_fails_terminally() {
+    let mut core = SchedulerCore::with_retry_config(
+        TimeoutConfig::default(),
+        issue536_config(3, Duration::from_millis(10), Duration::from_secs(30)),
+    );
+    let now = Instant::now();
+    let inq = make_issue536_inquiry(InquiryResponseSpec::Raw, CommandCategory::Quick);
+    core.start_inquiry(cmd_id(1), inq, Priority::Normal, CameraId::CAMERA_1, now);
+
+    let actions = core.process_event(syntax_error_for(cmd_id(1)), now);
+    assert_eq!(actions.len(), 1);
+    match &actions[0] {
+        SchedulerAction::CommandFailed { id, error } => {
+            assert_eq!(*id, cmd_id(1));
+            assert!(matches!(error, Error::SyntaxError), "got {error:?}");
+        }
+        other => panic!("expected terminal CommandFailed, got {other:?}"),
+    }
+    assert_eq!(
+        core.retry_queue_depth(),
+        0,
+        "raw inquiry 0x02 must not queue a retry"
+    );
+    assert!(!core.is_awaiting_inquiry_reply(cmd_id(1)));
+}
+
+#[test]
+fn test_inquiry_syntax_retry_count_exhaustion_returns_syntax_error() {
+    // Movement budget == base max_retries (2), giving a small, exact budget.
+    let mut core = SchedulerCore::with_retry_config(
+        TimeoutConfig::default(),
+        issue536_config(2, Duration::from_millis(5), Duration::from_secs(30)),
+    );
+    let now = Instant::now();
+    let inq = make_issue536_inquiry(
+        InquiryResponseSpec::Builtin(InquiryKind::Power),
+        CommandCategory::Movement,
+    );
+    core.start_inquiry(cmd_id(1), inq, Priority::Normal, CameraId::CAMERA_1, now);
+
+    let mut t = now;
+    // Two retries are permitted (attempt 0->1, 1->2).
+    for expected_attempt in 1..=2u32 {
+        let actions = core.process_event(syntax_error_for(cmd_id(1)), t);
+        assert!(
+            matches!(actions[0], SchedulerAction::RetryCommand { .. }),
+            "attempt {expected_attempt} should retry"
+        );
+        assert_eq!(
+            core.inquiries.get(&cmd_id(1)).unwrap().attempt,
+            expected_attempt
+        );
+        t += Duration::from_millis(10);
+        resend_ready_inquiry(&mut core, cmd_id(1), t);
+    }
+
+    // Third 0x02 exceeds the budget -> terminal SyntaxError (NOT Timeout).
+    let actions = core.process_event(syntax_error_for(cmd_id(1)), t);
+    assert_eq!(actions.len(), 1);
+    match &actions[0] {
+        SchedulerAction::CommandFailed { id, error } => {
+            assert_eq!(*id, cmd_id(1));
+            assert!(
+                is_syntax_error(error),
+                "expected syntax semantics, got {error:?}"
+            );
+            assert!(
+                !matches!(error, Error::Timeout),
+                "must not degrade to Timeout"
+            );
+            assert!(!error.is_retryable());
+        }
+        other => panic!("expected terminal CommandFailed, got {other:?}"),
+    }
+    assert!(!core.is_command_pending(cmd_id(1)));
+}
+
+#[test]
+fn test_inquiry_syntax_max_duration_exhaustion_returns_syntax_error() {
+    let mut core = SchedulerCore::with_retry_config(
+        TimeoutConfig::default(),
+        issue536_config(10, Duration::from_millis(10), Duration::from_millis(100)),
+    );
+    let now = Instant::now();
+    let inq = make_issue536_inquiry(
+        InquiryResponseSpec::Builtin(InquiryKind::Power),
+        CommandCategory::Quick,
+    );
+    core.start_inquiry(cmd_id(1), inq, Priority::Normal, CameraId::CAMERA_1, now);
+
+    // Within the duration budget -> retry.
+    let actions = core.process_event(syntax_error_for(cmd_id(1)), now + Duration::from_millis(40));
+    assert!(matches!(actions[0], SchedulerAction::RetryCommand { .. }));
+    resend_ready_inquiry(&mut core, cmd_id(1), now + Duration::from_millis(60));
+
+    // Past max_retry_duration (measured from original submission) -> terminal.
+    let actions = core.process_event(
+        syntax_error_for(cmd_id(1)),
+        now + Duration::from_millis(150),
+    );
+    assert_eq!(actions.len(), 1);
+    match &actions[0] {
+        SchedulerAction::CommandFailed { id, error } => {
+            assert_eq!(*id, cmd_id(1));
+            assert!(
+                is_syntax_error(error),
+                "expected syntax semantics, got {error:?}"
+            );
+            assert!(
+                !matches!(error, Error::Timeout),
+                "must not degrade to Timeout"
+            );
+        }
+        other => panic!("expected terminal CommandFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_inquiry_syntax_retry_preserves_attempt_submitted_at_and_spec() {
+    let mut core = SchedulerCore::with_retry_config(
+        TimeoutConfig::default(),
+        issue536_config(3, Duration::from_millis(10), Duration::from_secs(30)),
+    );
+    let now = Instant::now();
+    let inq = make_issue536_inquiry(
+        InquiryResponseSpec::Builtin(InquiryKind::Power),
+        CommandCategory::Quick,
+    );
+    core.start_inquiry(cmd_id(1), inq, Priority::Normal, CameraId::CAMERA_1, now);
+    let original_submitted_at = core.inquiries.get(&cmd_id(1)).unwrap().submitted_at;
+
+    core.process_event(syntax_error_for(cmd_id(1)), now + Duration::from_millis(5));
+
+    let state = core.inquiries.get(&cmd_id(1)).unwrap();
+    assert_eq!(state.attempt, 1, "attempt incremented exactly once");
+    assert_eq!(
+        state.submitted_at, original_submitted_at,
+        "submitted_at preserved so max_retry_duration measures from first submission"
+    );
+    assert!(matches!(
+        state.response_spec,
+        InquiryResponseSpec::Builtin(InquiryKind::Power)
+    ));
+}
+
+#[test]
+fn test_inquiry_syntax_retry_fifo_has_no_duplicates() {
+    let mut core = SchedulerCore::with_retry_config(
+        TimeoutConfig::default(),
+        issue536_config(3, Duration::from_millis(10), Duration::from_secs(30)),
+    );
+    let now = Instant::now();
+    let inq = make_issue536_inquiry(
+        InquiryResponseSpec::Builtin(InquiryKind::Power),
+        CommandCategory::Quick,
+    );
+    core.start_inquiry(cmd_id(1), inq, Priority::Normal, CameraId::CAMERA_1, now);
+    assert_eq!(core.inquiries_order.len(), 1);
+
+    core.process_event(syntax_error_for(cmd_id(1)), now);
+    assert!(!core.inquiries_order.contains(&cmd_id(1)));
+    assert_eq!(core.inquiries_order.len(), 0);
+
+    resend_ready_inquiry(&mut core, cmd_id(1), now + Duration::from_millis(20));
+    assert_eq!(
+        core.inquiries_order
+            .iter()
+            .filter(|&&x| x == cmd_id(1))
+            .count(),
+        1,
+        "resend re-adds to FIFO exactly once"
+    );
+    assert_eq!(core.inquiries_order.len(), 1);
+}
+
+#[test]
+fn test_inquiry_syntax_retry_waits_for_backoff() {
+    let mut core = SchedulerCore::with_retry_config(
+        TimeoutConfig::default(),
+        issue536_config(3, Duration::from_millis(100), Duration::from_secs(30)),
+    );
+    let now = Instant::now();
+    let inq = make_issue536_inquiry(
+        InquiryResponseSpec::Builtin(InquiryKind::Power),
+        CommandCategory::Quick,
+    );
+    core.start_inquiry(cmd_id(1), inq, Priority::Normal, CameraId::CAMERA_1, now);
+    core.process_event(syntax_error_for(cmd_id(1)), now);
+
+    // Before the computed backoff delay, the retry cannot be dispatched.
+    assert_eq!(
+        core.promote_ready_retries(now + Duration::from_millis(50)),
+        0
+    );
+    assert!(core
+        .next_item_to_send(now + Duration::from_millis(50))
+        .is_none());
+
+    // Once the backoff elapses it becomes ready.
+    assert_eq!(
+        core.promote_ready_retries(now + Duration::from_millis(100)),
+        1
+    );
+}
+
+#[test]
+fn test_inquiry_syntax_retry_applies_inquiry_cooldown() {
+    // base_retry_delay drives both the backoff and the inquiry cooldown (100ms).
+    let mut core = SchedulerCore::with_retry_config(
+        TimeoutConfig::default(),
+        issue536_config(3, Duration::from_millis(100), Duration::from_secs(30)),
+    );
+    let now = Instant::now();
+
+    // Inquiry A in flight; inquiry B queued behind it.
+    let inq_a = make_issue536_inquiry(
+        InquiryResponseSpec::Builtin(InquiryKind::Power),
+        CommandCategory::Quick,
+    );
+    let inq_b = make_issue536_inquiry(
+        InquiryResponseSpec::Builtin(InquiryKind::Power),
+        CommandCategory::Quick,
+    );
+    core.start_inquiry(cmd_id(1), inq_a, Priority::Normal, CameraId::CAMERA_1, now);
+    core.queue_command(PendingCommand {
+        id: cmd_id(2),
+        command: inq_b,
+        priority: Priority::Normal,
+        camera_id: CameraId::CAMERA_1,
+        submitted_at: now,
+    });
+
+    // A reports a transient 0x02: the inquiry class is put on cooldown.
+    core.process_event(syntax_error_for(cmd_id(1)), now);
+
+    // Neither the retried inquiry nor the queued inquiry B may send yet.
+    assert!(!core.can_send_inquiry(now));
+    assert!(core.next_item_to_send(now).is_none());
+    assert!(!core.can_send_inquiry(now + Duration::from_millis(99)));
+
+    // The cooldown is reflected in the scheduler's next deadline.
+    assert_eq!(
+        core.next_deadline(now),
+        Some(now + Duration::from_millis(100))
+    );
+
+    // After the cooldown, queued inquiry B becomes sendable.
+    assert!(core.can_send_inquiry(now + Duration::from_millis(100)));
+    let pending = core
+        .next_item_to_send(now + Duration::from_millis(100))
+        .expect("inquiry B should send once cooldown clears");
+    assert_eq!(pending.id, cmd_id(2));
+}
+
+#[test]
+fn test_inquiry_cooldown_does_not_pause_commands() {
+    let mut core = SchedulerCore::with_retry_config(
+        TimeoutConfig::default(),
+        issue536_config(3, Duration::from_millis(100), Duration::from_secs(30)),
+    );
+    let now = Instant::now();
+    let inq = make_issue536_inquiry(
+        InquiryResponseSpec::Builtin(InquiryKind::Power),
+        CommandCategory::Quick,
+    );
+    core.start_inquiry(cmd_id(1), inq, Priority::Normal, CameraId::CAMERA_1, now);
+    core.process_event(syntax_error_for(cmd_id(1)), now);
+
+    // Commands are governed by command pacing/capacity only, not the inquiry cooldown.
+    core.queue_command(PendingCommand {
+        id: cmd_id(2),
+        command: make_issue536_command(CommandCategory::Quick),
+        priority: Priority::Normal,
+        camera_id: CameraId::CAMERA_1,
+        submitted_at: now,
+    });
+    assert!(
+        core.can_send_command(now),
+        "inquiry cooldown must not pause commands"
+    );
+    let pending = core
+        .next_item_to_send(now)
+        .expect("command should send during inquiry cooldown");
+    assert_eq!(pending.id, cmd_id(2));
+}
+
+#[test]
+fn test_inquiry_syntax_retry_respects_min_command_spacing() {
+    let mut core = SchedulerCore::with_retry_config(
+        TimeoutConfig::default(),
+        issue536_config(3, Duration::from_millis(10), Duration::from_secs(30)),
+    );
+    core.set_min_command_spacing(Duration::from_millis(200));
+    let now = Instant::now();
+    let inq = make_issue536_inquiry(
+        InquiryResponseSpec::Builtin(InquiryKind::Power),
+        CommandCategory::Quick,
+    );
+    core.start_inquiry(cmd_id(1), inq, Priority::Normal, CameraId::CAMERA_1, now);
+    core.process_event(syntax_error_for(cmd_id(1)), now);
+
+    // Backoff (10ms) has elapsed, but command spacing (200ms since last send)
+    // still blocks the resend.
+    let t = now + Duration::from_millis(50);
+    assert_eq!(core.promote_ready_retries(t), 1);
+    assert!(!core.can_send_inquiry(t));
+    assert!(core.next_item_to_send(t).is_none());
+
+    // Once command spacing is satisfied, the promoted retry can be sent.
+    let t2 = now + Duration::from_millis(200);
+    let pending = core
+        .next_item_to_send(t2)
+        .expect("retry should send once command spacing clears");
+    assert_eq!(pending.id, cmd_id(1));
+}
+
+#[test]
+fn test_stale_sequenced_syntax_error_is_ignored() {
+    let mut core = SchedulerCore::with_retry_config(
+        TimeoutConfig::default(),
+        issue536_config(3, Duration::from_millis(10), Duration::from_secs(30)),
+    );
+    let now = Instant::now();
+    let inq = make_issue536_inquiry(
+        InquiryResponseSpec::Builtin(InquiryKind::Power),
+        CommandCategory::Quick,
+    );
+    core.start_inquiry(cmd_id(1), inq, Priority::Normal, CameraId::CAMERA_1, now);
+    let ignored_before = core.ignored_unmatched_sequenced_replies();
+
+    // A sequenced 0x02 that matches no active command must be dropped without
+    // any FIFO or temporal fallback, and must not consume the in-flight inquiry.
+    let stale = SchedulerEvent::Error {
+        source: ReplySource::Sequenced {
+            sequence: 9999,
+            socket: None,
+        },
+        code: 0x02,
+    };
+    let actions = core.process_event(stale, now);
+    assert!(
+        actions.is_empty(),
+        "stale sequenced error must produce no actions"
+    );
+    assert_eq!(
+        core.ignored_unmatched_sequenced_replies(),
+        ignored_before + 1
+    );
+    assert_eq!(
+        core.retry_queue_depth(),
+        0,
+        "no retry from a stale sequenced error"
+    );
+    assert!(
+        core.is_awaiting_inquiry_reply(cmd_id(1)),
+        "inquiry untouched"
+    );
+    assert!(
+        core.inquiries_order.contains(&cmd_id(1)),
+        "FIFO attribution intact"
+    );
 }

--- a/src/runtime/loop_task.rs
+++ b/src/runtime/loop_task.rs
@@ -13,7 +13,7 @@ use crate::{
     protocol::framer::ProtocolFramer,
     runtime::{
         async_adapter::{AsyncAdapter, ControlRequest, SubmitRequest, UrgentControlRequest},
-        core::{CancelOutcome, PendingCommand},
+        core::CancelOutcome,
         driver::send_one,
     },
     timeout::TimeoutConfig,
@@ -695,45 +695,12 @@ pub async fn runtime_loop_with_config<
             adapter.pending_ack_count()
         );
 
-        // Process any newly ready retries
-        let ready_retries = adapter.get_ready_retries();
-        for retry in ready_retries {
-            debug!(
-                "Processing retry for command {} (attempt {})",
-                retry.id, retry.attempt
-            );
+        // Promote any retries whose backoff has elapsed back onto the send
+        // queues so the drain below dispatches them through the same pacing and
+        // capacity gates as fresh sends, rather than bypassing them.
+        adapter.promote_ready_retries();
 
-            // Category and kind are derived from EncodedCommand
-            let pending_cmd = PendingCommand {
-                id: retry.id,
-                command: retry.command,
-                priority: retry.priority,
-                camera_id: retry.camera_id,
-                submitted_at: executor.now(),
-            };
-
-            if let Err(e) = send_one(
-                &mut transport,
-                &executor,
-                &mut adapter,
-                pending_cmd,
-                &config.envelope,
-                &mut send_buf,
-                config.write_timeout,
-            )
-            .await
-            {
-                handle_send_failure!(
-                    transport,
-                    adapter,
-                    boundary_receivers,
-                    e,
-                    "Send failed during retry"
-                );
-            }
-        }
-
-        // Try to send any queued items
+        // Try to send any queued items (fresh sends and promoted retries alike).
         while let Some(cmd) = adapter.next_item_to_send() {
             if let Err(e) = send_one(
                 &mut transport,

--- a/src/testing/testkit/scripted_transport.rs
+++ b/src/testing/testkit/scripted_transport.rs
@@ -727,6 +727,26 @@ pub mod helpers {
         ]
     }
 
+    /// Create a transient inquiry SYNTAX ERROR (0x02) followed by a successful
+    /// data reply on resend (issue #536).
+    ///
+    /// The first send of an inquiry matching `pattern` receives a `0x02` syntax
+    /// error (no socket assignment, per VISCA immediate-error framing); the
+    /// resend receives `data`. This models a camera that briefly reports `0x02`
+    /// for an inquiry while overloaded and then answers correctly.
+    pub fn syntax_error_then_inquiry_success(pattern: Vec<u8>, data: Vec<u8>) -> Vec<Step> {
+        vec![
+            Step::OnSend {
+                matches: Some(pattern.clone()),
+                responses: vec![vec![0x90, 0x60, 0x02, VISCA_TERMINATOR]],
+            },
+            Step::OnSend {
+                matches: Some(pattern),
+                responses: vec![data], // No ACK for inquiries per VISCA spec
+            },
+        ]
+    }
+
     /// Create a sequence of BUFFER FULL responses followed by success
     pub fn buffer_full_sequence_then_success(socket: u8, full_count: usize) -> Vec<Step> {
         let mut steps = Vec::new();

--- a/tests/issue_536_inquiry_syntax_retry_test.rs
+++ b/tests/issue_536_inquiry_syntax_retry_test.rs
@@ -1,0 +1,114 @@
+//! Issue #536: bounded contextual retry for transient inquiry-side `0x02`.
+//!
+//! Runtime-level (blocking) coverage. A scripted transport returns a `0x02`
+//! syntax error for an inquiry and then a valid data reply on the resend; the
+//! caller receives the successful inquiry result, exactly one resend occurs,
+//! and the resend is delayed by the profile's inquiry pacing. A command-side
+//! `0x02` is verified to stay terminal with no resend.
+
+#![cfg(all(not(feature = "mode-async"), feature = "test-utils"))]
+
+use std::time::{Duration, Instant};
+
+use grafton_visca::{
+    camera::profiles::PtzOpticsG2,
+    command::{InquiryData, PanTiltPositionInquiry, Response},
+    runtime::testing::BlockingRunner,
+    testing::testkit::scripted_transport::{ScriptedBlockingTransport, Step},
+    timeout::TimeoutConfig,
+    transport::{BackoffStrategy, RetryConfig},
+    CameraId,
+};
+
+/// Build a `PtzOpticsG2` runner with a short retry backoff so the profile's
+/// 150ms inquiry pacing (not the backoff) dominates the observed resend timing.
+fn fast_backoff_runner() -> BlockingRunner<PtzOpticsG2> {
+    BlockingRunner::<PtzOpticsG2>::builder(TimeoutConfig::default())
+        .retry_config(RetryConfig {
+            max_retries: 3,
+            base_retry_delay: Duration::from_millis(5),
+            max_retry_duration: Duration::from_secs(30),
+            backoff_strategy: BackoffStrategy::Constant,
+        })
+        .build()
+}
+
+/// Encode a pan/tilt DataReply frame: `90 50 pppp tttt FF`.
+fn pan_tilt_reply(pan_u16: u16, tilt_u16: u16) -> Vec<u8> {
+    let mut frame = vec![0x90, 0x50];
+    for shift in [12u16, 8, 4, 0] {
+        frame.push(((pan_u16 >> shift) & 0x0F) as u8);
+    }
+    for shift in [12u16, 8, 4, 0] {
+        frame.push(((tilt_u16 >> shift) & 0x0F) as u8);
+    }
+    frame.push(0xFF);
+    frame
+}
+
+#[test]
+fn blocking_inquiry_syntax_error_retries_then_succeeds() {
+    let mut runner = fast_backoff_runner();
+
+    // First send of the inquiry gets a transient 0x02; the resend gets the data.
+    let mut transport = ScriptedBlockingTransport::new(vec![
+        Step::OnSend {
+            matches: None,
+            responses: vec![vec![0x90, 0x60, 0x02, 0xFF]], // Syntax error, no socket
+        },
+        Step::OnSend {
+            matches: None,
+            responses: vec![pan_tilt_reply(0x1234, 0x5678)],
+        },
+    ]);
+
+    let started = Instant::now();
+    let result = runner.send_command(&mut transport, &PanTiltPositionInquiry, CameraId::CAMERA_1);
+    let elapsed = started.elapsed();
+
+    match result {
+        Ok(Response::Inquiry(InquiryData::PanTiltPosition { pan, tilt })) => {
+            assert_eq!(pan, 0x1234_i16);
+            assert_eq!(tilt, 0x5678_i16);
+        }
+        other => panic!("expected PanTiltPosition after a transient 0x02 retry, got {other:?}"),
+    }
+
+    assert_eq!(
+        transport.sent().len(),
+        2,
+        "exactly one resend should occur after the transient 0x02"
+    );
+    assert!(
+        elapsed >= Duration::from_millis(140),
+        "resend must honor the profile inquiry pacing (elapsed = {elapsed:?})"
+    );
+}
+
+#[test]
+fn blocking_command_syntax_error_is_terminal_without_retry() {
+    let mut runner = fast_backoff_runner();
+
+    // A command that gets 0x02 must fail immediately with no resend.
+    let mut transport = ScriptedBlockingTransport::new(vec![Step::OnSend {
+        matches: None,
+        responses: vec![vec![0x90, 0x60, 0x02, 0xFF]],
+    }]);
+
+    // PowerOn is a plain command (not an inquiry).
+    let result = runner.send_command(
+        &mut transport,
+        &grafton_visca::command::PowerOn::new(),
+        CameraId::CAMERA_1,
+    );
+
+    assert!(
+        matches!(result, Err(grafton_visca::Error::SyntaxError)),
+        "command-side 0x02 must fail terminally with SyntaxError, got {result:?}"
+    );
+    assert_eq!(
+        transport.sent().len(),
+        1,
+        "command-side 0x02 must not be retried"
+    );
+}

--- a/tests/runtime_parity_test.rs
+++ b/tests/runtime_parity_test.rs
@@ -159,49 +159,136 @@ mod parity_tests {
         });
     }
 
-    // Test error handling parity
+    // Command-side syntax error (0x02) must surface to the caller as a terminal
+    // error, on both runtimes. (Inquiry-side 0x02 is transient; see the retry
+    // tests below.)
     #[cfg(feature = "runtime-tokio")]
     #[tokio::test]
-    async fn test_tokio_error_handling() {
+    async fn test_tokio_command_syntax_error_is_terminal() {
         use grafton_visca::TokioExecutor;
         let executor = Arc::new(TokioExecutor::from_handle(tokio::runtime::Handle::current()));
         let transport: ScriptedTransport<TokioExecutor> =
             ScriptedTransport::new(vec![Step::OnSend {
-                matches: Some(vec![0x81, 0x09, 0x04, 0x00, 0xFF]),
-                responses: vec![vec![0x90, 0x60, 0x02, 0xFF]], // Error response
+                matches: Some(vec![0x81, 0x01, 0x04, 0x00, 0x03, 0xFF]), // Power off command
+                responses: vec![vec![0x90, 0x60, 0x02, 0xFF]],           // Syntax error
             }])
             .with_executor(executor.clone());
 
         let camera = CameraBuilder::<TokioExecutor>::with_executor(executor)
-            .open_async::<grafton_visca::camera::profiles::PtzOpticsG2, _>(transport)
+            .open_async::<grafton_visca::camera::profiles::PtzOpticsG2, _>(transport.clone())
             .await
             .expect("Failed to create camera");
 
-        let result = camera.power().state().await;
-        assert!(result.is_err(), "Expected error from error response");
+        let result = camera.power().off().await;
+        assert!(result.is_err(), "Command-side 0x02 must fail terminally");
+        assert_eq!(
+            transport.sent().len(),
+            1,
+            "Command-side 0x02 must not be retried"
+        );
     }
 
     #[cfg(feature = "runtime-smol")]
     #[test]
-    fn test_smol_error_handling() {
+    fn test_smol_command_syntax_error_is_terminal() {
         use grafton_visca::SmolExecutor;
 
         smol::block_on(async {
             let executor = Arc::new(SmolExecutor::new());
             let transport: ScriptedTransport<SmolExecutor> =
                 ScriptedTransport::new(vec![Step::OnSend {
-                    matches: Some(vec![0x81, 0x09, 0x04, 0x00, 0xFF]),
-                    responses: vec![vec![0x90, 0x60, 0x02, 0xFF]], // Error response
+                    matches: Some(vec![0x81, 0x01, 0x04, 0x00, 0x03, 0xFF]),
+                    responses: vec![vec![0x90, 0x60, 0x02, 0xFF]],
                 }])
                 .with_executor(executor.clone());
 
             let camera = CameraBuilder::<SmolExecutor>::with_executor(executor)
-                .open_async::<grafton_visca::camera::profiles::PtzOpticsG2, _>(transport)
+                .open_async::<grafton_visca::camera::profiles::PtzOpticsG2, _>(transport.clone())
                 .await
                 .expect("Failed to create camera");
 
-            let result = camera.power().state().await;
-            assert!(result.is_err(), "Expected error from error response");
+            let result = camera.power().off().await;
+            assert!(result.is_err(), "Command-side 0x02 must fail terminally");
+            assert_eq!(transport.sent().len(), 1);
+        });
+    }
+
+    // Issue #536: a transient inquiry-side 0x02 is retried by the scheduler and
+    // the original operation still succeeds once the camera answers, on both
+    // runtimes. Exactly one resend occurs, and it is delayed by the profile's
+    // inquiry pacing (PtzOpticsG2 MIN_INQUIRY_SPACING = 150ms).
+    #[cfg(feature = "runtime-tokio")]
+    #[tokio::test]
+    async fn test_tokio_inquiry_syntax_error_retries_then_succeeds() {
+        use grafton_visca::testing::testkit::scripted_transport::helpers;
+        use grafton_visca::TokioExecutor;
+        use std::time::Instant;
+
+        let executor = Arc::new(TokioExecutor::from_handle(tokio::runtime::Handle::current()));
+        let transport: ScriptedTransport<TokioExecutor> =
+            ScriptedTransport::new(helpers::syntax_error_then_inquiry_success(
+                vec![0x81, 0x09, 0x04, 0x00, 0xFF], // Power inquiry
+                vec![0x90, 0x50, 0x02, 0xFF],       // Power on
+            ))
+            .with_executor(executor.clone());
+
+        let camera = CameraBuilder::<TokioExecutor>::with_executor(executor)
+            .open_async::<grafton_visca::camera::profiles::PtzOpticsG2, _>(transport.clone())
+            .await
+            .expect("Failed to create camera");
+
+        let started = Instant::now();
+        let power_status = camera
+            .power()
+            .state()
+            .await
+            .expect("inquiry should succeed after a transient 0x02 retry");
+        let elapsed = started.elapsed();
+
+        assert!(power_status, "expected power on after retry");
+        assert_eq!(
+            transport.sent().len(),
+            2,
+            "expected exactly one resend after the transient 0x02"
+        );
+        assert!(
+            elapsed >= std::time::Duration::from_millis(140),
+            "resend must honor profile inquiry pacing (elapsed = {elapsed:?})"
+        );
+    }
+
+    #[cfg(feature = "runtime-smol")]
+    #[test]
+    fn test_smol_inquiry_syntax_error_retries_then_succeeds() {
+        use grafton_visca::testing::testkit::scripted_transport::helpers;
+        use grafton_visca::SmolExecutor;
+
+        smol::block_on(async {
+            let executor = Arc::new(SmolExecutor::new());
+            let transport: ScriptedTransport<SmolExecutor> =
+                ScriptedTransport::new(helpers::syntax_error_then_inquiry_success(
+                    vec![0x81, 0x09, 0x04, 0x00, 0xFF],
+                    vec![0x90, 0x50, 0x02, 0xFF],
+                ))
+                .with_executor(executor.clone());
+
+            let camera = CameraBuilder::<SmolExecutor>::with_executor(executor)
+                .open_async::<grafton_visca::camera::profiles::PtzOpticsG2, _>(transport.clone())
+                .await
+                .expect("Failed to create camera");
+
+            let power_status = camera
+                .power()
+                .state()
+                .await
+                .expect("inquiry should succeed after a transient 0x02 retry");
+
+            assert!(power_status, "expected power on after retry");
+            assert_eq!(
+                transport.sent().len(),
+                2,
+                "expected exactly one resend after the transient 0x02"
+            );
         });
     }
 }


### PR DESCRIPTION
Resolves #536.

## Summary

Treat a VISCA `0x02` Syntax Error attributed to an **active built-in inquiry** as a transient camera-overload signal and retry it with bounded backoff, reusing the existing per-category retry budget, backoff, and `RetryConfig::max_retry_duration`. This is a **narrow, contextual** retry — not general syntax-error retryability. `Error::SyntaxError.is_retryable()` remains `false`.

## What changed

**Single scheduler-owned decision path** (`src/runtime/core/mod.rs`)
- Replaced `should_retry_command` (`bool`) with `classify_error_retry → RetryDecision { Retry { inquiry_syntax }, Fail(Error) }`, keyed on the raw error code plus live entry context (entry kind, response spec, lifecycle phase, attempt, submission time, retry config).
  - Built-in inquiry `0x02` still awaiting reply + within budget → retry; exhausted (count or duration) → contextual `SyntaxError`, never a generic `Timeout`.
  - Command-side `0x02` and `InquiryResponseSpec::Raw` `0x02` → terminal `SyntaxError`, no retry queued.
- `Error::is_retryable()` is untouched.

**Pacing fix (applies to all retries)**
- Ready retries were dispatched directly by the runtime loops, bypassing pacing. They now re-enter the scheduler send path (`promote_ready_retries` + `next_item_to_send`), so retries honor `MIN_COMMAND_SPACING`, `MIN_INQUIRY_SPACING`, the max in-flight inquiry limit, and command socket capacity. `blocking_runner.rs` and `loop_task.rs` are simplified to a single pacing-gated drain, keeping blocking and async equivalent.

**Inquiry-class cooldown**
- New `inquiry_cooldown_until`, gated in `can_send_inquiry` and folded into `next_deadline`, armed for the backoff window after a transient `0x02`. Commands are never paused.

**Diagnostics**
- Warn-level transient retry (cmd id, response spec, attempt, delay); error-level terminal syntax error; removed the misleading "caller may retry" log now that the scheduler retries internally.

## Acceptance criteria

- [x] Built-in inquiry `0x02` retries with bounded backoff and completes from a later valid reply
- [x] Command-side `0x02` fails immediately with `SyntaxError`, no retry
- [x] Raw custom inquiry `0x02` remains terminal
- [x] Retry budget and max retry duration respected
- [x] Retry exhaustion returns `SyntaxError` semantics, not `Timeout`
- [x] Retry dispatch cannot occur before the retry delay or profile pacing permits
- [x] Retryable inquiry `0x02` applies an inquiry cooldown to subsequent inquiry sends (commands unaffected)
- [x] FIFO/order correct: no duplicate entries, no orphaned state, no dropped retries
- [x] Stale/unmatched sequenced errors remain ignored, no FIFO/temporal fallback
- [x] Blocking and async behavior equivalent
- [x] `Error::SyntaxError.is_retryable()` remains `false`
- [x] Changelog documents this as bounded contextual inquiry retry

## Testing

- 13 new focused scheduler tests (`src/runtime/core/tests.rs`) covering every bullet in the issue's Test Requirements.
- Runtime-level end-to-end: blocking (`BlockingRunner`) and async tokio + smol (`camera.power().state()` over a scripted `0x02`-then-data transport) — success after exactly one resend, resend delayed by profile pacing; plus command-side `0x02` terminal parity tests.
- Full suites green in both modes: 822 blocking + 791 async lib tests, all integration tests, doc tests, `cargo fmt --check`, and clippy across every feature combination.