### PR TITLE
Complete 1.1.0 operation semantics and release preparation

### DIFF
--- a/.github/scripts/test-all-features.sh
+++ b/.github/scripts/test-all-features.sh
@@ -122,7 +122,7 @@ run_test "runtime-smol + test-utils" \
 run_test "#539 blocking operation handles" \
     "cargo test --no-default-features --features test-utils --test issue_539_blocking_handle_test"
 
-run_test "#539 runtime-agnostic async contracts" \
+run_test "#539 mode-async command-metadata contracts" \
     "cargo test --no-default-features --features mode-async,test-utils --test issue_539_async_handle_test"
 
 run_test "#539 Tokio operation handles" \

--- a/.github/scripts/test-all-features.sh
+++ b/.github/scripts/test-all-features.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# 1.0 support-matrix testing script.
+# 1.x support-matrix testing script.
 #
 # Keep this list in sync with README.md and CONTRIBUTING.md. Entries below are
 # part of the documented support contract unless they are explicitly labelled
@@ -116,6 +116,20 @@ run_test "runtime-tokio + test-utils" \
 
 run_test "runtime-smol + test-utils" \
     "cargo test --no-default-features --features runtime-smol,test-utils"
+
+# Operation-handle release gates (#539). Keep these explicit so a cfg change
+# cannot silently turn a runtime's semantic suite into zero executed tests.
+run_test "#539 blocking operation handles" \
+    "cargo test --no-default-features --features test-utils --test issue_539_blocking_handle_test"
+
+run_test "#539 runtime-agnostic async contracts" \
+    "cargo test --no-default-features --features mode-async,test-utils --test issue_539_async_handle_test"
+
+run_test "#539 Tokio operation handles" \
+    "cargo test --no-default-features --features runtime-tokio,test-utils --test issue_539_async_handle_test"
+
+run_test "#539 smol operation handles" \
+    "cargo test --no-default-features --features runtime-smol,test-utils --test issue_539_async_handle_test"
 
 clean_target_checkpoint "runtime/test-utils feature group"
 

--- a/.github/scripts/validate-release.sh
+++ b/.github/scripts/validate-release.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+release_tag="${1:-${GITHUB_REF_NAME:-}}"
+if [[ ! "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+    echo "release tag must have the form vX.Y.Z (received: ${release_tag:-<empty>})" >&2
+    exit 1
+fi
+
+release_version="${release_tag#v}"
+
+python3 - "${release_version}" <<'PY'
+import pathlib
+import re
+import subprocess
+import sys
+import tomllib
+
+expected = sys.argv[1]
+root = pathlib.Path.cwd()
+
+metadata = subprocess.run(
+    ["cargo", "metadata", "--format-version", "1", "--no-deps", "--locked"],
+    check=True,
+    capture_output=True,
+    text=True,
+).stdout
+
+import json
+packages = {package["name"]: package for package in json.loads(metadata)["packages"]}
+for name in ("grafton-visca", "grafton-visca-macros"):
+    actual = packages[name]["version"]
+    if actual != expected:
+        raise SystemExit(f"{name} version {actual} does not match tag version {expected}")
+
+manifest = tomllib.loads((root / "Cargo.toml").read_text())
+macro_dependency = manifest["dependencies"]["grafton-visca-macros"]["version"]
+if macro_dependency != f"={expected}":
+    raise SystemExit(
+        "grafton-visca-macros dependency version "
+        f"{macro_dependency} is not pinned to the tag version ={expected}"
+    )
+
+lock = tomllib.loads((root / "Cargo.lock").read_text())
+locked = {
+    package["name"]: package["version"]
+    for package in lock["package"]
+    if package["name"] in {"grafton-visca", "grafton-visca-macros"}
+}
+for name in ("grafton-visca", "grafton-visca-macros"):
+    if locked.get(name) != expected:
+        raise SystemExit(
+            f"Cargo.lock {name} version {locked.get(name)!r} does not match {expected}"
+        )
+
+changelog = (root / "CHANGELOG.md").read_text()
+heading = re.compile(
+    rf"^## \[{re.escape(expected)}\] - \d{{4}}-\d{{2}}-\d{{2}}$", re.MULTILINE
+)
+if not heading.search(changelog):
+    raise SystemExit(
+        f"CHANGELOG.md must contain a dated '## [{expected}] - YYYY-MM-DD' heading"
+    )
+PY
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "version=${release_version}" >> "${GITHUB_OUTPUT}"
+fi
+
+echo "release metadata is consistent for ${release_tag}"

--- a/.github/scripts/wait-for-crate.sh
+++ b/.github/scripts/wait-for-crate.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+crate_name="${1:?crate name is required}"
+crate_version="${2:?crate version is required}"
+timeout_seconds="${3:-300}"
+deadline=$((SECONDS + timeout_seconds))
+
+while (( SECONDS < deadline )); do
+    if cargo info --registry crates-io "${crate_name}@${crate_version}" >/dev/null 2>&1; then
+        echo "${crate_name}@${crate_version} is available from the crates.io index"
+        exit 0
+    fi
+    echo "waiting for ${crate_name}@${crate_version} to reach the crates.io index..."
+    sleep 10
+done
+
+echo "timed out waiting for ${crate_name}@${crate_version} after ${timeout_seconds}s" >&2
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: Rust CI/CD
 # - Cross-compilation testing
 # - Reusable workflows for better organization
 # - Job timeouts for reliability
-# - Comprehensive 1.0 support-matrix testing (matches README and contributor docs)
+# - Comprehensive 1.x support-matrix testing (matches README and contributor docs)
 # - Tests blocking, async runtimes, serial transports, dyn-api, and serialization features
 # - Enhanced clippy coverage for all feature combinations
 # - Platform matrix testing (ubuntu, windows, macos) × (stable, beta)
@@ -674,6 +674,8 @@ jobs:
     if: github.event_name != 'pull_request' && !(github.event_name == 'push' && startsWith(github.ref, 'refs/heads/feature/'))
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install system dependencies
         run: |
@@ -694,16 +696,24 @@ jobs:
           save-if: false
 
       # Package verification for releases
-      - name: Check package (release tags only)
+      - name: Validate release metadata and ancestry
+        id: release
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          bash .github/scripts/validate-release.sh "$GITHUB_REF_NAME"
+
+      - name: Inspect package payloads (release tags only)
         if: startsWith(github.ref, 'refs/tags/')
         env:
           RUSTC_WRAPPER: ""  # Disable sccache for packaging
         run: |
-          echo "Running package check for release tag..."
-          # The main crate depends on the same-version macro crate from the
-          # registry, so it can only be verified after the macro crate has been
-          # published and indexed.
-          cargo package -p grafton-visca-macros --no-verify
+          echo "Inspecting package payloads for release tag..."
+          cargo package -p grafton-visca-macros --locked --no-verify
+          cargo package -p grafton-visca-macros --list
+          cargo package -p grafton-visca --list
+          echo "The main archive is packaged after its exact macro version reaches crates.io."
 
       # Build validation for non-releases
       - name: Build validation (non-release)
@@ -762,6 +772,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install system dependencies
         run: |
@@ -777,31 +789,53 @@ jobs:
           shared-key: "rust-cache-ubuntu-latest-stable"
           save-if: false
 
-      # Dry run first
-      - name: Publish macro crate dry run
+      - name: Validate release metadata and inspect payloads
+        id: release
         env:
           RUSTC_WRAPPER: ""  # Disable sccache for packaging
-        run: cargo publish -p grafton-visca-macros --dry-run
+        run: |
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          bash .github/scripts/validate-release.sh "$GITHUB_REF_NAME"
+          cargo package -p grafton-visca-macros --locked --no-verify
+          cargo package -p grafton-visca-macros --list
+          cargo package -p grafton-visca --list
 
-      # Publish macro crate first
-      - name: Publish grafton-visca-macros to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
-          RUSTC_WRAPPER: ""  # Disable sccache for packaging
-        run: cargo publish -p grafton-visca-macros
-
-      # Wait for crates.io indexing
-      - name: Wait for crates.io indexing
-        run: sleep 30
-
-      - name: Publish main crate dry run
-        env:
-          RUSTC_WRAPPER: ""  # Disable sccache for packaging
-        run: cargo publish -p grafton-visca --dry-run
-
-      # Publish main crate
-      - name: Publish grafton-visca to crates.io
+      - name: Publish grafton-visca-macros if needed
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
           RUSTC_WRAPPER: ""  # Disable sccache for packaging
-        run: cargo publish -p grafton-visca
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          if cargo info --registry crates-io "grafton-visca-macros@${RELEASE_VERSION}" >/dev/null 2>&1; then
+            echo "grafton-visca-macros@${RELEASE_VERSION} is already published"
+          else
+            cargo publish -p grafton-visca-macros --locked --dry-run
+            cargo publish -p grafton-visca-macros --locked
+          fi
+
+      - name: Wait for the macro crate index entry
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: bash .github/scripts/wait-for-crate.sh grafton-visca-macros "$RELEASE_VERSION" 300
+
+      - name: Publish grafton-visca if needed
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+          RUSTC_WRAPPER: ""  # Disable sccache for packaging
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          if cargo info --registry crates-io "grafton-visca@${RELEASE_VERSION}" >/dev/null 2>&1; then
+            echo "grafton-visca@${RELEASE_VERSION} is already published"
+          else
+            cargo package -p grafton-visca --locked --no-verify
+            cargo publish -p grafton-visca --locked --dry-run
+            cargo publish -p grafton-visca --locked
+          fi
+
+      - name: Verify both published versions
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          bash .github/scripts/wait-for-crate.sh grafton-visca-macros "$RELEASE_VERSION" 300
+          bash .github/scripts/wait-for-crate.sh grafton-visca "$RELEASE_VERSION" 300

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,12 +587,59 @@ jobs:
             exit 1
           fi
 
+  # Enforce the workspace's declared minimum supported Rust version.
+  msrv:
+    name: MSRV 1.88 (${{ matrix.surface }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - surface: blocking
+            features: ""
+          - surface: async-dyn
+            features: runtime-tokio,dyn-api,test-utils
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust 1.88.0
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.88.0
+
+      - uses: Swatinem/rust-cache@v2
+        continue-on-error: true
+        with:
+          shared-key: "rust-cache-msrv-${{ matrix.surface }}"
+          save-if: false
+
+      - name: Check ${{ matrix.surface }} public surface on MSRV
+        shell: bash
+        run: |
+          if [ -z "${{ matrix.features }}" ]; then
+            cargo check --workspace --all-targets --no-default-features
+          else
+            cargo check --workspace --all-targets --no-default-features \
+              --features "${{ matrix.features }}"
+          fi
+
   # Semver compatibility check
   semver:
-    name: Check semver
+    name: Check semver (${{ matrix.surface }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: github.event_name == 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - surface: blocking
+            feature_group: default-features
+            features: ""
+          - surface: async-dyn
+            feature_group: only-explicit-features
+            features: runtime-tokio,transport-serial,transport-serial-tokio,serde,schemars,ts-rs,dyn-api,test-utils
     steps:
       - uses: actions/checkout@v6
 
@@ -616,8 +663,8 @@ jobs:
 
       - uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
-          feature-group: only-explicit-features
-          features: runtime-tokio,transport-serial,transport-serial-tokio,serde,schemars,ts-rs,dyn-api,test-utils
+          feature-group: ${{ matrix.feature_group }}
+          features: ${{ matrix.features }}
 
   # Check package metadata and dependencies
   package-check:
@@ -686,6 +733,9 @@ jobs:
       - lint-and-docs
       - async-transport-integration
       - cross-compile
+      - miri
+      - msrv
+      - semver
       - package-check
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-19
+
+### Added
+
+- Dynamic operation handles now expose `await_applied`, `await_settled`, and
+  `detach` alongside ID-based cancellation. Public `OperationMetadata` and
+  command-derived metadata keep applied-only versus targeted behavior aligned
+  across blocking, async, and dynamic handles.
+- Maintained blocking and Tokio operation-handle examples now demonstrate exact
+  per-command deadlines, physical settling, and explicit detach/stop behavior.
+
+#### Mode-Honest Operation Handles for Movement Commands (#539)
+
+- Added a single `submit(command)` primitive on both async and blocking cameras
+  that returns an operation handle which is genuine in either mode. This replaces
+  the async-only `_op` handle surface with one unified path.
+  - Async cameras return `InFlight`; blocking cameras return the new
+    `BlockingInFlight`. `BlockingInFlight` drives completion **synchronously on
+    the caller's thread** with no async executor involved. Both handle types
+    expose the same lifecycle vocabulary, with signatures appropriate to their
+    blocking or async mode.
+  - `Camera::submit(command)` takes a prepared `ViscaCommand`, submits it as a
+    command-derived targeted or applied-only operation, and returns its handle
+    without waiting. Custom commands without metadata retain the conservative
+    targeted/all-axes 1.x fallback.
+    `Camera::submit_continuous(command)` does the same but marks a custom command
+    as applied-only, with no well-defined settled state.
+- Added handle completion methods with explicit *applied* vs *settled* semantics:
+  - `await_applied(timeout)` resolves when the camera has accepted and
+    protocol-completed the command. It is available on every handle — including
+    applied-only operations — and is the method to use for a bounded deadman
+    `STOP`.
+  - `await_settled(timeout)` resolves when physical motion has ended. Both modes
+    use exact operation completion when the profile supports it and bounded
+    position polling otherwise. It is meaningful only for targeted moves;
+    applied-only handles return `Error::NotSupported`.
+  - `cancel()` requests scheduler-owned, ID/socket-safe cancellation. Queued
+    commands can be removed before sending; sent commands use the protocol cancel
+    path once their socket is known. Success does not prove physical motion has
+    stopped. `detach()` is the explicit fire-and-forget escape hatch.
+- Added `OpKind` (`Targeted` / `Continuous`, where `Continuous` is the 1.x name
+  for any applied-only operation) to describe whether an operation has a settled
+  state, and re-exported it from `grafton_visca::camera`.
+- Blocking movement detection (`is_moving_axes_with_deadline`) can now be called
+  through a shared `&self` reference so it composes with the new handle waits.
+
 ### Fixed
 
 #### Complete Operation-Handle Semantics and Mode Parity (#539)
@@ -15,7 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and affected axes across blocking, async, and dynamic handles.
 - Async `await_settled` now matches blocking mode: it uses the exact command
   completion on profiles with operation-complete support and position polling
-  otherwise, under one timeout budget spanning application and settling.
+  otherwise, under one timeout budget spanning exact protocol completion and
+  fallback settling.
 - Blocking submission performs its initial synchronous dispatch before returning
   a handle, retains out-of-order results for multiple live handles, and uses the
   scheduler's protocol-aware cancellation path.
@@ -23,6 +70,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cancel, and detach semantics with the static handle surface.
 - CI gates the declared Rust 1.88 MSRV and checks semver compatibility for the
   cfg-exclusive blocking and async/dynamic public surfaces separately.
+- Release and API documentation now distinguishes lifecycle management from
+  profile-aware command conversion, async queue acceptance from blocking initial
+  dispatch, and cancellation requests from proof that physical motion stopped.
 
 ### Changed
 
@@ -50,91 +100,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failed inquiry's resend and any other queued inquiry for the backoff window
   without pausing command traffic.
 
-## [1.1.0] - 2026-07-16
-
-### Added
-
-#### Mode-Honest Operation Handles for Movement Commands (#539)
-
-- Added a single `submit(command)` primitive on both async and blocking cameras
-  that returns an operation handle which is genuine in either mode. This replaces
-  the async-only `_op` handle surface with one unified path.
-  - Async cameras return `InFlight`; blocking cameras return the new
-    `BlockingInFlight`. `BlockingInFlight` drives completion **synchronously on
-    the caller's thread** with no async executor involved. Both handle types
-    expose the same methods so code reads the same across modes.
-  - `Camera::submit(command)` takes a prepared `ViscaCommand`, submits it as a
-    targeted operation, and returns its handle without waiting.
-    `Camera::submit_continuous(command)` does the same but marks the handle as a
-    continuous drive or stop, for which there is no well-defined settled state.
-- Added handle completion methods with explicit *applied* vs *settled* semantics:
-  - `await_applied(timeout)` resolves when the camera has accepted and
-    protocol-completed the command. It is available on every handle — including
-    continuous drives and stops — and is the method to use for a bounded deadman
-    `STOP`.
-  - `await_settled(timeout)` resolves when physical motion has ended. In 1.1.0,
-    blocking handles used position polling when needed; async fallback polling
-    was completed in the subsequent #539 correctness follow-up. It is meaningful
-    only for targeted moves; continuous or stop handles return
-    `Error::NotSupported`.
-  - `cancel()` discards the command through the runtime's ID-based cancel path;
-    `detach()` is the explicit fire-and-forget escape hatch.
-- Added `OpKind` (`Targeted` / `Continuous`) to describe whether an operation has
-  a settled state, and re-exported it from `grafton_visca::camera`.
-- Blocking movement detection (`is_moving_axes_with_deadline`) can now be called
-  through a shared `&self` reference so it composes with the new handle waits.
-
-### Changed
+#### Operation-Handle Lifecycle (#539)
 
 - Operation handles (`InFlight` and `BlockingInFlight`) are now `#[must_use]`, so
   directly ignoring a returned handle raises a lint. Rust does not enforce linear
   use after a handle is bound to a variable. **Dropping a handle never stops the
   command** — drop is equivalent to `detach`. Use `cancel()` for explicit
   cancellation.
-- The deprecated `_op` handle methods and the new `submit` primitive now share a
-  single internal submission implementation, so the handle-producing paths cannot
-  drift.
+- The deprecated concrete async `_op` handle methods and the new `submit`
+  primitive now share a single internal submission implementation, so the
+  handle-producing lifecycle paths cannot drift. The similarly named dyn trait
+  methods remain the object-safe 1.x handle surface because `submit` is not
+  object-safe.
 
 ### Deprecated
 
-- The `_op` movement handle methods are deprecated in favor of `submit(command)`
-  plus `await_applied` / `await_settled`:
+- The concrete async `_op` movement handle methods are deprecated ahead of the
+  2.0 operation redesign:
   `pan_tilt_absolute_op`, `pan_tilt_relative_op`, `pan_tilt_home_op`,
   `pan_tilt_reset_op`, `set_zoom_op`, `set_zoom_normalized_op`,
   `set_zoom_normalized_in_domain_op`, `set_focus_op`, and `preset_recall_op`.
-  They remain thin, behavior-preserving shims and will be removed in 2.0.
+  They remain profile-aware, behavior-preserving shims throughout 1.x. When the
+  equivalent command has already been constructed and profile-validated, prefer
+  `submit(command)` plus `await_applied` / `await_settled`.
 - `InFlight::await_completion` is deprecated in favor of `await_applied`, which
   makes the applied-versus-settled completion distinction explicit. The old name
   remains as a delegating shim and will be removed in 2.0.
 
 ##### Migration Notes
 
-This release is fully additive: existing code — including the `_op` methods and
-`await_completion` — continues to compile and behave identically, emitting only
-deprecation warnings. To migrate:
+This release is source-compatible: existing code — including the `_op` methods
+and `await_completion` — continues to compile and retains its documented
+behavior, emitting only deprecation warnings. To migrate:
 
-- Fire-and-forget callers need no change: the ergonomic methods and noun
-  accessors (`camera.pan_tilt().absolute(...)`, `camera.zoom().stop()`, …) are
-  unchanged.
+- Ordinary command-completion callers need no change: the ergonomic methods and
+  noun accessors (`camera.pan_tilt().absolute(...)`, `camera.zoom().stop()`, …)
+  are unchanged.
 - Replace `handle.await_completion(timeout)` with `handle.await_applied(timeout)`.
-- To obtain a handle for a command you can construct directly — `PanTilt::Home`,
-  `Zoom::Stop`, a preset recall, or a raw position — use
+- To obtain a handle for a command you can construct and validate directly —
+  such as `PanTilt::Home` or `Zoom::Stop` — use
   `camera.submit(&command)` and drive it with `await_applied` / `await_settled`.
   Blocking callers gain a real handle here for the first time
   (`camera.submit(&command)?.await_applied(timeout)?`), which previously required
   a separate idle-polling wait.
-- For handles created from ergonomic inputs (degrees, normalized units), the
-  `_op` methods remain available as compatibility shims throughout 1.x. Their
-  final replacement is part of the coherent 2.0 operation API design.
+- `submit` manages lifecycle but does not add the profile-aware conversion or
+  validation performed by typed noun controls. For handles created from
+  ergonomic inputs (degrees, normalized units, or preset IDs), the `_op` methods
+  remain profile-aware compatibility shims throughout 1.x. Their final
+  replacement is part of the coherent 2.0 operation API design.
 
 Intended follow-up changes, targeted for the next major release (2.0) unless
 noted:
 
-- The deprecated `_op` methods and `InFlight::await_completion` will then be
-  removed.
-- The coarse operation markers will be split into targeted and continuous
-  variants so that calling `await_settled` on a continuous or stop handle becomes
-  a compile error instead of a runtime `Error::NotSupported`.
+- The deprecated concrete-camera `_op` methods and the static and dynamic
+  `await_completion` compatibility aliases will then be removed. The dyn handle
+  entry points will be redesigned with the rest of the operation API rather than
+  removed without a replacement.
+- The coarse operation markers will be split into targeted and applied-only
+  variants so that calling `await_settled` on an applied-only handle becomes a
+  compile error instead of a runtime `Error::NotSupported`.
 - The public surface will move to typed consuming handles with compile-time
   targeted/applied-only completion constraints.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### Complete Operation-Handle Semantics and Mode Parity (#539)
+
+- Built-in command metadata is now the single source of truth for operation kind
+  and affected axes across blocking, async, and dynamic handles.
+- Async `await_settled` now matches blocking mode: it uses the exact command
+  completion on profiles with operation-complete support and position polling
+  otherwise, under one timeout budget spanning application and settling.
+- Blocking submission performs its initial synchronous dispatch before returning
+  a handle, retains out-of-order results for multiple live handles, and uses the
+  scheduler's protocol-aware cancellation path.
+- The dynamic facade retains operation metadata and shares applied, settled,
+  cancel, and detach semantics with the static handle surface.
+- CI gates the declared Rust 1.88 MSRV and checks semver compatibility for the
+  cfg-exclusive blocking and async/dynamic public surfaces separately.
+
 ### Changed
 
 #### Bounded Contextual Retry for Transient Inquiry Syntax Errors (#536)
@@ -50,18 +67,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     targeted operation, and returns its handle without waiting.
     `Camera::submit_continuous(command)` does the same but marks the handle as a
     continuous drive or stop, for which there is no well-defined settled state.
-    (Ergonomic, noun-scoped `submit_*` helpers that accept degrees/normalized
-    inputs and return a handle are planned as a follow-up — see the migration
-    notes below.)
 - Added handle completion methods with explicit *applied* vs *settled* semantics:
   - `await_applied(timeout)` resolves when the camera has accepted and
     protocol-completed the command. It is available on every handle — including
     continuous drives and stops — and is the method to use for a bounded deadman
     `STOP`.
-  - `await_settled(timeout)` resolves when physical motion has ended (via the
-    operation-complete message on profiles that report it, otherwise via position
-    polling). It is meaningful only for targeted moves; on a continuous or stop
-    handle it returns `Error::NotSupported`.
+  - `await_settled(timeout)` resolves when physical motion has ended. In 1.1.0,
+    blocking handles used position polling when needed; async fallback polling
+    was completed in the subsequent #539 correctness follow-up. It is meaningful
+    only for targeted moves; continuous or stop handles return
+    `Error::NotSupported`.
   - `cancel()` discards the command through the runtime's ID-based cancel path;
     `detach()` is the explicit fire-and-forget escape hatch.
 - Added `OpKind` (`Targeted` / `Continuous`) to describe whether an operation has
@@ -71,12 +86,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Operation handles (`InFlight` and `BlockingInFlight`) are now `#[must_use]`:
-  producing a handle and dropping it without `await_applied`, `await_settled`,
-  `cancel`, or `detach` raises a lint. **Dropping a handle never stops the
-  command** — drop is equivalent to `detach`. The already-dispatched command
-  keeps running; a still-queued blocking command is flushed by the next blocking
-  operation. Use `cancel()` to discard a command instead.
+- Operation handles (`InFlight` and `BlockingInFlight`) are now `#[must_use]`, so
+  directly ignoring a returned handle raises a lint. Rust does not enforce linear
+  use after a handle is bound to a variable. **Dropping a handle never stops the
+  command** — drop is equivalent to `detach`. Use `cancel()` for explicit
+  cancellation.
 - The deprecated `_op` handle methods and the new `submit` primitive now share a
   single internal submission implementation, so the handle-producing paths cannot
   drift.
@@ -84,7 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - The `_op` movement handle methods are deprecated in favor of `submit(command)`
-  (or the noun accessors) plus `await_applied` / `await_settled`:
+  plus `await_applied` / `await_settled`:
   `pan_tilt_absolute_op`, `pan_tilt_relative_op`, `pan_tilt_home_op`,
   `pan_tilt_reset_op`, `set_zoom_op`, `set_zoom_normalized_op`,
   `set_zoom_normalized_in_domain_op`, `set_focus_op`, and `preset_recall_op`.
@@ -109,29 +123,20 @@ deprecation warnings. To migrate:
   Blocking callers gain a real handle here for the first time
   (`camera.submit(&command)?.await_applied(timeout)?`), which previously required
   a separate idle-polling wait.
-- For handles created from ergonomic inputs (degrees, normalized units), keep
-  using the `_op` methods for now. They stay available (with a deprecation
-  warning) until the ergonomic `submit_*` helpers described below replace them;
-  the `_op` methods will not be removed before that replacement exists.
+- For handles created from ergonomic inputs (degrees, normalized units), the
+  `_op` methods remain available as compatibility shims throughout 1.x. Their
+  final replacement is part of the coherent 2.0 operation API design.
 
 Intended follow-up changes, targeted for the next major release (2.0) unless
 noted:
 
-- Ergonomic, noun-scoped `submit_*` handle helpers (accepting degrees/normalized
-  inputs, returning a typed handle) will land as the drop-in replacement for the
-  deprecated `_op` methods. This is the additive step that must precede removal.
 - The deprecated `_op` methods and `InFlight::await_completion` will then be
   removed.
 - The coarse operation markers will be split into targeted and continuous
   variants so that calling `await_settled` on a continuous or stop handle becomes
   a compile error instead of a runtime `Error::NotSupported`.
-- The object-safe `dyn` API facade will be generated from the same command
-  descriptors as the static movement surface, keeping the two in lockstep.
-
-Until then, note that async `await_settled` resolves on the command's completion
-message; on profiles that do not report operation completion, follow it with
-`camera.await_axes_idle(...)` for a strict position-based settle. Blocking
-`await_settled` already performs that position poll internally.
+- The public surface will move to typed consuming handles with compile-time
+  targeted/applied-only completion constraints.
 
 ## [1.0.0] - 2026-06-13
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Thank you for your interest in contributing to grafton-visca! This guide will he
 - [Testing](#testing)
 - [Documentation](#documentation)
 - [Pull Request Process](#pull-request-process)
+- [Release Process](#release-process)
 
 ## Getting Started
 
@@ -217,18 +218,12 @@ mod tests {
 
 ### Integration Tests
 
-For camera control features, add integration tests:
-
-```rust
-#[test]
-#[cfg(feature = "test-utils")]
-fn test_movement_safety() {
-    use crate::test_utils::MockCamera;
-
-    let cam = MockCamera::new();
-    // Test safety bounds and limits
-}
-```
+For camera control features, use the public utilities under
+`grafton_visca::testing::testkit` with the `test-utils` feature. Prefer
+`ScriptedBlockingTransport` or `ScriptedTransport` for protocol scripts and a
+real Tokio/smol executor for wall-clock timeout behavior. See
+`src/testing/testkit/README.md` and the existing operation-handle integration
+tests for maintained patterns.
 
 ### Running Tests
 
@@ -260,7 +255,11 @@ cargo test -- --nocapture
 
 ## Documentation
 
-For 1.x milestone work, update the Unreleased section of `CHANGELOG.md` in the same change as the implementation. If behavior, setup, examples, or contributor workflow changes, update the matching README, example, or contributor docs before closing the task.
+For 1.x milestone work, update the Unreleased section of `CHANGELOG.md` in the
+same change as the implementation. If behavior, setup, examples, or contributor
+workflow changes, update the matching README, example, or contributor docs
+before closing the task. `submit` examples must distinguish lifecycle management
+from profile-aware input validation and applied completion from physical settling.
 
 ### Code Documentation
 
@@ -272,26 +271,24 @@ For 1.x milestone work, update the Unreleased section of `CHANGELOG.md` in the s
 ### Example Documentation
 
 ```rust
-/// Controls camera zoom position.
+/// Return a camera to its home position and wait for physical settling.
 ///
 /// # Examples
 ///
 /// ```no_run
-/// # use grafton_visca::camera::Connect;
-/// # use grafton_visca::profiles::GenericVisca;
-/// let mut cam = Connect::open_udp_blocking::<GenericVisca>("192.168.0.110")?;
-/// cam.zoom_absolute(0x4000)?;
+/// # use std::time::Duration;
+/// # use grafton_visca::{camera::Connect, command::PanTilt, profiles::PtzOpticsG2};
+/// let camera = Connect::open_tcp_blocking::<PtzOpticsG2>("192.168.0.110")?;
+/// camera.submit(&PanTilt::Home)?
+///     .await_settled(Duration::from_secs(20))?;
+/// camera.close()?;
 /// # Ok::<(), grafton_visca::Error>(())
 /// ```
 ///
-/// # Safety
+/// # Errors
 ///
-/// Rapid zoom changes may affect camera stability. Allow time for
-/// mechanical stabilization after large zoom movements.
-#[must_use]
-pub fn zoom_absolute(&mut self, position: u16) -> Result<(), Error> {
-    // Implementation
-}
+/// Returns an error if submission, protocol completion, fallback settling, or
+/// shutdown fails.
 ```
 
 ## Pull Request Process
@@ -312,9 +309,10 @@ pub fn zoom_absolute(&mut self, position: u16) -> Result<(), Error> {
    - Testing performed
 
 4. **Checklist**: Before submitting:
-   - [ ] Tests pass: `cargo test --all-features`
+   - [ ] Declared cfg-aware matrix passes: `bash .github/scripts/test-all-features.sh`
    - [ ] No clippy warnings: `cargo clippy --all-targets --all-features -- -D warnings`
-   - [ ] Formatted: `cargo fmt`
+   - [ ] Formatted: `cargo +nightly fmt --all -- --check`
+   - [ ] Rustdoc and doctests pass for blocking, Tokio, and all-feature surfaces
    - [ ] Documentation updated
    - [ ] CHANGELOG.md updated (if applicable)
    - [ ] Safety documented for movement commands
@@ -323,6 +321,15 @@ pub fn zoom_absolute(&mut self, position: u16) -> Result<(), Error> {
    - Address reviewer feedback promptly
    - Keep discussions focused and professional
    - Update PR description with any significant changes
+
+## Release Process
+
+Releases use a two-crate publish sequence because the main crate depends on the
+same-version `grafton-visca-macros` package. Follow [RELEASING.md](RELEASING.md)
+for version selection, changelog finalization, validation, tagging, crates.io
+index verification, and recovery if the macro package publishes but the main
+package does not. Never create a release tag from a commit that has not passed
+both semver surfaces and the complete 1.x matrix on a pull request.
 
 ## Feature Flags
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Before contributing, please:
 git clone https://github.com/YOUR_USERNAME/grafton-visca.git
 cd grafton-visca
 
-# Run the declared 1.0 support matrix
+# Run the declared 1.x support matrix
 bash .github/scripts/test-all-features.sh
 
 # Or run individual matrix entries while iterating
@@ -236,7 +236,7 @@ fn test_movement_safety() {
 # Default test suite
 cargo test
 
-# Declared 1.0 runtime and transport feature combinations
+# Declared 1.x runtime and transport feature combinations
 bash .github/scripts/test-all-features.sh
 cargo test
 cargo test --no-default-features --features runtime-tokio
@@ -260,7 +260,7 @@ cargo test -- --nocapture
 
 ## Documentation
 
-For v1.0 milestone work, update the Unreleased section of `CHANGELOG.md` in the same change as the implementation. If behavior, setup, examples, or contributor workflow changes, update the matching README, example, or contributor docs before closing the task.
+For 1.x milestone work, update the Unreleased section of `CHANGELOG.md` in the same change as the implementation. If behavior, setup, examples, or contributor workflow changes, update the matching README, example, or contributor docs before closing the task.
 
 ### Code Documentation
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ exclude = [
     ".claude/",
     ".git-hooks/",
     ".pre-commit-config.yaml",
+    "RELEASING.md",
     "all_source.txt",
 ]
 readme = "README.md"
@@ -64,7 +65,7 @@ DISABLED = []
 bytes = "1.11"
 flume = "0.12"
 smallvec = "1.15"
-grafton-visca-macros = { path = "grafton-visca-macros", version = "1.1.0" }
+grafton-visca-macros = { path = "grafton-visca-macros", version = "=1.1.0" }
 tracing = "0.1"
 nom = "8.0.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
@@ -108,6 +109,13 @@ name = "quickstart"
 
 [[example]]
 name = "quickstart_async"
+required-features = ["runtime-tokio"]
+
+[[example]]
+name = "operation_handles"
+
+[[example]]
+name = "operation_handles_async"
 required-features = ["runtime-tokio"]
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -204,6 +204,46 @@ For smol, enable `runtime-smol` and use `SmolRuntime`.
 
 ---
 
+## Bounded Movement Operations
+
+Ordinary noun methods remain the simplest command-completion surface. When a
+caller needs a per-command deadline, cancellation, or a physical settle signal,
+submit a built-in movement command and drive its operation handle explicitly.
+
+```rust,ignore
+use std::time::Duration;
+use grafton_visca::{camera::Connect, command::{PanTilt, Zoom}, profiles::PtzOpticsG2};
+
+let cam = Connect::open_tcp_blocking::<PtzOpticsG2>("192.168.0.110")?;
+
+// Blocking submit performs the initial synchronous dispatch before returning.
+cam.submit(&PanTilt::Home)?
+    .await_settled(Duration::from_secs(20))?;
+
+// A stop/continuous command has no meaningful settled state; wait for it to be
+// accepted and protocol-completed instead.
+cam.submit(&Zoom::Stop)?
+    .await_applied(Duration::from_secs(2))?;
+```
+
+The async form has the same vocabulary and awaits submission and terminal
+operations:
+
+```rust,ignore
+let handle = cam.submit(&PanTilt::Home).await?;
+handle.await_settled(Duration::from_secs(20)).await?;
+```
+
+- `await_applied` means the exact command was accepted and protocol-completed.
+- `await_settled` additionally means targeted physical motion ended. Profiles
+  with an operation-complete signal use it; other profiles poll only the affected
+  axes under the same total deadline.
+- `cancel` requests ID/socket-safe protocol cancellation.
+- `detach` is explicit fire-and-forget. Dropping a handle has the same non-canceling
+  behavior; `#[must_use]` warns only when a returned handle is ignored directly.
+
+---
+
 ## Public API Boundaries
 
 - Use `grafton_visca::camera::{Connect, CameraConfig, CameraBuilder, Camera}`

--- a/README.md
+++ b/README.md
@@ -12,13 +12,18 @@ A pure Rust library for controlling PTZ cameras via the VISCA protocol. Supports
 
 ---
 
-## 1.0 Support Matrix
+## 1.x Support Matrix
 
-The 1.0 contract is the camera-first API, the documented transport/runtime
+The 1.x contract is the camera-first API, the documented transport/runtime
 configuration types, root-level control trait and raw command extension
 surfaces, and the optional feature surfaces listed below. Hardware validation is
 narrower than software support: the library contract is tested automatically,
 while device-specific firmware quirks are handled as reproducible bugs.
+
+The upcoming 1.x release keeps the 1.0 camera-first surface stable while
+completing the additive operation-handle model across blocking, async, and
+dynamic use. Concrete async `_op` methods remain compatibility shims throughout
+1.x; their coherent typed replacement is intentionally deferred to 2.0.
 
 The rows below are the support promise. CI also includes compatibility checks
 for feature unions that can appear in downstream dependency graphs; those checks
@@ -27,19 +32,19 @@ documented rows they combine.
 
 ### APIs and runtimes
 
-| Area | Supported 1.0 contract | Automated validation |
+| Area | Supported 1.x contract | Automated validation |
 | ---- | ---------------------- | -------------------- |
 | Blocking API | Baseline build when `mode-async` is not enabled | `cargo test --no-default-features` |
 | Runtime-agnostic async | `mode-async` with caller-provided executor/runtime | `cargo test --no-default-features --features mode-async` |
 | Tokio async | `runtime-tokio`, `TokioRuntime`, Tokio TCP/UDP adapters | `cargo test --no-default-features --features runtime-tokio` |
 | smol async | `runtime-smol`, `SmolRuntime`, smol TCP/UDP adapters | `cargo test --no-default-features --features runtime-smol` |
 | Runtime coexistence | `runtime-tokio` and `runtime-smol` may be enabled together; camera construction still chooses one runtime explicitly | `cargo check --no-default-features --features runtime-tokio,runtime-smol` |
-| Dynamic API | `dyn-api` object-safe camera traits for async cameras, with runtime capabilities, command-completion timeouts, and cancellable in-flight handles | `cargo test --no-default-features --features runtime-tokio,dyn-api,test-utils --test dyn_api_integration_test`, `cargo test --no-default-features --features runtime-smol,dyn-api,test-utils --test dyn_api_smol_integration_test` |
+| Dynamic API | `dyn-api` object-safe camera traits for async cameras, with runtime capabilities and in-flight handles supporting applied/settled waits, cancellation, and detach | `cargo test --no-default-features --features runtime-tokio,dyn-api,test-utils --test dyn_api_integration_test`, `cargo test --no-default-features --features runtime-smol,dyn-api,test-utils --test dyn_api_smol_integration_test` |
 | Raw command extension | Custom command and inquiry implementations through `grafton_visca::command::{ViscaCommand, CommandBehavior, InquiryResponseSpec, InquiryKind, ResponseParser}` plus root command value re-exports. `ViscaCommand` covers encoding and response routing; typed built-in and raw inquiry responses are supplied by `ResponseParser`. | API contract tests |
 
 ### Transports
 
-| Transport | Supported 1.0 contract | Automated validation |
+| Transport | Supported 1.x contract | Automated validation |
 | --------- | ---------------------- | -------------------- |
 | TCP | Blocking, Tokio, and smol camera connections through `Connect`, `CameraConfig`, and transport config types | Runtime matrix above |
 | UDP | Blocking, Tokio, and smol camera connections through `Connect`, `CameraConfig`, and transport config types | Runtime matrix above |
@@ -49,7 +54,7 @@ documented rows they combine.
 
 ### Profiles
 
-| Profile family | Protocol | 1.0 support |
+| Profile family | Protocol | 1.x support |
 | -------------- | -------- | ----------- |
 | `GenericVisca` | Raw VISCA | Supported baseline profile with conservative capabilities |
 | `PtzOpticsG2`, `PtzOpticsG3`, `PtzOptics30X` | Raw VISCA | Supported; G2/G3 TCP and UDP behavior is hardware-validated |
@@ -126,12 +131,12 @@ matrix fit together.
 
 ### Optional features
 
-| Feature | 1.0 support |
+| Feature | 1.x support |
 | ------- | ----------- |
 | `serde` | Stable serialization/deserialization for public value and configuration types |
 | `schemars` | Stable JSON Schema generation for serde-backed public types |
 | `ts-rs` | Stable TypeScript type generation for supported exported types |
-| `dyn-api` | Stable object-safe async camera traits with command timeout and cancellation support |
+| `dyn-api` | Stable object-safe async camera traits with applied/settled waits, command timeouts, cancellation, and detach |
 | `test-utils` | Stable deterministic test transports, executors, and Tokio camera simulator under `grafton_visca::testing`; `runtime-tokio` alone does not expose test helpers |
 
 ### Compatibility-only checks
@@ -210,37 +215,66 @@ Ordinary noun methods remain the simplest command-completion surface. When a
 caller needs a per-command deadline, cancellation, or a physical settle signal,
 submit a built-in movement command and drive its operation handle explicitly.
 
-```rust,ignore
+`submit` manages lifecycle; it does not add profile capability or range
+validation beyond the command's own checks. Prefer typed noun controls for
+profile-validated ergonomic input. Built-in commands provide exact completion
+metadata. In 1.x, custom commands without metadata use a conservative targeted,
+all-axes fallback; use `submit_continuous` for a custom applied-only command.
+
+```rust
 use std::time::Duration;
 use grafton_visca::{camera::Connect, command::{PanTilt, Zoom}, profiles::PtzOpticsG2};
 
-let cam = Connect::open_tcp_blocking::<PtzOpticsG2>("192.168.0.110")?;
+fn move_home() -> Result<(), grafton_visca::Error> {
+    let cam = Connect::open_tcp_blocking::<PtzOpticsG2>("192.168.0.110")?;
 
-// Blocking submit performs the initial synchronous dispatch before returning.
-cam.submit(&PanTilt::Home)?
-    .await_settled(Duration::from_secs(20))?;
+    // Blocking submit performs initial synchronous dispatch before returning.
+    cam.submit(&PanTilt::Home)?
+        .await_settled(Duration::from_secs(20))?;
 
-// A stop/continuous command has no meaningful settled state; wait for it to be
-// accepted and protocol-completed instead.
-cam.submit(&Zoom::Stop)?
-    .await_applied(Duration::from_secs(2))?;
+    // Applied-only commands have no meaningful settled state.
+    cam.submit(&Zoom::Stop)?
+        .await_applied(Duration::from_secs(2))?;
+
+    cam.close()
+}
 ```
 
 The async form has the same vocabulary and awaits submission and terminal
 operations:
 
-```rust,ignore
-let handle = cam.submit(&PanTilt::Home).await?;
-handle.await_settled(Duration::from_secs(20)).await?;
+```rust
+use std::time::Duration;
+use grafton_visca::{camera::Connect, command::PanTilt, profiles::PtzOpticsG2, runtime::TokioRuntime};
+
+async fn move_home() -> Result<(), grafton_visca::Error> {
+    let runtime = TokioRuntime::from_current()?;
+    let cam = Connect::open_tcp_async::<PtzOpticsG2, _>(
+        "192.168.0.110",
+        runtime,
+    ).await?;
+
+    let handle = cam.submit(&PanTilt::Home).await?;
+    handle.await_settled(Duration::from_secs(20)).await?;
+
+    cam.close().await?;
+    Ok(())
+}
 ```
 
 - `await_applied` means the exact command was accepted and protocol-completed.
 - `await_settled` additionally means targeted physical motion ended. Profiles
   with an operation-complete signal use it; other profiles poll only the affected
   axes under the same total deadline.
-- `cancel` requests ID/socket-safe protocol cancellation.
-- `detach` is explicit fire-and-forget. Dropping a handle has the same non-canceling
-  behavior; `#[must_use]` warns only when a returned handle is ignored directly.
+- `cancel` requests scheduler-owned, ID/socket-safe cancellation. Success means
+  the request was recorded or sent; it does not prove physical motion stopped.
+- `detach` is explicit fire-and-forget. Dropping a handle has the same
+  non-canceling behavior; the submitted command remains scheduler-owned and may
+  still be dispatched and complete. `#[must_use]` warns only when a returned
+  handle is ignored directly.
+
+See the maintained [blocking](examples/operation_handles.rs) and
+[Tokio](examples/operation_handles_async.rs) examples for complete programs.
 
 ---
 
@@ -344,7 +378,7 @@ before any socket or serial device is opened.
 
 - **[API Reference](https://docs.rs/grafton-visca)** — Complete type and method documentation
 - **[Examples](examples/)** — Maintained examples for common scenarios
-- **[Example Policy](docs/examples.md)** — 1.0 examples contract and maintenance rules
+- **[Example Policy](docs/examples.md)** — 1.x examples contract and maintenance rules
 - **[VISCA Protocol Reference](docs/visca_reference.md)** — Consolidated PTZOptics, Axis, and protocol evidence used for built-in profile decisions
 - **[Camera Profile Support Guide](docs/camera_profile_support.md)** — Workflow and testing rules for adding camera capabilities
 - **[CHANGELOG](CHANGELOG.md)** — Version history and migration guides
@@ -356,12 +390,14 @@ before any socket or serial device is opened.
 | Blocking quickstart | `cargo run --example quickstart -- 192.168.0.110` |
 | Blocking quickstart with movement | `cargo run --example quickstart -- 192.168.0.110 --move` |
 | Async quickstart (Tokio) | `cargo run --example quickstart_async --features runtime-tokio -- 192.168.0.110` |
-| Inquiry quickstart | `cargo run --example inquiry_quickstart` |
+| Blocking operation handles | `cargo run --example operation_handles -- 192.168.0.110` |
+| Async operation handles (Tokio) | `cargo run --example operation_handles_async --features runtime-tokio -- 192.168.0.110` |
+| Inquiry quickstart | `cargo run --example inquiry_quickstart -- 192.168.0.110` |
 | Configured transport policy | `cargo run --example transport_builder_demo -- 192.168.0.110` |
 | Caller-owned transport | `cargo run --example builder_api -- 192.168.0.110:1259` |
 | Preset recall | `cargo run --example preset_demo -- 192.168.0.110 recall 1` |
-| Error handling | `cargo run --example error_handling --features runtime-tokio` |
-| Serial (async) | `cargo run --example serial_async_demo --features runtime-tokio,transport-serial-tokio` |
+| Error handling | `cargo run --example error_handling --features runtime-tokio -- 192.168.0.110` |
+| Serial (async) | `cargo run --example serial_async_demo --features runtime-tokio,transport-serial-tokio -- /dev/ttyUSB0 1` |
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,98 @@
+# Releasing grafton-visca 1.x
+
+This checklist is the source of truth for a 1.x release. The workspace contains
+two same-version crates, and crates.io publication is irreversible. Run the
+release from a clean `main` commit whose pull request passed every required CI
+job, including both blocking and async/dynamic semver checks.
+
+## 1. Choose And Record The Version
+
+1. Choose the next semantic version. Do not infer it from the current
+   `Unreleased` section: fixes normally use a patch release; additive public API
+   normally uses a minor release.
+2. Set `[workspace.package].version` in `Cargo.toml`.
+3. Pin the `grafton-visca-macros` dependency in the main crate to the exact same
+   version (`=X.Y.Z`). Both package manifests inherit the workspace version.
+4. Run `cargo check --workspace --no-default-features` to refresh the two local
+   workspace entries in `Cargo.lock`, then verify that no unrelated dependency
+   versions changed.
+5. Move the release notes from `## [Unreleased]` to
+   `## [X.Y.Z] - YYYY-MM-DD`, then restore an empty `Unreleased` heading.
+
+The release workflow rejects a tag unless the `vX.Y.Z` tag, workspace packages,
+macro dependency, lockfile, and changelog heading all agree.
+
+## 2. Validate The Release Commit
+
+Run the same gates expected by CI:
+
+```sh
+cargo +nightly fmt --all -- --check
+bash .github/scripts/test-all-features.sh
+cargo clippy --all-targets --all-features -- -D warnings
+
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --no-default-features
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --no-default-features --features runtime-tokio
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+cargo test --doc --no-default-features
+cargo test --doc --no-default-features --features runtime-tokio
+cargo test --doc --all-features
+
+cargo +1.88.0 check --workspace --all-targets --no-default-features
+cargo +1.88.0 check --workspace --all-targets --no-default-features --features runtime-tokio,dyn-api,test-utils
+
+cargo test --no-default-features --test api_stability_test
+cargo test --no-default-features --features runtime-tokio --test api_stability_test
+cargo test --no-default-features --features runtime-tokio,dyn-api --test api_stability_test
+cargo audit
+```
+
+Inspect the publish file lists and build the macro payload before tagging:
+
+```sh
+cargo package -p grafton-visca-macros --locked --no-verify
+cargo package -p grafton-visca-macros --list
+cargo package -p grafton-visca --list
+```
+
+Cargo cannot build the main `.crate` archive until its exact same-version macro
+dependency exists in the registry. The workflow packages and dry-runs the main
+crate only after the macro package is published and its exact index entry is
+visible. The pre-tag file-list inspection still catches accidental inclusions or
+omissions without pretending the dependency can already resolve.
+
+## 3. Tag And Publish
+
+After the release pull request is merged and required checks pass on `main`:
+
+```sh
+git tag -s vX.Y.Z -m "grafton-visca X.Y.Z"
+git push origin vX.Y.Z
+```
+
+The tag workflow then:
+
+1. validates tag/version/changelog consistency;
+2. packages the macro payload and inspects both crate file lists;
+3. dry-runs and publishes `grafton-visca-macros` with `--locked`;
+4. polls crates.io for the exact macro version with a bounded timeout;
+5. packages, dry-runs, and publishes `grafton-visca` with `--locked`; and
+6. verifies that both exact versions are available from crates.io.
+
+Do not manually publish the main crate first. Do not create or move a release
+tag to bypass a failed validation gate.
+
+## 4. Partial-Publish Recovery
+
+If the macro crate publishes but the main crate fails, do not reuse the version
+for different source. The macro package is already immutable.
+
+1. Keep the tag and source unchanged.
+2. Diagnose the main-crate dry-run or publish failure.
+3. If the fix does not change either package payload, rerun the failed workflow
+   job or publish the main crate from the exact tagged commit.
+4. If source or package metadata must change, choose a new patch version, update
+   both workspace versions and the changelog, and run the complete process again.
+
+After success, verify both package pages and docs.rs, then create the GitHub
+release from the signed tag using the matching changelog section.

--- a/docs/camera_profile_support.md
+++ b/docs/camera_profile_support.md
@@ -190,7 +190,7 @@ cargo test --no-default-features --features test-utils --test compile_time_safet
 cargo clippy --all-targets --all-features -- -D warnings
 ```
 
-Before merging 1.0 contract work, run the declared matrix:
+Before merging 1.x contract work, run the declared matrix:
 
 ```sh
 bash .github/scripts/test-all-features.sh

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,6 @@
 # Example Policy
 
-Examples are part of the 1.0 public surface. They should teach APIs we expect
+Examples are part of the 1.x public surface. They should teach APIs we expect
 to maintain, compile in CI, and avoid surprising camera movement or camera
 configuration changes.
 
@@ -14,6 +14,7 @@ The maintained examples in `examples/` fall into these categories:
 | Inquiry and typed data | `inquiry_quickstart`, `typed_inquiry_demo`, `type_safe_commands` | Demonstrate accessors, profile metadata, conversion helpers, and capability bounds. |
 | Transport setup | `transport_builder_demo`, `transports`, `builder_api`, `serial_async_demo` | Demonstrate current `CameraConfig`, `Connect`, or `CameraBuilder` paths. |
 | Operational patterns | `concurrent_control`, `error_handling`, `runtime_demo`, `runtime_agnostic` | Demonstrate runtime and application patterns without relying on private runtime internals. |
+| Operation handles | `operation_handles`, `operation_handles_async` | Demonstrate blocking and Tokio submission, exact applied waits, physical settled waits, and explicit detach. |
 | Protocol and lab validation | `sony_encapsulation`, `validate_inquiries`, `validate_ae_commands` | Advanced or lab-oriented material that should stay consistent with `docs/visca_reference.md`; not the recommended first path. |
 
 ## Rules
@@ -38,6 +39,13 @@ The maintained examples in `examples/` fall into these categories:
   and keep examples runnable.
 - Keep examples focused. A single example should demonstrate one API path or one
   operational pattern, not a broad hardware tour.
+- Use ordinary noun methods when command completion is sufficient. Use
+  `submit` plus `await_applied` or `await_settled` when the example needs an
+  exact per-command deadline, cancellation, detach, or a physical-settle signal.
+  Use `submit_continuous` for custom applied-only commands.
+- Propagate command, task-join, and shutdown errors in operational examples.
+  A deliberate best-effort cleanup must report its failure rather than silently
+  discarding it.
 - When examples demonstrate optional vendor features, use the support-marker
   bounds for typed controls (`HasNdFilter`, `HasMotionSync`,
   `HasVariableSpeed`) and metadata traits only for runtime discovery. The
@@ -51,20 +59,22 @@ The maintained examples in `examples/` fall into these categories:
 
 ## Release Checks
 
-Before a 1.0 release, run:
+Before a 1.x release, run:
 
 ```sh
-cargo fmt
-cargo check --examples
-cargo check --examples --features runtime-tokio
-cargo check --examples --features runtime-smol
-cargo check --example serial_async_demo --features runtime-tokio,transport-serial-tokio
-cargo test api_contracts --all-features
+cargo +nightly fmt --all -- --check
+cargo check --examples --no-default-features
+cargo check --examples --no-default-features --features mode-async
+cargo check --examples --no-default-features --features runtime-tokio
+cargo check --examples --no-default-features --features runtime-smol
+cargo check --example serial_async_demo --no-default-features --features runtime-tokio,transport-serial-tokio
+cargo clippy --examples --no-default-features --features runtime-tokio -- -D warnings
+bash .github/scripts/test-all-features.sh
 ```
 
 Lab validation tools can be run separately against a known camera bench:
 
 ```sh
 cargo run --example validate_inquiries
-cargo run --example validate_ae_commands
+cargo run --example validate_ae_commands -- --apply
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,19 +3,24 @@
 This directory contains working examples for the current `grafton-visca` API surface.
 
 Preferred usage:
+
 - Use `Connect` for simple blocking and async camera connections.
 - Use `CameraConfig` when a standard TCP, UDP, or serial connection needs explicit timeouts, retry policy, keepalive, or camera ID.
 - Use `CameraBuilder` only when you already own a custom transport and need to attach it to a camera.
 - Import camera construction/session types from `grafton_visca::camera` and generic control traits from the crate root.
 - Use checked public value types such as `UnitInterval::new(...)` and `CameraId`/`try_camera_id(...)` instead of raw normalized floats or raw camera ID setters.
 - Treat raw transport, protocol, and lab-validation programs as advanced integration/reference material.
+- Use ordinary noun methods for simple command completion. Use operation handles
+  when a command needs an exact deadline, physical-settle wait, cancellation, or
+  explicit detach.
 
 Example quality bar:
+
 - A runnable example should either connect to a camera, validate public API types, or be clearly marked as reference material.
 - Examples that move hardware should take the camera address from an argument or environment variable and should keep movement focused.
 - Hard-coded lab IPs belong only in validation utilities, not in getting-started examples.
 
-See [docs/examples.md](../docs/examples.md) for the 1.0 example maintenance policy.
+See [docs/examples.md](../docs/examples.md) for the 1.x example maintenance policy.
 
 ## Important: Feature Flags
 
@@ -35,8 +40,10 @@ If you're new to the library, start with these examples in order:
 1. **[quickstart.rs](quickstart.rs)** - Blocking connection and read-only state query
 2. **[inquiry_quickstart.rs](inquiry_quickstart.rs)** - Blocking inquiry flow with the current accessor API
 3. **[quickstart_async.rs](quickstart_async.rs)** - Tokio async connection and read-only state query
-4. **[type_safe_commands.rs](type_safe_commands.rs)** - Profile metadata, validation, and compile-time capability bounds
-5. **[transport_builder_demo.rs](transport_builder_demo.rs)** - Configured connection setup with `CameraConfig`
+4. **[operation_handles.rs](operation_handles.rs)** - Blocking applied/settled operation waits
+5. **[operation_handles_async.rs](operation_handles_async.rs)** - Tokio applied/settled operation waits and detach
+6. **[type_safe_commands.rs](type_safe_commands.rs)** - Profile metadata, validation, and compile-time capability bounds
+7. **[transport_builder_demo.rs](transport_builder_demo.rs)** - Configured connection setup with `CameraConfig`
 
 ## Examples by Category
 
@@ -45,20 +52,22 @@ If you're new to the library, start with these examples in order:
 - **[quickstart_async.rs](quickstart_async.rs)** - Async version for Tokio
 - **[inquiry_quickstart.rs](inquiry_quickstart.rs)** - High-level inquiry accessors and typed responses
 - **[preset_demo.rs](preset_demo.rs)** - Single preset set, recall, or clear operation
+- **[operation_handles.rs](operation_handles.rs)** - Blocking per-command deadlines and completion levels
+- **[operation_handles_async.rs](operation_handles_async.rs)** - Tokio per-command deadlines and explicit detach
 - **[type_safe_commands.rs](type_safe_commands.rs)** - Compile-time profile and capability safety (no camera required)
 
 ### Connection, Transport, and Configuration
-- **[transports.rs](transports.rs)** - Check TCP and UDP connectivity without changing camera state
+- **[transports.rs](transports.rs)** - Check PTZOptics G2 TCP and UDP connectivity without changing camera state
 - **[transport_builder_demo.rs](transport_builder_demo.rs)** - Current `CameraConfig` transport policy setup
 - **[builder_api.rs](builder_api.rs)** - Attach a caller-owned UDP transport with `CameraBuilder`
 - **[sony_encapsulation.rs](sony_encapsulation.rs)** - Sony encapsulated protocol with 8-byte header (advanced)
-- **[serial_async_demo.rs](serial_async_demo.rs)** - Tokio serial transport setup
+- **[serial_async_demo.rs](serial_async_demo.rs)** - Tokio serial `CameraConfig`, checked camera ID, read-only inquiries, and explicit session close
 
 ### Advanced Patterns
-- **[runtime_agnostic.rs](runtime_agnostic.rs)** - Reference skeleton for custom executor and async transport integrations
+- **[runtime_agnostic.rs](runtime_agnostic.rs)** - Runnable custom `Executor` adapter exercising spawn, sleep, and timeout behavior
 - **[runtime_demo.rs](runtime_demo.rs)** - Tokio runtime setup with concurrent read-only inquiries
-- **[concurrent_control.rs](concurrent_control.rs)** - Concurrent async control patterns
-- **[error_handling.rs](error_handling.rs)** - Comprehensive error handling and recovery strategies
+- **[concurrent_control.rs](concurrent_control.rs)** - Concurrent async inquiries, safely ordered movement, and producer-consumer commands
+- **[error_handling.rs](error_handling.rs)** - Error classification with propagated connection and inquiry failures
 
 ### Validation and Reference
 - **[typed_inquiry_demo.rs](typed_inquiry_demo.rs)** - Typed inquiry API walkthrough
@@ -70,13 +79,13 @@ If you're new to the library, start with these examples in order:
 ### Prerequisites
 
 1. Ensure you have a VISCA-compatible camera connected to your network
-2. Update the IP address in the examples to match your camera (default: `192.168.0.110`)
+2. Pass the camera address as documented by the example, or set its documented environment variable (default: `192.168.0.110`)
 3. Verify the port number; defaults vary by camera model:
    - PTZOptics cameras: TCP port `5678`, UDP port `1259`
    - Sony professional profiles: UDP port `52381`; TCP is not a supported standard construction path
    - The selected profile will provide the default port when you omit it
 
-Most user-facing examples accept a camera address as the first positional argument. Some also read `VISCA_CAMERA_ADDR` or `CAMERA_IP`; check the example header for the exact input.
+Most user-facing examples accept a camera address as the first positional argument. Most also read `VISCA_CAMERA_ADDR`; `builder_api` uses `VISCA_CAMERA_UDP_ADDR`. Check the example header for the exact input.
 
 ### Basic Execution
 
@@ -84,7 +93,8 @@ Run blocking examples:
 ```bash
 cargo run --example quickstart -- 192.168.0.110
 cargo run --example quickstart -- 192.168.0.110 --move
-cargo run --example inquiry_quickstart
+cargo run --example inquiry_quickstart -- 192.168.0.110
+cargo run --example operation_handles -- 192.168.0.110
 cargo run --example preset_demo -- 192.168.0.110 recall 1
 cargo run --example transports -- 192.168.0.110
 cargo run --example builder_api -- 192.168.0.110:1259
@@ -96,11 +106,12 @@ cargo run --example transport_builder_demo -- 192.168.0.110 --udp
 Run async examples:
 ```bash
 cargo run --example quickstart_async --features runtime-tokio -- 192.168.0.110
-cargo run --example concurrent_control --features runtime-tokio
-cargo run --example error_handling --features runtime-tokio
-cargo run --example runtime_demo --features runtime-tokio
-cargo run --example sony_encapsulation --features runtime-tokio
-cargo run --example serial_async_demo --features runtime-tokio,transport-serial-tokio
+cargo run --example operation_handles_async --features runtime-tokio -- 192.168.0.110
+cargo run --example concurrent_control --features runtime-tokio -- 192.168.0.110
+cargo run --example error_handling --features runtime-tokio -- 192.168.0.110
+cargo run --example runtime_demo --features runtime-tokio -- 192.168.0.110
+cargo run --example sony_encapsulation --features runtime-tokio -- 192.168.0.110
+cargo run --example serial_async_demo --features runtime-tokio,transport-serial-tokio -- /dev/ttyUSB0 1
 
 # Runtime-agnostic async example
 cargo run --example runtime_agnostic --features mode-async
@@ -109,15 +120,15 @@ cargo run --example runtime_agnostic --features mode-async
 Run lab validation tools only after editing their camera lists or confirming the checked-in defaults match your test bench:
 ```bash
 cargo run --example validate_inquiries
-cargo run --example validate_ae_commands
+cargo run --example validate_ae_commands -- --apply
 ```
 
 ### With Logging
 
 Enable debug logging to see VISCA commands and responses:
 ```bash
-RUST_LOG=debug cargo run --example quickstart
-RUST_LOG=grafton_visca=debug cargo run --example quickstart_async --features runtime-tokio
+RUST_LOG=debug cargo run --example quickstart -- 192.168.0.110
+RUST_LOG=grafton_visca=debug cargo run --example quickstart_async --features runtime-tokio -- 192.168.0.110
 ```
 
 ## Camera Profiles
@@ -132,7 +143,7 @@ The examples use different camera profiles to demonstrate compile-time type safe
 - `SonyBRC300` - Sony BRC-300 standard PTZ cameras
 - `GenericVisca` - Basic VISCA profile for unknown cameras
 
-Profiles enable compile-time validation of camera capabilities. Commands not supported by a profile won't compile, preventing runtime errors. Optional vendor-specific typed controls are intentionally narrower than runtime metadata: `SonyFR7` exposes ND filter and variable speed controls; built-in PTZOptics profiles are not marked for typed Motion Sync from the current model capability specs.
+Profiles provide compile-time protocol selection, typed capability gates, and runtime capability metadata. Capability-gated typed commands do not compile for unsupported profiles; baseline VISCA commands can still fail at runtime when hardware or firmware differs from the selected profile. Optional vendor-specific typed controls are intentionally narrower than runtime metadata: `SonyFR7` exposes ND filter and variable speed controls; built-in PTZOptics profiles are not marked for typed Motion Sync from the current model capability specs.
 
 Profile capability contributions should follow the [Camera Profile Support Guide](../docs/camera_profile_support.md) and the [VISCA Protocol Reference](../docs/visca_reference.md), which define how protocol evidence, metadata traits, and typed support markers fit together.
 
@@ -146,6 +157,7 @@ use grafton_visca::transport::{TcpKeepaliveConfig, TransportConfig};
 
 let blocking = Connect::open_tcp_blocking::<PtzOpticsG2>("192.168.0.110")?;
 let is_on = blocking.power().state()?;
+blocking.close()?;
 
 let runtime = TokioRuntime::from_current()?;
 let async_camera = CameraConfig::<PtzOpticsG2>::tcp("192.168.0.110")
@@ -156,6 +168,7 @@ let async_camera = CameraConfig::<PtzOpticsG2>::tcp("192.168.0.110")
     .open_async(runtime)
     .await?;
 let is_on = async_camera.power().state().await?;
+async_camera.close().await?;
 ```
 
 ## Troubleshooting
@@ -164,7 +177,7 @@ let is_on = async_camera.power().state().await?;
 - Verify camera IP address and port
 - Check network connectivity: `ping <camera-ip>`
 - Ensure camera supports VISCA over IP
-- Try both TCP and UDP transports
+- Use a transport declared by the selected profile; `transports.rs` can compare both defaults for `PtzOpticsG2`
 
 ### Command Failures
 - Enable debug logging: `RUST_LOG=debug`
@@ -174,11 +187,9 @@ let is_on = async_camera.power().state().await?;
 
 ### Performance
 - Use async for concurrent operations
-- Consider UDP for lower latency (but less reliable)
-- TCP provides better reliability and is recommended
+- Choose among the transports declared by the selected profile and supported by the camera configuration
+- TCP is an ordered byte stream; UDP preserves datagram boundaries but requires application-appropriate timeout and retry policy
 - Adjust timeouts, retry policy, and TCP keepalive based on network conditions
-- The library uses zero-copy parsing and stack-allocated buffers
-- Runtime-agnostic design means zero overhead when not using async
 
 ## Contributing
 

--- a/examples/builder_api.rs
+++ b/examples/builder_api.rs
@@ -9,14 +9,20 @@
 //! ```
 
 #[cfg(not(feature = "mode-async"))]
+mod support;
+
+#[cfg(not(feature = "mode-async"))]
 mod blocking {
-    use std::{env, time::Duration};
+    use std::{env, io, net::SocketAddr, time::Duration};
 
     use grafton_visca::{
         camera::profiles::PtzOpticsG2,
+        capabilities::Capabilities,
         transport::{BackoffStrategy, RetryConfig, Transport, TransportConfig},
         CameraBuilder,
     };
+
+    use super::support::finish_session;
 
     fn transport_config() -> TransportConfig {
         TransportConfig {
@@ -38,15 +44,71 @@ mod blocking {
         }
     }
 
-    pub fn main() -> grafton_visca::Result<()> {
+    fn udp_endpoint() -> Result<String, io::Error> {
+        let mut values = env::args().skip(1);
+        let endpoint = match values.next() {
+            Some(value) if value.starts_with('-') => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unknown option `{value}`"),
+                ));
+            }
+            Some(endpoint) => endpoint,
+            None => match env::var("VISCA_CAMERA_UDP_ADDR") {
+                Ok(endpoint) => endpoint,
+                Err(_) => {
+                    let capabilities = Capabilities::from_profile::<PtzOpticsG2>();
+                    let port = capabilities.default_udp_port.ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::Unsupported,
+                            "PtzOpticsG2 profile does not declare UDP support",
+                        )
+                    })?;
+                    format!("192.168.0.110:{port}")
+                }
+            },
+        };
+
+        if let Some(extra) = values.next() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "unexpected extra argument `{extra}`\nusage: cargo run --example builder_api -- [udp-address:port]"
+                ),
+            ));
+        }
+        if !has_explicit_nonzero_port(&endpoint) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "UDP endpoint must include a nonzero port (for example, 192.168.0.110:1259)",
+            ));
+        }
+
+        Ok(endpoint)
+    }
+
+    fn has_explicit_nonzero_port(endpoint: &str) -> bool {
+        if let Ok(address) = endpoint.parse::<SocketAddr>() {
+            return address.port() != 0;
+        }
+
+        endpoint.matches(':').count() == 1
+            && endpoint
+                .rsplit_once(':')
+                .and_then(|(_, port)| port.parse::<u16>().ok())
+                .is_some_and(|port| port != 0)
+    }
+
+    pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         let _ = tracing_subscriber::fmt::try_init();
 
-        let udp_endpoint = env::args()
-            .nth(1)
-            .or_else(|| env::var("VISCA_CAMERA_UDP_ADDR").ok())
-            .unwrap_or_else(|| "192.168.0.110:1259".to_string());
+        let udp_endpoint = udp_endpoint()?;
 
         println!("CameraBuilder BYO transport example");
+        println!(
+            "Profile: {}",
+            Capabilities::from_profile::<PtzOpticsG2>().model_name
+        );
         println!("UDP endpoint: {udp_endpoint}");
 
         let transport = Transport::udp()
@@ -58,19 +120,20 @@ mod blocking {
             .profile::<PtzOpticsG2>()
             .open()?;
 
-        let power = camera.power().state()?;
+        let power_result = camera.power().state();
+        let close_result = camera.close();
+        let power = finish_session(power_result, close_result)?;
         println!(
             "Connected through caller-owned transport. Power is {}.",
             power_label(power)
         );
-        camera.close()?;
 
         Ok(())
     }
 }
 
 #[cfg(not(feature = "mode-async"))]
-fn main() -> grafton_visca::Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     blocking::main()
 }
 

--- a/examples/concurrent_control.rs
+++ b/examples/concurrent_control.rs
@@ -11,10 +11,12 @@
 //!
 //! Run with:
 //! ```sh
-//! cargo run --example concurrent_control --features runtime-tokio [camera_ip[:port]]
+//! cargo run --example concurrent_control --features runtime-tokio -- [camera_ip[:port]]
 //! ```
 
-use std::sync::Arc;
+mod support;
+
+use std::{env, fmt::Display, io, sync::Arc};
 
 use tokio::{
     sync::mpsc,
@@ -22,21 +24,18 @@ use tokio::{
 };
 
 use grafton_visca::{
-    camera::{profiles::PtzOpticsG2, CameraSession, Connect},
-    mode::Async,
-    runtime::TransportHandle,
+    camera::{profiles::PtzOpticsG2, Connect},
     types::SpeedLevel,
     units::UnitInterval,
-    PanTiltDirection, PresetNumber, Result, TokioRuntime,
+    Error, PanTiltDirection, PresetNumber, TokioRuntime,
 };
+use support::finish_session;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let camera_addr = std::env::args()
-        .nth(1)
-        .unwrap_or_else(|| "192.168.0.110".to_string());
+    let camera_addr = camera_address()?;
 
     println!("=== Concurrent Camera Control Demo ===\n");
     println!("Camera address: {camera_addr}\n");
@@ -52,90 +51,120 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn parallel_operations(camera_addr: &str) -> Result<()> {
+fn camera_address() -> Result<String, io::Error> {
+    let mut values = env::args().skip(1);
+    let address = match values.next() {
+        Some(value) if value.starts_with('-') => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unknown option `{value}`"),
+            ));
+        }
+        Some(value) => value,
+        None => env::var("VISCA_CAMERA_ADDR").unwrap_or_else(|_| "192.168.0.110".to_string()),
+    };
+
+    if let Some(extra) = values.next() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "unexpected extra argument `{extra}`\nusage: cargo run --example concurrent_control --features runtime-tokio -- [address]"
+            ),
+        ));
+    }
+
+    Ok(address)
+}
+
+async fn parallel_operations(camera_addr: &str) -> Result<(), Box<dyn std::error::Error>> {
     println!("--- Example 1: Parallel Operations ---");
 
     let runtime = TokioRuntime::from_current()?;
-    let camera: Arc<
-        CameraSession<Async, PtzOpticsG2, TransportHandle<TokioRuntime>, TokioRuntime>,
-    > = Arc::new(Connect::open_tcp_async::<PtzOpticsG2, _>(camera_addr, runtime).await?);
+    let camera = Connect::open_tcp_async::<PtzOpticsG2, _>(camera_addr, runtime).await?;
 
-    println!("Querying multiple states in parallel...");
+    let operation_result = async {
+        println!("Querying multiple states in parallel...");
 
-    // Query multiple camera states concurrently
-    // Note: accessors must be bound before passing to tokio::join!
-    let power_acc = camera.power();
-    let pan_tilt_acc = camera.pan_tilt();
-    let zoom_acc = camera.zoom();
-    let focus_acc = camera.focus();
+        // Query multiple camera states concurrently
+        // Note: accessors must be bound before passing to tokio::join!
+        let power_acc = camera.power();
+        let pan_tilt_acc = camera.pan_tilt();
+        let zoom_acc = camera.zoom();
+        let focus_acc = camera.focus();
 
-    let (power, pan_tilt, zoom, focus) = tokio::join!(
-        power_acc.state(),
-        pan_tilt_acc.position(),
-        zoom_acc.position(),
-        focus_acc.position()
-    );
+        let (power, pan_tilt, zoom, focus) = tokio::try_join!(
+            power_acc.state(),
+            pan_tilt_acc.position(),
+            zoom_acc.position(),
+            focus_acc.position()
+        )?;
 
-    println!("Power: {power:?}");
-    println!("Pan/Tilt: {pan_tilt:?}");
-    println!("Zoom: {zoom:?}");
-    println!("Focus: {focus:?}");
+        println!("Power: {power:?}");
+        println!("Pan/Tilt: {pan_tilt:?}");
+        println!("Zoom: {zoom:?}");
+        println!("Focus: {focus:?}");
 
-    println!("\nExecuting coordinated movements...");
+        println!("\nExecuting coordinated movements...");
 
-    // Launch concurrent movement commands
-    let zoom_task = {
-        let cam = camera.clone();
-        tokio::spawn(async move { cam.zoom().tele().await })
-    };
+        // Dispatch both starts and observe both results before issuing either stop.
+        let zoom = camera.zoom();
+        let pan_tilt = camera.pan_tilt();
+        let (zoom_start, pan_start) = tokio::join!(
+            zoom.tele(),
+            pan_tilt.move_direction(
+                PanTiltDirection::UpRight,
+                SpeedLevel::Slow.into(),
+                SpeedLevel::Slow.into(),
+            )
+        );
 
-    let pan_task = {
-        let cam = camera.clone();
-        tokio::spawn(async move {
-            cam.pan_tilt()
-                .move_direction(
-                    PanTiltDirection::UpRight,
-                    SpeedLevel::Slow.into(),
-                    SpeedLevel::Slow.into(),
-                )
-                .await
-        })
-    };
+        // Let movements run briefly
+        sleep(Duration::from_millis(100)).await;
 
-    // Let movements run briefly
-    sleep(Duration::from_millis(100)).await;
+        // Attempt both stops even if one start or stop reported an error. A timed-out
+        // start may still have reached the camera, so stopping is the safe cleanup.
+        let zoom = camera.zoom();
+        let pan_tilt = camera.pan_tilt();
+        let (zoom_stop, pan_stop) = tokio::join!(zoom.stop(), pan_tilt.stop());
 
-    // Stop all movements
-    camera.zoom().stop().await?;
-    camera.pan_tilt().stop().await?;
+        report_result("zoom start", &zoom_start);
+        report_result("pan/tilt start", &pan_start);
+        report_result("zoom STOP", &zoom_stop);
+        report_result("pan/tilt STOP", &pan_stop);
 
-    // Wait for movements to settle
-    let _ = tokio::join!(
-        camera.await_zoom_idle(Duration::from_secs(5)),
-        camera.await_pan_tilt_idle(Duration::from_secs(5))
-    );
+        zoom_start?;
+        pan_start?;
+        zoom_stop?;
+        pan_stop?;
 
-    // Ensure spawned tasks complete
-    let _ = tokio::join!(zoom_task, pan_task);
+        // Wait for movements to settle
+        tokio::try_join!(
+            camera.await_zoom_idle(Duration::from_secs(5)),
+            camera.await_pan_tilt_idle(Duration::from_secs(5))
+        )?;
 
-    println!("✓ Parallel operations completed");
+        println!("✓ Parallel operations completed");
 
-    // Return to home
-    println!("Returning to home position...");
-    camera.pan_tilt().home().await?;
-    camera.await_idle(Duration::from_secs(5)).await?;
-    println!("✓ Camera returned to home\n");
+        // Return to home
+        println!("Returning to home position...");
+        camera.pan_tilt().home().await?;
+        camera.await_idle(Duration::from_secs(5)).await?;
+        println!("✓ Camera returned to home\n");
 
+        Ok::<(), Error>(())
+    }
+    .await;
+    let close_result = camera.close().await;
+
+    finish_session(operation_result, close_result)?;
     Ok(())
 }
 
-async fn producer_consumer_pattern(camera_addr: &str) -> Result<()> {
+async fn producer_consumer_pattern(camera_addr: &str) -> Result<(), Box<dyn std::error::Error>> {
     println!("--- Example 2: Producer-Consumer Pattern ---");
 
     let runtime = TokioRuntime::from_current()?;
-    let camera: Arc<
-        CameraSession<Async, PtzOpticsG2, TransportHandle<TokioRuntime>, TokioRuntime>,
-    > = Arc::new(Connect::open_tcp_async::<PtzOpticsG2, _>(camera_addr, runtime).await?);
+    let camera = Arc::new(Connect::open_tcp_async::<PtzOpticsG2, _>(camera_addr, runtime).await?);
 
     let (tx, mut rx) = mpsc::channel(10);
 
@@ -143,39 +172,55 @@ async fn producer_consumer_pattern(camera_addr: &str) -> Result<()> {
     let consumer = {
         let cam = camera.clone();
         tokio::spawn(async move {
+            let max_preset = cam.camera().capabilities().max_presets;
+
             while let Some(cmd) = rx.recv().await {
                 match cmd {
                     Command::Home => {
                         println!("  Executing: Home");
-                        let _ = cam.pan_tilt().home().await;
-                        let _ = cam.await_pan_tilt_idle(Duration::from_secs(5)).await;
+                        cam.pan_tilt().home().await?;
+                        cam.await_pan_tilt_idle(Duration::from_secs(5)).await?;
                     }
-                    Command::Preset(n) => {
-                        println!("  Executing: Preset {n}");
-                        if PresetNumber::new(n).is_ok() {
-                            let _ = cam.presets().recall(n).await;
-                            let _ = cam.await_idle(Duration::from_secs(5)).await;
+                    Command::Preset(preset) => {
+                        let preset = preset.value();
+                        println!("  Executing: Preset {preset}");
+                        if preset > max_preset {
+                            return Err(Error::ParameterOutOfRange {
+                                parameter: "preset_number",
+                                value: i32::from(preset),
+                                min: 0,
+                                max: i32::from(max_preset),
+                            });
                         }
+                        cam.presets().recall(preset).await?;
+                        cam.await_idle(Duration::from_secs(5)).await?;
                     }
                     Command::Zoom(level) => {
-                        println!("  Executing: Zoom to {:.0}%", level * 100.0);
-                        if let Ok(position) = UnitInterval::new(level) {
-                            let _ = cam.zoom().set_normalized(position).await;
-                            let _ = cam.await_zoom_idle(Duration::from_secs(5)).await;
-                        }
+                        println!("  Executing: Zoom to {:.0}%", level.value() * 100.0);
+                        cam.zoom().set_normalized(level).await?;
+                        cam.await_zoom_idle(Duration::from_secs(5)).await?;
                     }
                 }
             }
+
+            Ok::<(), Error>(())
         })
     };
+
+    let preset_1 = PresetNumber::new(1)?;
+    let preset_2 = PresetNumber::new(2)?;
+    let preset_3 = PresetNumber::new(3)?;
+    let zoom_half = UnitInterval::new(0.5)?;
+    let zoom_three_quarters = UnitInterval::new(0.75)?;
 
     // Producer 1 - sends a sequence of commands
     let producer1 = {
         let tx = tx.clone();
         tokio::spawn(async move {
-            let _ = tx.send(Command::Home).await;
-            let _ = tx.send(Command::Preset(1)).await;
-            let _ = tx.send(Command::Zoom(0.5)).await;
+            tx.send(Command::Home).await?;
+            tx.send(Command::Preset(preset_1)).await?;
+            tx.send(Command::Zoom(zoom_half)).await?;
+            Ok::<(), mpsc::error::SendError<Command>>(())
         })
     };
 
@@ -183,18 +228,39 @@ async fn producer_consumer_pattern(camera_addr: &str) -> Result<()> {
     let producer2 = {
         let tx = tx.clone();
         tokio::spawn(async move {
-            let _ = tx.send(Command::Preset(2)).await;
-            let _ = tx.send(Command::Zoom(0.75)).await;
-            let _ = tx.send(Command::Preset(3)).await;
+            tx.send(Command::Preset(preset_2)).await?;
+            tx.send(Command::Zoom(zoom_three_quarters)).await?;
+            tx.send(Command::Preset(preset_3)).await?;
+            Ok::<(), mpsc::error::SendError<Command>>(())
         })
     };
 
     // Wait for producers to finish sending
-    let _ = tokio::join!(producer1, producer2);
+    let (producer1_result, producer2_result) = tokio::join!(producer1, producer2);
 
     // Close channel and wait for consumer to finish
     drop(tx);
-    let _ = consumer.await;
+    let consumer_result = consumer.await;
+    let camera = Arc::try_unwrap(camera)
+        .map_err(|_| io::Error::other("camera still has outstanding task owners"))?;
+    let close_result = camera.close().await;
+
+    report_task_result("producer 1", &producer1_result);
+    report_task_result("producer 2", &producer2_result);
+    report_task_result("consumer", &consumer_result);
+    let task_failed = task_failed(&producer1_result)
+        || task_failed(&producer2_result)
+        || task_failed(&consumer_result);
+    if task_failed {
+        if let Err(error) = &close_result {
+            eprintln!("The camera session also failed to close cleanly: {error}");
+        }
+    }
+
+    producer1_result??;
+    producer2_result??;
+    consumer_result??;
+    close_result?;
 
     println!("✓ Producer-consumer pattern completed\n");
 
@@ -204,6 +270,27 @@ async fn producer_consumer_pattern(camera_addr: &str) -> Result<()> {
 #[derive(Debug)]
 enum Command {
     Home,
-    Preset(u8),
-    Zoom(f32),
+    Preset(PresetNumber),
+    Zoom(UnitInterval),
+}
+
+fn report_result(label: &str, result: &Result<(), Error>) {
+    if let Err(error) = result {
+        eprintln!("{label} failed: {error}");
+    }
+}
+
+fn report_task_result<E>(label: &str, result: &Result<Result<(), E>, tokio::task::JoinError>)
+where
+    E: Display,
+{
+    match result {
+        Ok(Err(error)) => eprintln!("{label} failed: {error}"),
+        Err(error) => eprintln!("{label} task failed: {error}"),
+        Ok(Ok(())) => {}
+    }
+}
+
+fn task_failed<E>(result: &Result<Result<(), E>, tokio::task::JoinError>) -> bool {
+    !matches!(result, Ok(Ok(())))
 }

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -8,7 +8,9 @@
 //! cargo run --example error_handling --features runtime-tokio -- 192.168.0.110
 //! ```
 
-use std::{borrow::Cow, time::Duration};
+mod support;
+
+use std::{borrow::Cow, env, io, time::Duration};
 
 use grafton_visca::{
     camera::{profiles::PtzOpticsG2, CameraConfig},
@@ -17,6 +19,8 @@ use grafton_visca::{
     Error,
 };
 
+use support::finish_session;
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt()
@@ -24,16 +28,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_target(false)
         .try_init();
 
-    let address = std::env::args()
-        .nth(1)
-        .or_else(|| std::env::var("VISCA_CAMERA_ADDR").ok())
-        .unwrap_or_else(|| "192.168.0.110".to_string());
+    let address = address()?;
 
     println!("VISCA error handling example");
     classify_common_errors();
-    connect_and_query(&address).await;
+    connect_and_query(&address).await?;
 
     Ok(())
+}
+
+fn address() -> Result<String, io::Error> {
+    let mut values = env::args().skip(1);
+    let address = match values.next() {
+        Some(value) if value.starts_with('-') => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unknown option `{value}`"),
+            ));
+        }
+        Some(value) => value,
+        None => env::var("VISCA_CAMERA_ADDR").unwrap_or_else(|_| "192.168.0.110".to_string()),
+    };
+
+    if let Some(extra) = values.next() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "unexpected extra argument `{extra}`\nusage: cargo run --example error_handling --features runtime-tokio -- [address]"
+            ),
+        ));
+    }
+
+    Ok(address)
 }
 
 fn classify_common_errors() {
@@ -63,7 +89,7 @@ fn classify_common_errors() {
     }
 }
 
-async fn connect_and_query(address: &str) {
+async fn connect_and_query(address: &str) -> Result<(), Error> {
     println!("\nConnection check:");
     println!("  Address: {address}");
 
@@ -74,31 +100,28 @@ async fn connect_and_query(address: &str) {
         ..TransportConfig::default()
     });
 
-    let runtime = match TokioRuntime::from_current() {
-        Ok(runtime) => runtime,
-        Err(error) => {
-            println!("  Runtime unavailable: {error}");
-            return;
-        }
-    };
-
-    match config.open_async(runtime).await {
-        Ok(camera) => {
-            match camera.power().state().await {
-                Ok(is_on) => println!(
-                    "  Connected. Power is {}.",
-                    if is_on { "on" } else { "off" }
-                ),
-                Err(error) => println!("  Connected, but power inquiry failed: {error}"),
-            }
-            let _ = camera.close().await;
-        }
+    let runtime = TokioRuntime::from_current()?;
+    let camera = match config.open_async(runtime).await {
+        Ok(camera) => camera,
         Err(error) => {
             println!("  Connection failed: {error}");
             println!("  retryable={}", error.is_retryable());
             if let Some(delay) = error.suggested_retry_delay() {
                 println!("  suggested retry delay: {delay:?}");
             }
+            return Err(error);
         }
+    };
+
+    let inquiry_result = camera.power().state().await;
+    match &inquiry_result {
+        Ok(is_on) => println!(
+            "  Connected. Power is {}.",
+            if *is_on { "on" } else { "off" }
+        ),
+        Err(error) => println!("  Connected, but power inquiry failed: {error}"),
     }
+    let close_result = camera.close().await;
+
+    finish_session(inquiry_result.map(|_| ()), close_result)
 }

--- a/examples/inquiry_quickstart.rs
+++ b/examples/inquiry_quickstart.rs
@@ -9,76 +9,102 @@
 //! ```
 
 #[cfg(not(feature = "mode-async"))]
+mod support;
+
+#[cfg(not(feature = "mode-async"))]
 mod blocking {
+    use std::{env, io};
+
     use grafton_visca::{
         camera::{profiles::PtzOpticsG2, Connect},
         inquiry_conversions::{PanTiltPositionRaw, ZoomDomain},
-        ZoomPositionExt,
+        Error, ZoomPositionExt,
     };
 
-    pub fn main() -> grafton_visca::Result<()> {
+    use super::support::finish_session;
+
+    fn address() -> Result<String, io::Error> {
+        let mut values = env::args().skip(1);
+        let address = match values.next() {
+            Some(value) if value.starts_with('-') => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unknown option `{value}`"),
+                ));
+            }
+            Some(value) => value,
+            None => env::var("VISCA_CAMERA_ADDR").unwrap_or_else(|_| "192.168.0.110".to_string()),
+        };
+
+        if let Some(extra) = values.next() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "unexpected extra argument `{extra}`\nusage: cargo run --example inquiry_quickstart -- [address]"
+                ),
+            ));
+        }
+
+        Ok(address)
+    }
+
+    pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         let _ = tracing_subscriber::fmt::try_init();
 
-        let address = std::env::args()
-            .nth(1)
-            .or_else(|| std::env::var("VISCA_CAMERA_ADDR").ok())
-            .unwrap_or_else(|| "192.168.0.110".to_string());
+        let address = address()?;
 
         println!("Inquiry quickstart");
         println!("Address: {address}");
 
         let camera = Connect::open_tcp_blocking::<PtzOpticsG2>(&address)?;
+        let query_result = (|| -> Result<(), Error> {
+            let capabilities = camera.capabilities();
+            println!("Profile: {}", capabilities.model_name);
 
-        match camera.power().state() {
-            Ok(is_on) => println!("Power: {}", if is_on { "on" } else { "off" }),
-            Err(error) => println!("Power inquiry failed: {error}"),
-        }
+            let is_on = camera.power().state()?;
+            println!("Power: {}", if is_on { "on" } else { "off" });
 
-        match camera.pan_tilt().position() {
-            Ok(position) => {
-                let degrees = PanTiltPositionRaw::new(position.pan, position.tilt).as_degrees();
-                println!(
-                    "Pan/tilt: pan={:.1} deg, tilt={:.1} deg",
-                    degrees.pan.0, degrees.tilt.0
-                );
-            }
-            Err(error) => println!("Pan/tilt inquiry failed: {error}"),
-        }
+            let position = camera.pan_tilt().position()?;
+            let degrees = PanTiltPositionRaw::new(position.pan, position.tilt).as_degrees();
+            println!(
+                "Pan/tilt: pan={:.1} deg, tilt={:.1} deg",
+                degrees.pan.0, degrees.tilt.0
+            );
 
-        match camera.zoom().position() {
-            Ok(position) => match position.normalize_with_max(ZoomDomain::Optical, 0x4000, None) {
-                Ok(optical) => println!(
-                    "Zoom: 0x{:04X} ({:.1}% optical)",
-                    position.value(),
-                    optical.value() * 100.0
-                ),
-                Err(error) => println!("Zoom normalization failed: {error}"),
-            },
-            Err(error) => println!("Zoom inquiry failed: {error}"),
-        }
+            let position = camera.zoom().position()?;
+            let optical_max = *capabilities.zoom_range_optical.end();
+            let digital_max = capabilities
+                .zoom_range_digital
+                .as_ref()
+                .map(|range| *range.end());
+            let optical =
+                position.normalize_with_max(ZoomDomain::Optical, optical_max, digital_max)?;
+            println!(
+                "Zoom: 0x{:04X} ({:.1}% optical)",
+                position.value(),
+                optical.value() * 100.0
+            );
 
-        match camera.focus().mode() {
-            Ok(mode) => println!("Focus mode: {mode:?}"),
-            Err(error) => println!("Focus mode inquiry failed: {error}"),
-        }
+            let mode = camera.focus().mode()?;
+            println!("Focus mode: {mode:?}");
 
-        match camera.exposure().mode() {
-            Ok(mode) => println!("Exposure mode: {mode:?}"),
-            Err(error) => println!("Exposure mode inquiry failed: {error}"),
-        }
+            let mode = camera.exposure().mode()?;
+            println!("Exposure mode: {mode:?}");
 
-        match camera.white_balance().mode() {
-            Ok(mode) => println!("White balance mode: {mode:?}"),
-            Err(error) => println!("White balance inquiry failed: {error}"),
-        }
+            let mode = camera.white_balance().mode()?;
+            println!("White balance mode: {mode:?}");
 
-        camera.close()?;
+            Ok(())
+        })();
+        let close_result = camera.close();
+
+        finish_session(query_result, close_result)?;
         Ok(())
     }
 }
 
 #[cfg(not(feature = "mode-async"))]
-fn main() -> grafton_visca::Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     blocking::main()
 }
 

--- a/examples/operation_handles.rs
+++ b/examples/operation_handles.rs
@@ -1,0 +1,88 @@
+//! Blocking operation handles with exact per-command completion semantics.
+//!
+//! This example moves real hardware. It returns the camera home, briefly starts
+//! zooming, and then sends a bounded stop command.
+//!
+//! Run with:
+//! ```sh
+//! cargo run --example operation_handles -- 192.168.0.110
+//! ```
+
+#[cfg(not(feature = "mode-async"))]
+mod support;
+
+#[cfg(not(feature = "mode-async"))]
+mod blocking {
+    use std::{env, io, thread::sleep, time::Duration};
+
+    use grafton_visca::{
+        camera::{profiles::PtzOpticsG2, Connect},
+        command::{PanTilt, Zoom},
+        Error,
+    };
+
+    use super::support::finish_session;
+
+    pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+        let address = camera_address()?;
+
+        let camera = Connect::open_tcp_blocking::<PtzOpticsG2>(&address)?;
+
+        let operation_result: Result<(), Error> = (|| {
+            // A targeted command has a meaningful physical-settle state. One
+            // deadline covers exact protocol completion and any profile fallback.
+            camera
+                .submit(&PanTilt::Home)?
+                .await_settled(Duration::from_secs(20))?;
+
+            // Detach is explicit fire-and-forget. It does not cancel or stop the
+            // command, so this example always follows it with a bounded STOP.
+            camera.submit(&Zoom::TeleStd)?.detach();
+            sleep(Duration::from_millis(250));
+            camera
+                .submit(&Zoom::Stop)?
+                .await_applied(Duration::from_secs(2))?;
+            Ok(())
+        })();
+
+        let close_result = camera.close();
+        finish_session(operation_result, close_result)?;
+        Ok(())
+    }
+
+    fn camera_address() -> Result<String, io::Error> {
+        let mut values = env::args().skip(1);
+        let address = match values.next() {
+            Some(value) if value.starts_with('-') => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unknown option `{value}`"),
+                ));
+            }
+            Some(value) => value,
+            None => env::var("VISCA_CAMERA_ADDR").unwrap_or_else(|_| "192.168.0.110".to_string()),
+        };
+
+        if let Some(extra) = values.next() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "unexpected extra argument `{extra}`\nusage: cargo run --example operation_handles -- [address]"
+                ),
+            ));
+        }
+
+        Ok(address)
+    }
+}
+
+#[cfg(not(feature = "mode-async"))]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    blocking::main()
+}
+
+#[cfg(feature = "mode-async")]
+fn main() {
+    eprintln!("This example uses the blocking API. Run without async features:");
+    eprintln!("  cargo run --example operation_handles -- 192.168.0.110");
+}

--- a/examples/operation_handles_async.rs
+++ b/examples/operation_handles_async.rs
@@ -1,0 +1,81 @@
+//! Tokio operation handles with exact per-command completion semantics.
+//!
+//! This example moves real hardware. It returns the camera home, briefly starts
+//! zooming, and then sends a bounded stop command.
+//!
+//! Run with:
+//! ```sh
+//! cargo run --example operation_handles_async --features runtime-tokio -- 192.168.0.110
+//! ```
+
+mod support;
+
+use std::{env, io, time::Duration};
+
+use grafton_visca::{
+    camera::{profiles::PtzOpticsG2, Connect},
+    command::{PanTilt, Zoom},
+    runtime::TokioRuntime,
+    Error,
+};
+
+use support::finish_session;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let address = camera_address()?;
+
+    let runtime = TokioRuntime::from_current()?;
+    let camera = Connect::open_tcp_async::<PtzOpticsG2, _>(&address, runtime).await?;
+
+    let operation_result: Result<(), Error> = async {
+        // A targeted command has a meaningful physical-settle state. One
+        // deadline covers exact protocol completion and any profile fallback.
+        camera
+            .submit(&PanTilt::Home)
+            .await?
+            .await_settled(Duration::from_secs(20))
+            .await?;
+
+        // Async submission returns after scheduler acceptance. Detach leaves the
+        // command scheduler-owned, so this example always follows it with a STOP.
+        camera.submit(&Zoom::TeleStd).await?.detach();
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        camera
+            .submit(&Zoom::Stop)
+            .await?
+            .await_applied(Duration::from_secs(2))
+            .await?;
+        Ok(())
+    }
+    .await;
+
+    let close_result = camera.close().await;
+    finish_session(operation_result, close_result)?;
+    Ok(())
+}
+
+fn camera_address() -> Result<String, io::Error> {
+    let mut values = env::args().skip(1);
+    let address = match values.next() {
+        Some(value) if value.starts_with('-') => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unknown option `{value}`"),
+            ));
+        }
+        Some(value) => value,
+        None => env::var("VISCA_CAMERA_ADDR").unwrap_or_else(|_| "192.168.0.110".to_string()),
+    };
+
+    if let Some(extra) = values.next() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "unexpected extra argument `{extra}`\nusage: cargo run --example operation_handles_async --features runtime-tokio -- [address]"
+            ),
+        ));
+    }
+
+    Ok(address)
+}

--- a/examples/preset_demo.rs
+++ b/examples/preset_demo.rs
@@ -11,13 +11,19 @@
 //! ```
 
 #[cfg(not(feature = "mode-async"))]
+mod support;
+
+#[cfg(not(feature = "mode-async"))]
 mod blocking {
-    use std::{env, time::Duration};
+    use std::{env, io};
 
     use grafton_visca::{
         camera::{profiles::PtzOpticsG2, AwaitConfig, Connect},
+        capabilities::Capabilities,
         Error,
     };
+
+    use super::support::finish_session;
 
     #[derive(Debug, Clone, Copy)]
     enum Operation {
@@ -33,7 +39,7 @@ mod blocking {
     }
 
     impl Args {
-        fn parse() -> Result<Self, String> {
+        fn parse() -> Result<Self, io::Error> {
             let mut values = env::args().skip(1).collect::<Vec<_>>();
 
             if values.len() == 2 {
@@ -44,21 +50,30 @@ mod blocking {
             }
 
             let [address, command, preset] = values.as_slice() else {
-                return Err(usage());
+                return Err(invalid_input(usage()));
             };
+            if address.starts_with('-') {
+                return Err(invalid_input(format!(
+                    "invalid address `{address}`\n{}",
+                    usage()
+                )));
+            }
 
             let preset = preset
                 .parse::<u8>()
-                .map_err(|_| "preset must be an integer from 0 to 127".to_string())?;
-            if preset > 127 {
-                return Err("preset must be an integer from 0 to 127".to_string());
+                .map_err(|_| invalid_input("preset must be an integer from 0 to 255"))?;
+            let max_preset = Capabilities::from_profile::<PtzOpticsG2>().max_presets;
+            if preset > max_preset {
+                return Err(invalid_input(format!(
+                    "preset must be in the PtzOpticsG2 profile range 0..={max_preset}"
+                )));
             }
 
             let operation = match command.as_str() {
                 "set" => Operation::Set(preset),
                 "recall" => Operation::Recall(preset),
                 "clear" | "reset" => Operation::Clear(preset),
-                _ => return Err(usage()),
+                _ => return Err(invalid_input(usage())),
             };
 
             Ok(Self {
@@ -73,43 +88,44 @@ mod blocking {
             .to_string()
     }
 
-    pub fn main() -> Result<(), Error> {
+    fn invalid_input(message: impl Into<String>) -> io::Error {
+        io::Error::new(io::ErrorKind::InvalidInput, message.into())
+    }
+
+    pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         let _ = tracing_subscriber::fmt::try_init();
 
-        let args = match Args::parse() {
-            Ok(args) => args,
-            Err(message) => {
-                eprintln!("{message}");
-                return Ok(());
-            }
-        };
+        let args = Args::parse()?;
 
         let mut camera = Connect::open_tcp_blocking::<PtzOpticsG2>(&args.address)?;
+        let operation_result = (|| -> Result<(), Error> {
+            match args.operation {
+                Operation::Set(preset) => {
+                    camera.presets().set(preset)?;
+                    println!("Saved current position to preset {preset}.");
+                }
+                Operation::Recall(preset) => {
+                    camera.presets().recall(preset)?;
+                    camera.await_with_config(&AwaitConfig::for_preset_recall())?;
+                    println!("Recalled preset {preset}.");
+                }
+                Operation::Clear(preset) => {
+                    camera.presets().reset(preset)?;
+                    println!("Cleared preset {preset}.");
+                }
+            }
 
-        match args.operation {
-            Operation::Set(preset) => {
-                camera.presets().set(preset)?;
-                println!("Saved current position to preset {preset}.");
-            }
-            Operation::Recall(preset) => {
-                camera.presets().recall(preset)?;
-                camera.await_with_config(&AwaitConfig::for_preset_recall())?;
-                println!("Recalled preset {preset}.");
-            }
-            Operation::Clear(preset) => {
-                camera.presets().reset(preset)?;
-                println!("Cleared preset {preset}.");
-            }
-        }
+            Ok(())
+        })();
+        let close_result = camera.close();
 
-        let _ = camera.await_idle(Duration::from_secs(1));
-        camera.close()?;
+        finish_session(operation_result, close_result)?;
         Ok(())
     }
 }
 
 #[cfg(not(feature = "mode-async"))]
-fn main() -> grafton_visca::Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     blocking::main()
 }
 

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -10,13 +10,18 @@
 //! ```
 
 #[cfg(not(feature = "mode-async"))]
+mod support;
+
+#[cfg(not(feature = "mode-async"))]
 mod blocking {
-    use std::{env, thread::sleep, time::Duration};
+    use std::{env, io, thread::sleep, time::Duration};
 
     use grafton_visca::{
         camera::{profiles::PtzOpticsG2, Connect},
         Error,
     };
+
+    use super::support::finish_session;
 
     #[derive(Debug)]
     struct Args {
@@ -25,25 +30,41 @@ mod blocking {
     }
 
     impl Args {
-        fn parse() -> Self {
+        fn parse() -> Result<Self, io::Error> {
             let mut address = None;
             let mut move_camera = false;
 
             for arg in env::args().skip(1) {
                 match arg.as_str() {
                     "--move" => move_camera = true,
+                    "-h" | "--help" => return Err(io::Error::other(usage())),
+                    _ if arg.starts_with('-') => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("unknown option `{arg}`\n{}", usage()),
+                        ));
+                    }
                     _ if address.is_none() => address = Some(arg),
-                    _ => {}
+                    _ => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("unexpected extra argument `{arg}`\n{}", usage()),
+                        ));
+                    }
                 }
             }
 
-            Self {
+            Ok(Self {
                 address: address
                     .or_else(|| env::var("VISCA_CAMERA_ADDR").ok())
                     .unwrap_or_else(|| "192.168.0.110".to_string()),
                 move_camera,
-            }
+            })
         }
+    }
+
+    fn usage() -> &'static str {
+        "usage: cargo run --example quickstart -- [address] [--move]"
     }
 
     fn power_label(is_on: bool) -> &'static str {
@@ -54,41 +75,55 @@ mod blocking {
         }
     }
 
-    pub fn main() -> Result<(), Error> {
+    pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         let _ = tracing_subscriber::fmt::try_init();
 
-        let args = Args::parse();
+        let args = Args::parse()?;
         println!("Blocking quickstart");
         println!("Address: {}", args.address);
 
         let mut camera = Connect::open_tcp_blocking::<PtzOpticsG2>(&args.address)?;
+        let run_result = (|| -> Result<(), Error> {
+            let power = camera.power().state()?;
+            println!("Power: {}", power_label(power));
 
-        let power = camera.power().state()?;
-        println!("Power: {}", power_label(power));
+            let position = camera.zoom().position()?;
+            println!("Zoom position: 0x{:04X}", position.value());
 
-        match camera.zoom().position() {
-            Ok(position) => println!("Zoom position: 0x{:04X}", position.value()),
-            Err(error) => println!("Zoom position inquiry failed: {error}"),
-        }
+            if args.move_camera {
+                println!("Running short zoom movement.");
+                let start_result = camera.zoom().tele();
+                if start_result.is_ok() {
+                    sleep(Duration::from_millis(250));
+                }
 
-        if args.move_camera {
-            println!("Running short zoom movement.");
-            camera.zoom().tele()?;
-            sleep(Duration::from_millis(250));
-            camera.zoom().stop()?;
-            camera.await_zoom_idle(Duration::from_secs(2))?;
-            println!("Zoom stopped.");
-        } else {
-            println!("No movement requested. Pass --move to run a short zoom command.");
-        }
+                // Once movement starts, always attempt STOP before propagating
+                // its result or waiting for the axis to become idle.
+                let stop_result = camera.zoom().stop();
+                if start_result.is_err() {
+                    if let Err(error) = &stop_result {
+                        eprintln!("The safety STOP also failed: {error}");
+                    }
+                }
+                start_result?;
+                stop_result?;
+                camera.await_zoom_idle(Duration::from_secs(2))?;
+                println!("Zoom stopped.");
+            } else {
+                println!("No movement requested. Pass --move to run a short zoom command.");
+            }
 
-        camera.close()?;
+            Ok(())
+        })();
+        let close_result = camera.close();
+
+        finish_session(run_result, close_result)?;
         Ok(())
     }
 }
 
 #[cfg(not(feature = "mode-async"))]
-fn main() -> grafton_visca::Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     blocking::main()
 }
 

--- a/examples/quickstart_async.rs
+++ b/examples/quickstart_async.rs
@@ -9,7 +9,9 @@
 //! cargo run --example quickstart_async --features runtime-tokio -- 192.168.0.110 --move
 //! ```
 
-use std::env;
+mod support;
+
+use std::{env, io};
 
 use grafton_visca::{
     camera::{profiles::PtzOpticsG2, Connect},
@@ -18,6 +20,8 @@ use grafton_visca::{
 };
 use tokio::time::{sleep, Duration};
 
+use support::finish_session;
+
 #[derive(Debug)]
 struct Args {
     address: String,
@@ -25,25 +29,41 @@ struct Args {
 }
 
 impl Args {
-    fn parse() -> Self {
+    fn parse() -> Result<Self, io::Error> {
         let mut address = None;
         let mut move_camera = false;
 
         for arg in env::args().skip(1) {
             match arg.as_str() {
                 "--move" => move_camera = true,
+                "-h" | "--help" => return Err(io::Error::other(usage())),
+                _ if arg.starts_with('-') => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("unknown option `{arg}`\n{}", usage()),
+                    ));
+                }
                 _ if address.is_none() => address = Some(arg),
-                _ => {}
+                _ => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("unexpected extra argument `{arg}`\n{}", usage()),
+                    ));
+                }
             }
         }
 
-        Self {
+        Ok(Self {
             address: address
                 .or_else(|| env::var("VISCA_CAMERA_ADDR").ok())
                 .unwrap_or_else(|| "192.168.0.110".to_string()),
             move_camera,
-        }
+        })
     }
+}
+
+fn usage() -> &'static str {
+    "usage: cargo run --example quickstart_async --features runtime-tokio -- [address] [--move]"
 }
 
 fn power_label(is_on: bool) -> &'static str {
@@ -55,35 +75,51 @@ fn power_label(is_on: bool) -> &'static str {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let args = Args::parse();
+    let args = Args::parse()?;
     println!("Async quickstart (Tokio)");
     println!("Address: {}", args.address);
 
     let runtime = TokioRuntime::from_current()?;
     let camera = Connect::open_tcp_async::<PtzOpticsG2, _>(&args.address, runtime).await?;
 
-    let power = camera.power().state().await?;
-    println!("Power: {}", power_label(power));
+    let run_result = async {
+        let power = camera.power().state().await?;
+        println!("Power: {}", power_label(power));
 
-    match camera.zoom().position().await {
-        Ok(position) => println!("Zoom position: 0x{:04X}", position.value()),
-        Err(error) => println!("Zoom position inquiry failed: {error}"),
+        let position = camera.zoom().position().await?;
+        println!("Zoom position: 0x{:04X}", position.value());
+
+        if args.move_camera {
+            println!("Running short zoom movement.");
+            let start_result = camera.zoom().tele().await;
+            if start_result.is_ok() {
+                sleep(Duration::from_millis(250)).await;
+            }
+
+            // Once movement starts, always attempt STOP before propagating
+            // its result or waiting for the axis to become idle.
+            let stop_result = camera.zoom().stop().await;
+            if start_result.is_err() {
+                if let Err(error) = &stop_result {
+                    eprintln!("The safety STOP also failed: {error}");
+                }
+            }
+            start_result?;
+            stop_result?;
+            camera.await_zoom_idle(Duration::from_secs(2)).await?;
+            println!("Zoom stopped.");
+        } else {
+            println!("No movement requested. Pass --move to run a short zoom command.");
+        }
+
+        Ok::<(), Error>(())
     }
+    .await;
+    let close_result = camera.close().await;
 
-    if args.move_camera {
-        println!("Running short zoom movement.");
-        camera.zoom().tele().await?;
-        sleep(Duration::from_millis(250)).await;
-        camera.zoom().stop().await?;
-        camera.await_zoom_idle(Duration::from_secs(2)).await?;
-        println!("Zoom stopped.");
-    } else {
-        println!("No movement requested. Pass --move to run a short zoom command.");
-    }
-
-    camera.close().await?;
+    finish_session(run_result, close_result)?;
     Ok(())
 }

--- a/examples/runtime_agnostic.rs
+++ b/examples/runtime_agnostic.rs
@@ -1,190 +1,132 @@
-//! Runtime-agnostic async example showing how to bring your own runtime.
+//! Runnable custom [`Executor`](grafton_visca::Executor) adapter.
 //!
-//! This example demonstrates:
-//! 1. How to implement the Executor trait for a custom runtime
-//! 2. How to use the library without depending on any specific runtime
-//! 3. How to create your own AsyncTransport implementation
+//! This deliberately small reference uses one OS thread per spawned task,
+//! `pollster` to drive futures, and `async-io` for timers. It favors clarity over
+//! scalability while exercising every timing/task primitive that a
+//! caller-provided grafton-visca executor must implement.
 //!
-//! The library provides built-in executors for common runtimes:
-//! - tokio (with --features runtime-tokio)
-//! - smol (with --features runtime-smol)
-//!
-//! But you can use ANY runtime by implementing the Executor trait!
+//! A real camera integration would pass `CustomExecutor` to
+//! `CameraBuilder::with_executor` together with a caller-owned `AsyncTransport`,
+//! then drive application futures with `CustomExecutor::block_on`. Production
+//! integrations should adapt their existing runtime instead of creating a thread
+//! for every spawned task.
 //!
 //! Run with:
 //! ```sh
 //! cargo run --example runtime_agnostic --features mode-async
-//! cargo run --example runtime_agnostic --features runtime-tokio
 //! ```
 
-fn main() {
-    use std::{future::Future, pin::Pin, time::Duration};
+use std::{future::Future, pin::Pin, time::Duration};
 
-    use grafton_visca::{Error, Executor};
+use grafton_visca::{Error, ExecError, Executor};
 
-    println!("🎥 Runtime-Agnostic Camera Control Demo");
-    println!("========================================");
-    println!();
+/// Minimal executor adapter built from runtime-neutral async crates.
+#[derive(Debug, Clone, Copy)]
+struct CustomExecutor;
 
-    // Show which runtime features are enabled
-    #[cfg(feature = "runtime-tokio")]
-    println!("✅ Tokio runtime support enabled");
+impl CustomExecutor {
+    fn new() -> Self {
+        Self
+    }
+}
 
-    #[cfg(feature = "runtime-smol")]
-    println!("✅ smol runtime support enabled");
+impl Executor for CustomExecutor {
+    type Join<T>
+        = Pin<Box<dyn Future<Output = Result<T, ExecError>> + Send + 'static>>
+    where
+        T: Send + 'static;
 
-    println!();
+    // The spawned task is explicitly detached below, so no extra token is needed.
+    type Detach = ();
 
-    // Example: Implement a custom executor for your runtime
-    // This shows the minimal interface you need to implement
-    #[derive(Debug, Clone)]
-    struct MyCustomExecutor;
-
-    impl Executor for MyCustomExecutor {
-        type Join<T>
-            = Pin<Box<dyn Future<Output = Result<T, grafton_visca::ExecError>> + Send + 'static>>
-        where
-            T: Send + 'static;
-
-        type Detach = ();
-
-        fn spawn_with_detach<F>(&self, future: F) -> (Self::Join<F::Output>, Self::Detach)
-        where
-            F: Future + Send + 'static,
-            F::Output: Send + 'static,
-        {
-            // For this demo, we return a stub
-            drop(future);
-            (
-                Box::pin(async {
-                    Err(grafton_visca::ExecError::TaskFailed(
-                        "Demo executor - implement spawn_with_detach() for your runtime".into(),
-                    ))
-                }),
-                (),
-            )
+    fn spawn_with_detach<F>(&self, future: F) -> (Self::Join<F::Output>, Self::Detach)
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let (result_tx, result_rx) = flume::bounded(1);
+        let spawn_error_tx = result_tx.clone();
+        let spawn_result = std::thread::Builder::new()
+            .name("grafton-visca-custom-executor".to_string())
+            .spawn(move || {
+                let result = pollster::block_on(future);
+                let _ = result_tx.send(Ok(result));
+            });
+        if let Err(error) = spawn_result {
+            let _ = spawn_error_tx.send(Err(ExecError::TaskFailed(error.to_string())));
         }
 
-        fn block_on<F: Future>(&self, future: F) -> F::Output {
-            // For this demo, we panic
-            drop(future);
-            panic!("Demo executor - implement block_on() for your runtime")
-        }
+        let join = async move {
+            result_rx
+                .recv_async()
+                .await
+                .map_err(|error| ExecError::JoinFailed(error.to_string()))?
+        };
 
-        #[allow(clippy::manual_async_fn)]
-        fn sleep(&self, duration: Duration) -> impl Future<Output = ()> + Send + '_ {
-            // For this demo, we return immediately
-            async move {
-                println!("  Would sleep for {:?}", duration);
-            }
-        }
+        (Box::pin(join), ())
+    }
 
-        #[allow(clippy::manual_async_fn)]
-        fn timeout<'a, F, T>(
-            &'a self,
-            duration: Duration,
-            future: F,
-        ) -> impl Future<Output = Result<T, Error>> + Send + 'a
-        where
-            F: Future<Output = T> + Send + 'a,
-            T: Send + 'a,
-        {
-            // For this demo, we return timeout error
-            async move {
-                let _ = (duration, future);
+    fn block_on<F>(&self, future: F) -> F::Output
+    where
+        F: Future,
+    {
+        pollster::block_on(future)
+    }
+
+    #[allow(clippy::manual_async_fn)]
+    fn sleep(&self, duration: Duration) -> impl Future<Output = ()> + Send + '_ {
+        async move {
+            async_io::Timer::after(duration).await;
+        }
+    }
+
+    #[allow(clippy::manual_async_fn)]
+    fn timeout<'a, F, T>(
+        &'a self,
+        duration: Duration,
+        future: F,
+    ) -> impl Future<Output = Result<T, Error>> + Send + 'a
+    where
+        F: Future<Output = T> + Send + 'a,
+        T: Send + 'a,
+    {
+        async move {
+            futures_lite::future::race(async move { Ok(future.await) }, async move {
+                async_io::Timer::after(duration).await;
                 Err(Error::Timeout)
-            }
+            })
+            .await
+        }
+    }
+}
+
+fn main() -> Result<(), Error> {
+    let executor = CustomExecutor::new();
+
+    let task = executor.spawn(async { 6_u8 * 7 });
+    let answer = executor.block_on(task).map_err(Error::from)?;
+    println!("spawn/join result: {answer}");
+
+    executor.block_on(executor.sleep(Duration::from_millis(5)));
+    println!("sleep completed");
+
+    let quick =
+        executor.block_on(executor.timeout(Duration::from_millis(50), async { "ready" }))?;
+    println!("quick timeout-wrapped future: {quick}");
+
+    let timed_out = executor.block_on(executor.timeout(Duration::from_millis(5), async {
+        async_io::Timer::after(Duration::from_millis(50)).await;
+    }));
+    match timed_out {
+        Err(Error::Timeout) => println!("slow future timed out as expected"),
+        Err(error) => return Err(error),
+        Ok(()) => {
+            return Err(Error::InvalidState(
+                "custom executor timeout completed unexpectedly".into(),
+            ));
         }
     }
 
-    // Demonstrate using different runtime executors
-    #[cfg(feature = "runtime-tokio")]
-    {
-        use grafton_visca::TokioExecutor;
-
-        println!("Using Tokio executor:");
-        if let Ok(_executor) = TokioExecutor::from_current() {
-            println!("  ✅ Created TokioExecutor from current runtime");
-        } else {
-            println!("  Creating TokioExecutor outside of runtime context");
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            let _guard = rt.enter();
-            let executor = TokioExecutor::from_current().unwrap();
-            println!("  ✅ Created TokioExecutor after entering runtime");
-            let _ = executor;
-        }
-    }
-
-    #[cfg(feature = "runtime-smol")]
-    {
-        use grafton_visca::SmolExecutor;
-
-        println!("Using smol executor:");
-        let executor = SmolExecutor::new();
-        println!("  ✅ Created SmolExecutor");
-        let _ = executor;
-    }
-
-    // Create an instance of your custom executor
-    let my_executor = MyCustomExecutor;
-    println!("\n✅ Created custom executor implementation");
-
-    // Example: How to create your own AsyncTransport
-    println!("\n📡 Custom AsyncTransport Example:");
-    println!("```rust");
-    println!("use grafton_visca::transport::AsyncTransport;");
-    println!("use bytes::Bytes;");
-    println!();
-    println!("struct MyCustomTransport {{ /* your fields */ }}");
-    println!();
-    println!("impl AsyncTransport for MyCustomTransport {{");
-    println!("    async fn send(&self, bytes: &[u8]) -> Result<()> {{");
-    println!("        // Send bytes using your async I/O");
-    println!("        Ok(())");
-    println!("    }}");
-    println!();
-    println!("    async fn recv(&self) -> Result<Bytes> {{");
-    println!("        // Receive response using your async I/O");
-    println!("        Ok(Bytes::new())");
-    println!("    }}");
-    println!("}}");
-    println!("```");
-
-    // Show how it all comes together
-    println!("\n🔧 Putting It All Together:");
-    println!("```rust");
-    println!("// Create your transport");
-    println!("let transport = MyCustomTransport::new();");
-    println!();
-    println!("// Create your executor");
-    println!("let executor = MyCustomExecutor;");
-    println!();
-    println!("// Build the camera with your components");
-    println!("let camera = CameraBuilder::with_executor(executor)");
-    println!("    .from_transport(transport)");
-    println!("    .profile::<PtzOpticsG2>()");
-    println!("    .open_async()");
-    println!("    .await?;");
-    println!();
-    println!("// Use the camera - all async operations use YOUR runtime!");
-    println!("let power_is_on = camera.power().state().await?;");
-    println!("let zoom = camera.zoom().position().await?;");
-    println!("```");
-
-    println!("\n📚 Key Benefits:");
-    println!("✅ No forced runtime dependency");
-    println!("✅ Works with ANY async runtime (tokio, smol, embassy, etc.)");
-    println!("✅ Can integrate with embedded async runtimes");
-    println!("✅ Full control over async execution");
-
-    println!("\n💡 Tips:");
-    println!("- Start with a provided executor (runtime-tokio) to test");
-    println!("- Look at TokioExecutor source for implementation example");
-    println!("- The spawn_with_detach() method is used for background tasks");
-    println!("- The timeout() method is critical for camera operations");
-
-    // Show that we can reference the executor
-    let _ = my_executor;
-
-    println!("\n✅ Example completed successfully!");
+    println!("custom Executor contract exercised successfully");
+    Ok(())
 }

--- a/examples/runtime_demo.rs
+++ b/examples/runtime_demo.rs
@@ -9,20 +9,23 @@
 //! cargo run --example runtime_demo --features runtime-tokio -- 192.168.0.110
 //! ```
 
+mod support;
+
+use std::{env, io};
+
 use grafton_visca::{
     camera::{profiles::PtzOpticsG2, Connect},
     runtime::TokioRuntime,
     Error,
 };
 
+use support::finish_session;
+
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let address = std::env::args()
-        .nth(1)
-        .or_else(|| std::env::var("VISCA_CAMERA_ADDR").ok())
-        .unwrap_or_else(|| "192.168.0.110".to_string());
+    let address = camera_address()?;
 
     println!("Tokio runtime example");
     println!("Address: {address}");
@@ -30,38 +33,53 @@ async fn main() -> Result<(), Error> {
     let runtime = TokioRuntime::from_current()?;
     let camera = Connect::open_tcp_async::<PtzOpticsG2, _>(&address, runtime).await?;
 
-    let power = camera.power();
-    let pan_tilt = camera.pan_tilt();
-    let zoom = camera.zoom();
-    let focus = camera.focus();
+    let inquiry_result: Result<(), Error> = async {
+        let power = camera.power();
+        let pan_tilt = camera.pan_tilt();
+        let zoom = camera.zoom();
+        let focus = camera.focus();
 
-    let (power, pan_tilt, zoom, focus) = tokio::join!(
-        power.state(),
-        pan_tilt.position(),
-        zoom.position(),
-        focus.position()
-    );
+        let (is_on, pan_tilt, zoom, focus) = tokio::try_join!(
+            power.state(),
+            pan_tilt.position(),
+            zoom.position(),
+            focus.position()
+        )?;
 
-    match power {
-        Ok(is_on) => println!("Power: {}", if is_on { "on" } else { "off" }),
-        Err(error) => println!("Power inquiry failed: {error}"),
+        println!("Power: {}", if is_on { "on" } else { "off" });
+        println!("Pan/tilt: pan={}, tilt={}", pan_tilt.pan, pan_tilt.tilt);
+        println!("Zoom: 0x{:04X}", zoom.value());
+        println!("Focus: {focus:?}");
+        Ok(())
     }
+    .await;
 
-    match pan_tilt {
-        Ok(position) => println!("Pan/tilt: pan={}, tilt={}", position.pan, position.tilt),
-        Err(error) => println!("Pan/tilt inquiry failed: {error}"),
-    }
-
-    match zoom {
-        Ok(position) => println!("Zoom: 0x{:04X}", position.value()),
-        Err(error) => println!("Zoom inquiry failed: {error}"),
-    }
-
-    match focus {
-        Ok(position) => println!("Focus: {position:?}"),
-        Err(error) => println!("Focus inquiry failed: {error}"),
-    }
-
-    camera.close().await?;
+    let close_result = camera.close().await;
+    finish_session(inquiry_result, close_result)?;
     Ok(())
+}
+
+fn camera_address() -> Result<String, io::Error> {
+    let mut values = env::args().skip(1);
+    let address = match values.next() {
+        Some(value) if value.starts_with('-') => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unknown option `{value}`"),
+            ));
+        }
+        Some(value) => value,
+        None => env::var("VISCA_CAMERA_ADDR").unwrap_or_else(|_| "192.168.0.110".to_string()),
+    };
+
+    if let Some(extra) = values.next() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "unexpected extra argument `{extra}`\nusage: cargo run --example runtime_demo --features runtime-tokio -- [address]"
+            ),
+        ));
+    }
+
+    Ok(address)
 }

--- a/examples/serial_async_demo.rs
+++ b/examples/serial_async_demo.rs
@@ -1,101 +1,125 @@
-//! Async Serial VISCA Demo
+//! Read-only Tokio serial VISCA example.
 //!
-//! This example demonstrates async serial communication with VISCA cameras
-//! using the new async serial transport implementation.
+//! The example builds a [`CameraConfig`](grafton_visca::camera::CameraConfig),
+//! validates the requested VISCA camera ID before opening the device, performs
+//! two inquiries, and explicitly closes the session on both inquiry success and
+//! failure.
 //!
-//! Usage:
-//!   cargo run --example serial_async_demo --features "runtime-tokio" [port] [camera_address]
+//! Run with the example's exact required features:
+//! ```sh
+//! cargo run --example serial_async_demo \
+//!   --features runtime-tokio,transport-serial-tokio -- [port] [camera_id]
+//! ```
 //!
-//! The example will:
-//! 1. Connect to the camera using async serial transport
-//! 2. Send I/F Clear and optionally Address Set commands
-//! 3. Send some basic commands to verify operation
+//! The defaults are `/dev/ttyUSB0` at 9600 baud and camera ID 1.
 
 use std::env;
 
 use grafton_visca::{
-    camera::{profiles::GenericVisca, Connect},
+    camera::{profiles::GenericVisca, CameraConfig},
     runtime::TokioRuntime,
     Error,
 };
 
+#[derive(Debug)]
+struct Args {
+    port: String,
+    camera_id: u8,
+}
+
+impl Args {
+    fn parse() -> Result<Self, Error> {
+        let mut args = env::args().skip(1);
+        let port = match args.next() {
+            Some(value) if value.starts_with('-') => {
+                return Err(Error::InvalidParameter {
+                    parameter: "arguments",
+                    value: value.into(),
+                    reason: "unknown option; expected [port] [camera_id]".into(),
+                });
+            }
+            Some(value) => value,
+            None => "/dev/ttyUSB0".to_string(),
+        };
+        let camera_id = match args.next() {
+            Some(raw) => raw.parse::<u8>().map_err(|_| Error::InvalidParameter {
+                parameter: "camera_id",
+                value: raw.into(),
+                reason: "expected a numeric VISCA camera ID in 1..=8".into(),
+            })?,
+            None => 1,
+        };
+
+        if let Some(extra) = args.next() {
+            return Err(Error::InvalidParameter {
+                parameter: "arguments",
+                value: extra.into(),
+                reason: "unexpected extra argument; expected [port] [camera_id]".into(),
+            });
+        }
+
+        Ok(Self { port, camera_id })
+    }
+}
+
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+async fn main() -> Result<(), Error> {
+    let _ = tracing_subscriber::fmt::try_init();
+    let args = Args::parse()?;
 
-    println!("Async Serial VISCA Demo");
-    println!("This example demonstrates async serial communication with VISCA cameras.\n");
+    println!("Tokio serial VISCA example");
+    println!("Port: {}", args.port);
+    println!("Baud rate: 9600");
+    println!("Camera ID: {}", args.camera_id);
 
-    let args: Vec<String> = env::args().collect();
-    let port = args.get(1).map(|s| s.as_str()).unwrap_or("/dev/ttyUSB0");
-    let camera_address = args.get(2).and_then(|s| s.parse::<u8>().ok()).unwrap_or(1);
-
-    println!("Serial port: {port}");
-    println!("Camera address: {camera_address}");
-    println!("Connecting to camera...\n");
-
-    // Create camera using the new unified serial API
+    let config = CameraConfig::<GenericVisca>::serial(args.port.clone(), 9600)
+        .try_camera_id(args.camera_id)?;
     let runtime = TokioRuntime::from_current()?;
+    let camera = config.open_serial_async(runtime).await.map_err(|error| {
+        error.context(format!(
+            "failed to open VISCA camera {} on serial port {}",
+            args.camera_id, args.port
+        ))
+    })?;
 
-    match Connect::open_serial_async::<GenericVisca, _>(port, 9600, runtime).await {
-        Ok(camera) => {
-            println!("✅ Serial Transport Connected!");
-            println!("✓ Camera session established");
+    println!("Serial camera session established; running read-only inquiries.");
+    let inquiry_result = async {
+        let version = camera
+            .system()
+            .version()
+            .await
+            .map_err(|error| error.with_context("serial version inquiry failed"))?;
+        println!("Version: {version:?}");
 
-            println!("\n🔍 Testing basic camera operations...");
+        let power = camera
+            .power()
+            .state()
+            .await
+            .map_err(|error| error.with_context("serial power inquiry failed"))?;
+        println!("Power: {}", if power { "on" } else { "standby" });
 
-            match camera.system().version().await {
-                Ok(version) => {
-                    println!("✓ Version Inquiry: {version:?}");
-                }
-                Err(e) => {
-                    println!("⚠ Version inquiry failed: {e}");
-                }
-            }
+        Ok::<(), Error>(())
+    }
+    .await;
 
-            match camera.power().state().await {
-                Ok(power_state) => {
-                    println!("✓ Power State: {power_state}");
-                }
-                Err(e) => {
-                    println!("⚠ Power inquiry failed: {e}");
-                }
-            }
+    // Close before propagating an inquiry error so the example demonstrates a
+    // complete session lifecycle even when the camera rejects an inquiry.
+    let close_result = camera
+        .close()
+        .await
+        .map(|_| ())
+        .map_err(|error| error.with_context("failed to close serial camera session"));
 
-            println!("\n✅ Async serial communication successful!");
-            println!("The camera is now connected and operational via async serial transport.");
+    match (inquiry_result, close_result) {
+        (Ok(()), Ok(())) => {
+            println!("Read-only serial checks completed and the session was closed.");
+            Ok(())
         }
-        Err(Error::TransportError(e)) if e.to_string().contains("No such file") => {
-            println!("❌ Serial Port Not Found: {port}");
-            println!("\nTroubleshooting:");
-            println!("• Verify the serial port exists and is accessible");
-            println!("• Check if the camera is connected and powered on");
-            println!("• Try different port paths:");
-            println!("  Linux:   /dev/ttyUSB0, /dev/ttyACM0, /dev/serial/by-id/...");
-            println!("  macOS:   /dev/cu.usbserial-..., /dev/cu.usbmodem-...");
-            println!("  Windows: COM1, COM2, etc.");
-            println!("• Ensure proper serial port permissions (may need sudo or group membership)");
-        }
-        Err(Error::TransportError(e)) if e.to_string().contains("Permission denied") => {
-            println!("❌ Permission Denied: {port}");
-            println!("\nTroubleshooting:");
-            println!("• Add your user to the dialout group: sudo usermod -a -G dialout $USER");
-            println!("• Then log out and log back in");
-            println!("• Or run with sudo (not recommended for regular use)");
-        }
-        Err(e) => {
-            println!("❌ Unexpected error: {e}");
+        (Err(inquiry_error), Ok(())) => Err(inquiry_error),
+        (Ok(()), Err(close_error)) => Err(close_error),
+        (Err(inquiry_error), Err(close_error)) => {
+            eprintln!("The session also failed to close cleanly: {close_error}");
+            Err(inquiry_error)
         }
     }
-
-    println!("\n📚 About Async Serial VISCA:");
-    println!("This implementation provides RS-232/422 support for async runtimes.");
-    println!("Features:");
-    println!("• Full async/await support using tokio-serial");
-    println!("• Automatic I/F Clear during connection establishment");
-    println!("• Optional Address Set for multi-camera daisy chains");
-    println!("• Proper VISCA framing with camera address insertion");
-    println!("• Configurable timeouts and retry policies");
-
-    Ok(())
 }

--- a/examples/sony_encapsulation.rs
+++ b/examples/sony_encapsulation.rs
@@ -9,6 +9,10 @@
 //! cargo run --example sony_encapsulation --features runtime-tokio -- 192.168.0.110
 //! ```
 
+mod support;
+
+use std::{env, io};
+
 use grafton_visca::{
     camera::{profiles::SonyFR7, Connect},
     capabilities::ProfileMetadata,
@@ -16,14 +20,13 @@ use grafton_visca::{
     Error,
 };
 
+use support::finish_session;
+
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let address = std::env::args()
-        .nth(1)
-        .or_else(|| std::env::var("VISCA_CAMERA_ADDR").ok())
-        .unwrap_or_else(|| "192.168.0.110".to_string());
+    let address = camera_address()?;
 
     println!("Sony encapsulation example");
     println!("Profile: {}", SonyFR7::MODEL_NAME);
@@ -32,21 +35,44 @@ async fn main() -> Result<(), Error> {
     let runtime = TokioRuntime::from_current()?;
     let camera = Connect::open_udp_async::<SonyFR7, _>(&address, runtime).await?;
 
-    match camera.power().state().await {
-        Ok(is_on) => println!("Power: {}", if is_on { "on" } else { "off" }),
-        Err(error) => println!("Power inquiry failed: {error}"),
-    }
+    let inquiry_result: Result<(), Error> = async {
+        let is_on = camera.power().state().await?;
+        let pan_tilt = camera.pan_tilt().position().await?;
+        let zoom = camera.zoom().position().await?;
 
-    match camera.pan_tilt().position().await {
-        Ok(position) => println!("Pan/tilt: pan={}, tilt={}", position.pan, position.tilt),
-        Err(error) => println!("Pan/tilt inquiry failed: {error}"),
+        println!("Power: {}", if is_on { "on" } else { "off" });
+        println!("Pan/tilt: pan={}, tilt={}", pan_tilt.pan, pan_tilt.tilt);
+        println!("Zoom: 0x{:04X}", zoom.value());
+        Ok(())
     }
+    .await;
 
-    match camera.zoom().position().await {
-        Ok(position) => println!("Zoom: 0x{:04X}", position.value()),
-        Err(error) => println!("Zoom inquiry failed: {error}"),
-    }
-
-    camera.close().await?;
+    let close_result = camera.close().await;
+    finish_session(inquiry_result, close_result)?;
     Ok(())
+}
+
+fn camera_address() -> Result<String, io::Error> {
+    let mut values = env::args().skip(1);
+    let address = match values.next() {
+        Some(value) if value.starts_with('-') => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unknown option `{value}`"),
+            ));
+        }
+        Some(value) => value,
+        None => env::var("VISCA_CAMERA_ADDR").unwrap_or_else(|_| "192.168.0.110".to_string()),
+    };
+
+    if let Some(extra) = values.next() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "unexpected extra argument `{extra}`\nusage: cargo run --example sony_encapsulation --features runtime-tokio -- [address]"
+            ),
+        ));
+    }
+
+    Ok(address)
 }

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -1,0 +1,19 @@
+//! Shared helpers for runnable examples.
+
+use grafton_visca::Error;
+
+/// Preserve an operation error while still surfacing a simultaneous close error.
+pub fn finish_session<T, C>(
+    operation: Result<T, Error>,
+    close: Result<C, Error>,
+) -> Result<T, Error> {
+    match (operation, close) {
+        (Ok(value), Ok(_)) => Ok(value),
+        (Err(operation_error), Ok(_)) => Err(operation_error),
+        (Ok(_), Err(close_error)) => Err(close_error),
+        (Err(operation_error), Err(close_error)) => {
+            eprintln!("The camera session also failed to close cleanly: {close_error}");
+            Err(operation_error)
+        }
+    }
+}

--- a/examples/transport_builder_demo.rs
+++ b/examples/transport_builder_demo.rs
@@ -11,13 +11,18 @@
 //! ```
 
 #[cfg(not(feature = "mode-async"))]
+mod support;
+
+#[cfg(not(feature = "mode-async"))]
 mod blocking {
-    use std::{env, time::Duration};
+    use std::{env, io, time::Duration};
 
     use grafton_visca::{
         camera::{profiles::PtzOpticsG2, CameraConfig},
         transport::{BackoffStrategy, RetryConfig, TcpKeepaliveConfig, TransportConfig},
     };
+
+    use super::support::finish_session;
 
     #[derive(Debug, Clone, Copy)]
     enum TransportKind {
@@ -41,26 +46,60 @@ mod blocking {
     }
 
     impl Args {
-        fn parse() -> Self {
+        fn parse() -> Result<Self, io::Error> {
             let mut address = None;
-            let mut transport = TransportKind::Tcp;
+            let mut transport = None;
 
             for arg in env::args().skip(1) {
                 match arg.as_str() {
-                    "--udp" => transport = TransportKind::Udp,
-                    "--tcp" => transport = TransportKind::Tcp,
+                    "--udp" => select_transport(&mut transport, TransportKind::Udp)?,
+                    "--tcp" => select_transport(&mut transport, TransportKind::Tcp)?,
+                    "-h" | "--help" => return Err(io::Error::other(usage())),
+                    _ if arg.starts_with('-') => {
+                        return Err(invalid_input(format!(
+                            "unknown option `{arg}`\n{}",
+                            usage()
+                        )));
+                    }
                     _ if address.is_none() => address = Some(arg),
-                    _ => {}
+                    _ => {
+                        return Err(invalid_input(format!(
+                            "unexpected extra argument `{arg}`\n{}",
+                            usage()
+                        )));
+                    }
                 }
             }
 
-            Self {
+            Ok(Self {
                 address: address
                     .or_else(|| env::var("VISCA_CAMERA_ADDR").ok())
                     .unwrap_or_else(|| "192.168.0.110".to_string()),
-                transport,
-            }
+                transport: transport.unwrap_or(TransportKind::Tcp),
+            })
         }
+    }
+
+    fn select_transport(
+        selected: &mut Option<TransportKind>,
+        requested: TransportKind,
+    ) -> Result<(), io::Error> {
+        if selected.is_some() {
+            return Err(invalid_input(format!(
+                "select exactly one of --tcp or --udp\n{}",
+                usage()
+            )));
+        }
+        *selected = Some(requested);
+        Ok(())
+    }
+
+    fn invalid_input(message: impl Into<String>) -> io::Error {
+        io::Error::new(io::ErrorKind::InvalidInput, message.into())
+    }
+
+    fn usage() -> &'static str {
+        "usage: cargo run --example transport_builder_demo -- [address] [--tcp|--udp]"
     }
 
     fn transport_config(kind: TransportKind) -> TransportConfig {
@@ -98,16 +137,18 @@ mod blocking {
         }
     }
 
-    pub fn main() -> grafton_visca::Result<()> {
+    pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         let _ = tracing_subscriber::fmt::try_init();
 
-        let args = Args::parse();
+        let args = Args::parse()?;
         println!("Configured connection example");
         println!("Address: {}", args.address);
         println!("Transport: {}", args.transport.label());
 
         let camera = camera_config(&args).open_blocking()?;
-        let power = camera.power().state()?;
+        let power_result = camera.power().state();
+        let close_result = camera.close();
+        let power = finish_session(power_result, close_result)?;
 
         println!("Connected. Power is {}.", power_label(power));
         Ok(())
@@ -115,7 +156,7 @@ mod blocking {
 }
 
 #[cfg(not(feature = "mode-async"))]
-fn main() -> grafton_visca::Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     blocking::main()
 }
 

--- a/examples/transports.rs
+++ b/examples/transports.rs
@@ -1,8 +1,9 @@
-//! Compare TCP and UDP connection setup.
+//! Compare TCP and UDP connection setup for a PTZOptics G2-compatible camera.
 //!
 //! This example keeps the camera state unchanged. It opens TCP and/or UDP
 //! connections and runs a power inquiry so users can confirm which transport
-//! works for their camera profile and network.
+//! works for that profile and network. When checking both transports, omit an
+//! explicit port so each transport uses its profile-defined default.
 //!
 //! Run with:
 //! ```sh
@@ -12,10 +13,17 @@
 //! ```
 
 #[cfg(not(feature = "mode-async"))]
-mod blocking {
-    use std::env;
+mod support;
 
-    use grafton_visca::{camera::Connect, profiles::PtzOpticsG2, Error};
+#[cfg(not(feature = "mode-async"))]
+mod blocking {
+    use std::{env, io, net::SocketAddr};
+
+    use grafton_visca::{
+        camera::Connect, capabilities::Capabilities, profiles::PtzOpticsG2, Error,
+    };
+
+    use super::support::finish_session;
 
     #[derive(Debug, Clone, Copy)]
     enum Selection {
@@ -31,25 +39,43 @@ mod blocking {
     }
 
     impl Args {
-        fn parse() -> Self {
+        fn parse() -> Result<Self, io::Error> {
             let mut address = None;
-            let mut selection = Selection::Both;
+            let mut selection = None;
 
             for arg in env::args().skip(1) {
                 match arg.as_str() {
-                    "--tcp-only" => selection = Selection::TcpOnly,
-                    "--udp-only" => selection = Selection::UdpOnly,
+                    "--tcp-only" => select(&mut selection, Selection::TcpOnly)?,
+                    "--udp-only" => select(&mut selection, Selection::UdpOnly)?,
+                    "-h" | "--help" => return Err(io::Error::other(usage())),
+                    _ if arg.starts_with('-') => {
+                        return Err(invalid_input(format!(
+                            "unknown option `{arg}`\n{}",
+                            usage()
+                        )));
+                    }
                     _ if address.is_none() => address = Some(arg),
-                    _ => {}
+                    _ => {
+                        return Err(invalid_input(format!(
+                            "unexpected extra argument `{arg}`\n{}",
+                            usage()
+                        )));
+                    }
                 }
             }
 
-            Self {
-                address: address
-                    .or_else(|| env::var("VISCA_CAMERA_ADDR").ok())
-                    .unwrap_or_else(|| "192.168.0.110".to_string()),
-                selection,
+            let selection = selection.unwrap_or(Selection::Both);
+            let address = address
+                .or_else(|| env::var("VISCA_CAMERA_ADDR").ok())
+                .unwrap_or_else(|| "192.168.0.110".to_string());
+
+            if matches!(selection, Selection::Both) && has_explicit_port(&address) {
+                return Err(invalid_input(
+                    "omit the port when checking both transports so TCP and UDP use their distinct profile defaults",
+                ));
             }
+
+            Ok(Self { address, selection })
         }
 
         fn include_tcp(&self) -> bool {
@@ -59,6 +85,33 @@ mod blocking {
         fn include_udp(&self) -> bool {
             matches!(self.selection, Selection::UdpOnly | Selection::Both)
         }
+    }
+
+    fn select(selected: &mut Option<Selection>, requested: Selection) -> Result<(), io::Error> {
+        if selected.is_some() {
+            return Err(invalid_input(format!(
+                "select at most one of --tcp-only or --udp-only\n{}",
+                usage()
+            )));
+        }
+        *selected = Some(requested);
+        Ok(())
+    }
+
+    fn has_explicit_port(address: &str) -> bool {
+        address.parse::<SocketAddr>().is_ok()
+            || (address.matches(':').count() == 1
+                && address
+                    .rsplit_once(':')
+                    .is_some_and(|(_, port)| port.parse::<u16>().is_ok()))
+    }
+
+    fn invalid_input(message: impl Into<String>) -> io::Error {
+        io::Error::new(io::ErrorKind::InvalidInput, message.into())
+    }
+
+    fn usage() -> &'static str {
+        "usage: cargo run --example transports -- [address] [--tcp-only|--udp-only]"
     }
 
     fn power_label(is_on: bool) -> &'static str {
@@ -71,43 +124,62 @@ mod blocking {
 
     fn check_tcp(address: &str) -> Result<(), Error> {
         let camera = Connect::open_tcp_blocking::<PtzOpticsG2>(address)?;
-        let power = camera.power().state()?;
+        let query_result = camera.power().state();
+        let close_result = camera.close();
+
+        let power = finish_session(query_result, close_result)?;
         println!("TCP: connected, power is {}", power_label(power));
-        camera.close()?;
         Ok(())
     }
 
     fn check_udp(address: &str) -> Result<(), Error> {
         let camera = Connect::open_udp_blocking::<PtzOpticsG2>(address)?;
-        let power = camera.power().state()?;
+        let query_result = camera.power().state();
+        let close_result = camera.close();
+
+        let power = finish_session(query_result, close_result)?;
         println!("UDP: connected, power is {}", power_label(power));
-        camera.close()?;
         Ok(())
     }
 
-    pub fn main() {
+    fn report(label: &str, result: &Result<(), Error>) {
+        if let Err(error) = result {
+            println!("{label}: failed: {error}");
+        }
+    }
+
+    pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         let _ = tracing_subscriber::fmt::try_init();
 
-        let args = Args::parse();
+        let args = Args::parse()?;
+        let capabilities = Capabilities::from_profile::<PtzOpticsG2>();
         println!("Transport check");
+        println!("Profile: {}", capabilities.model_name);
         println!("Address: {}", args.address);
 
-        if args.include_tcp() {
-            if let Err(error) = check_tcp(&args.address) {
-                println!("TCP: failed: {error}");
-            }
+        let tcp_result = args.include_tcp().then(|| check_tcp(&args.address));
+        let udp_result = args.include_udp().then(|| check_udp(&args.address));
+
+        if let Some(result) = &tcp_result {
+            report("TCP", result);
+        }
+        if let Some(result) = &udp_result {
+            report("UDP", result);
         }
 
-        if args.include_udp() {
-            if let Err(error) = check_udp(&args.address) {
-                println!("UDP: failed: {error}");
-            }
+        if let Some(result) = tcp_result {
+            result?;
         }
+        if let Some(result) = udp_result {
+            result?;
+        }
+
+        Ok(())
     }
 }
 
 #[cfg(not(feature = "mode-async"))]
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     blocking::main()
 }
 

--- a/examples/typed_inquiry_demo.rs
+++ b/examples/typed_inquiry_demo.rs
@@ -1,7 +1,9 @@
 //! Typed inquiry responses using high-level API methods.
 //!
 //! This example shows how inquiry methods return typed responses and avoids
-//! manual response parsing.
+//! manual response parsing. It uses the conservative `GenericVisca` profile;
+//! applications should select a model-specific profile when one matches their
+//! hardware.
 //!
 //! Run with:
 //! ```bash
@@ -9,60 +11,99 @@
 //! ```
 
 #[cfg(not(feature = "mode-async"))]
-mod blocking {
-    use grafton_visca::{camera::Connect, profiles::GenericVisca, Error};
+mod support;
 
-    pub fn main() -> Result<(), Error> {
+#[cfg(not(feature = "mode-async"))]
+mod blocking {
+    use std::{env, io};
+
+    use grafton_visca::{
+        camera::Connect, inquiry_conversions::ZoomDomain, profiles::GenericVisca, Error,
+        ZoomPositionExt,
+    };
+
+    use super::support::finish_session;
+
+    fn address() -> Result<String, io::Error> {
+        let mut values = env::args().skip(1);
+        let address = match values.next() {
+            Some(value) if value.starts_with('-') => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unknown option `{value}`"),
+                ));
+            }
+            Some(value) => value,
+            None => env::var("VISCA_CAMERA_ADDR").unwrap_or_else(|_| "192.168.0.110".to_string()),
+        };
+
+        if let Some(extra) = values.next() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "unexpected extra argument `{extra}`\nusage: cargo run --example typed_inquiry_demo -- [address]"
+                ),
+            ));
+        }
+
+        Ok(address)
+    }
+
+    pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         let _ = tracing_subscriber::fmt::try_init();
 
-        let address = std::env::args()
-            .nth(1)
-            .or_else(|| std::env::var("VISCA_CAMERA_ADDR").ok())
-            .unwrap_or_else(|| "192.168.0.110".to_string());
+        let address = address()?;
         println!("Connecting to camera at {address}...");
 
         let camera = Connect::open_tcp_blocking::<GenericVisca>(&address)?;
+        let query_result = (|| -> Result<(), Error> {
+            let capabilities = camera.capabilities();
+            println!("Profile metadata: {}", capabilities.model_name);
+            println!("Inquiry support: {:?}", capabilities.inquiry_support);
+            println!("\nHigh-level API inquiry demo\n");
 
-        println!("\nHigh-level API inquiry demo\n");
+            let power_on = camera.power().state()?;
+            let status = if power_on { "on" } else { "off" };
+            println!("Power: {status}");
 
-        match camera.power().state() {
-            Ok(power_on) => {
-                let status = if power_on { "on" } else { "off" };
-                println!("Power: {status}");
-            }
-            Err(error) => println!("Power inquiry failed: {error}"),
-        }
+            let zoom_pos = camera.zoom().position()?;
+            let raw_value = zoom_pos.value();
+            let optical_max = *capabilities.zoom_range_optical.end();
+            let digital_max = capabilities
+                .zoom_range_digital
+                .as_ref()
+                .map(|range| *range.end());
+            let optical =
+                zoom_pos.normalize_with_max(ZoomDomain::Optical, optical_max, digital_max)?;
 
-        match camera.zoom().position() {
-            Ok(zoom_pos) => {
-                let raw_value = zoom_pos.value();
+            println!("Zoom: 0x{raw_value:04X}");
+            println!("  Optical range: {:.1}%", optical.value() * 100.0);
 
-                use grafton_visca::{inquiry_conversions::ZoomDomain, ZoomPositionExt};
-
-                let optical_max = 0x4000u16;
-                let digital_max = Some(0x7000u16);
-                let optical =
-                    zoom_pos.normalize_with_max(ZoomDomain::Optical, optical_max, digital_max)?;
-                let full = zoom_pos.normalize_with_max(
+            if digital_max.is_some() {
+                let combined = zoom_pos.normalize_with_max(
                     ZoomDomain::OpticalPlusDigital,
                     optical_max,
                     digital_max,
                 )?;
-
-                println!("Zoom: 0x{raw_value:04X}");
-                println!("  Optical zoom: {:.1}%", optical.value() * 100.0);
-                println!("  Full range: {:.1}%", full.value() * 100.0);
+                println!(
+                    "  Optical + digital range: {:.1}%",
+                    combined.value() * 100.0
+                );
+            } else {
+                println!("  Digital zoom range: not declared by this profile");
             }
-            Err(error) => println!("Zoom inquiry failed: {error}"),
-        }
 
-        camera.close()?;
+            Ok(())
+        })();
+        let close_result = camera.close();
+
+        finish_session(query_result, close_result)?;
         Ok(())
     }
 }
 
 #[cfg(not(feature = "mode-async"))]
-fn main() -> grafton_visca::Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     blocking::main()
 }
 

--- a/examples/validate_ae_commands.rs
+++ b/examples/validate_ae_commands.rs
@@ -1,20 +1,31 @@
-//! Validate CAM_AE SET and CAM_AEModeInq against real cameras.
+//! Lab tool for validating CAM_AE SET and CAM_AEModeInq against real cameras.
 //!
 //! This script sends raw VISCA bytes to test exposure mode inquiry and set
 //! commands, validating that CAM_AEModeInq (81 09 04 39 FF) and CAM_AE SET
 //! (81 01 04 39 0p FF) work correctly on PTZOptics cameras.
 //!
+//! **Warning:** This tool changes exposure mode on every camera in `CAMERAS`.
+//! It attempts to restore each original mode and verifies the readback, but
+//! interruption, transport failure, or camera failure can prevent restoration.
+//! Review the hard-coded lab targets and pass `--apply` to acknowledge mutation.
+//!
 //! Run with:
 //! ```sh
-//! cargo run --example validate_ae_commands
+//! cargo run --example validate_ae_commands -- --apply
 //! ```
 
-use std::io::{Read, Write};
-use std::net::TcpStream;
-use std::time::Duration;
+use std::{
+    error::Error,
+    io::{self, Read, Write},
+    net::TcpStream,
+    time::Duration,
+};
 
 type ModeResults = Vec<(&'static str, bool)>;
 type CameraResult = Result<(bool, ModeResults, bool), String>;
+
+const VISCA_TERMINATOR: u8 = 0xFF;
+const MAX_FRAME_SIZE: usize = 4096;
 
 /// Camera addresses to test.
 const CAMERAS: &[(&str, &str)] = &[
@@ -45,25 +56,79 @@ fn exposure_mode_name(byte: u8) -> &'static str {
     }
 }
 
-/// Send bytes and read response, returning the raw response bytes.
-fn send_and_receive(stream: &mut TcpStream, bytes: &[u8]) -> Result<Vec<u8>, String> {
-    stream.write_all(bytes).map_err(|e| format!("send: {e}"))?;
+/// TCP is a byte stream, so preserve unread bytes when one read contains
+/// several VISCA frames and keep reading when a frame is fragmented.
+struct FramedViscaStream {
+    stream: TcpStream,
+    pending: Vec<u8>,
+}
 
-    // Wait for camera to respond
-    std::thread::sleep(Duration::from_millis(150));
+impl FramedViscaStream {
+    fn connect(address: &str) -> io::Result<Self> {
+        let stream = TcpStream::connect(address)?;
+        stream.set_read_timeout(Some(Duration::from_secs(3)))?;
+        stream.set_write_timeout(Some(Duration::from_secs(3)))?;
 
-    let mut buf = [0u8; 64];
-    match stream.read(&mut buf) {
-        Ok(0) => Err("connection closed".to_string()),
-        Ok(n) => Ok(buf[..n].to_vec()),
-        Err(e)
-            if e.kind() == std::io::ErrorKind::WouldBlock
-                || e.kind() == std::io::ErrorKind::TimedOut =>
-        {
-            Err("timeout".to_string())
-        }
-        Err(e) => Err(format!("read: {e}")),
+        Ok(Self {
+            stream,
+            pending: Vec::new(),
+        })
     }
+
+    fn send(&mut self, frame: &[u8]) -> io::Result<()> {
+        self.stream.write_all(frame)
+    }
+
+    fn recv_frame(&mut self) -> io::Result<Vec<u8>> {
+        loop {
+            if let Some(end) = self
+                .pending
+                .iter()
+                .position(|byte| *byte == VISCA_TERMINATOR)
+            {
+                return Ok(self.pending.drain(..=end).collect());
+            }
+
+            if self.pending.len() >= MAX_FRAME_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "VISCA response exceeded the lab tool's frame limit",
+                ));
+            }
+
+            let mut chunk = [0_u8; 256];
+            let read = self.stream.read(&mut chunk)?;
+            if read == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "camera closed the connection before a complete VISCA frame",
+                ));
+            }
+
+            self.pending.extend_from_slice(&chunk[..read]);
+            if self.pending.len() > MAX_FRAME_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "VISCA response exceeded the lab tool's frame limit",
+                ));
+            }
+        }
+    }
+}
+
+fn connect_camera(address: &str) -> Result<FramedViscaStream, String> {
+    FramedViscaStream::connect(address).map_err(|error| format!("connect/setup: {error}"))
+}
+
+/// Send bytes and read response, returning the raw response bytes.
+fn send_and_receive(stream: &mut FramedViscaStream, bytes: &[u8]) -> Result<Vec<u8>, String> {
+    stream.send(bytes).map_err(|e| format!("send: {e}"))?;
+    stream.recv_frame().map_err(|error| match error.kind() {
+        io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut => {
+            "inconclusive: no complete response before timeout".to_string()
+        }
+        _ => format!("read: {error}"),
+    })
 }
 
 /// Format bytes as hex string.
@@ -75,22 +140,34 @@ fn hex(bytes: &[u8]) -> String {
         .join(" ")
 }
 
-/// Parse a VISCA response. Returns Ok with the data payload for a successful
-/// inquiry reply (90 50 ...), or Err with a description.
-fn parse_inquiry_response(response: &[u8]) -> Result<Vec<u8>, String> {
+/// Parse the single-byte CAM_AEModeInq response.
+fn parse_exposure_mode_response(response: &[u8]) -> Result<u8, String> {
     if response.len() < 3 {
         return Err(format!("short response: {}", hex(response)));
+    }
+    if response.last() != Some(&VISCA_TERMINATOR) {
+        return Err(format!("missing terminator: {}", hex(response)));
     }
     if response[0] != 0x90 {
         return Err(format!("unexpected source: {}", hex(response)));
     }
     if response[1] == 0x50 {
-        // Data reply: 90 50 <data...> FF
-        let end = response.len() - 1; // skip trailing FF
-        Ok(response[2..end].to_vec())
-    } else if response[1] == 0x60 {
-        let code = response.get(2).copied().unwrap_or(0);
-        let desc = match code {
+        let payload = &response[2..response.len() - 1];
+        return match payload {
+            [mode] => Ok(*mode),
+            _ => Err(format!(
+                "CAM_AEModeInq expected one data byte, received {}: {}",
+                payload.len(),
+                hex(response)
+            )),
+        };
+    }
+    if response[1] & 0xF0 == 0x60 {
+        let payload = &response[2..response.len() - 1];
+        let [code] = payload else {
+            return Err(format!("malformed VISCA error: {}", hex(response)));
+        };
+        let desc = match *code {
             0x02 => "Syntax Error",
             0x03 => "Command Buffer Full",
             0x04 => "Command Cancelled",
@@ -103,76 +180,91 @@ fn parse_inquiry_response(response: &[u8]) -> Result<Vec<u8>, String> {
     }
 }
 
-/// Parse a VISCA command response. Reads ACK + Completion, handling the
-/// two-message flow (90 4x FF for ACK, then 90 5x FF for completion).
-fn send_command_and_wait(stream: &mut TcpStream, bytes: &[u8]) -> Result<(), String> {
-    stream.write_all(bytes).map_err(|e| format!("send: {e}"))?;
+#[derive(Debug, Clone, Copy)]
+enum CommandReply {
+    Ack(u8),
+    Completion(u8),
+    Error { socket: u8, code: u8 },
+}
 
-    // Read ACK (90 4x FF)
-    std::thread::sleep(Duration::from_millis(150));
-    let mut buf = [0u8; 64];
-    let n = stream
-        .read(&mut buf)
-        .map_err(|e| format!("read ACK: {e}"))?;
-    let ack = &buf[..n];
-
-    if n < 3 || ack[0] != 0x90 || (ack[1] & 0xF0) != 0x40 {
-        // Might be a direct completion or error
-        if n >= 3 && ack[0] == 0x90 && (ack[1] & 0xF0) == 0x50 {
-            return Ok(()); // Direct completion
-        }
-        if n >= 3 && ack[0] == 0x90 && ack[1] == 0x60 {
-            let code = ack.get(2).copied().unwrap_or(0);
-            return Err(format!("error 0x{code:02X} (no ACK)"));
-        }
-        return Err(format!("unexpected ACK: {}", hex(ack)));
+fn parse_command_reply(response: &[u8]) -> Result<CommandReply, String> {
+    if response.last() != Some(&VISCA_TERMINATOR) {
+        return Err(format!("missing terminator: {}", hex(response)));
+    }
+    if response.len() < 3 {
+        return Err(format!("short command response: {}", hex(response)));
+    }
+    if response[0] != 0x90 {
+        return Err(format!("unexpected response source: {}", hex(response)));
     }
 
-    // Check if completion was bundled with ACK
-    // Some cameras send ACK+Completion in the same TCP read
-    if n >= 6 {
-        let second = &ack[3..n];
-        if second.len() >= 3 && second[0] == 0x90 && (second[1] & 0xF0) == 0x50 {
-            return Ok(());
-        }
+    let socket = response[1] & 0x0F;
+    match response[1] & 0xF0 {
+        0x40 if response.len() == 3 => Ok(CommandReply::Ack(socket)),
+        0x50 if response.len() == 3 => Ok(CommandReply::Completion(socket)),
+        0x60 if response.len() == 4 => Ok(CommandReply::Error {
+            socket,
+            code: response[2],
+        }),
+        0x40 => Err(format!("malformed ACK: {}", hex(response))),
+        0x50 => Err(format!("malformed completion: {}", hex(response))),
+        0x60 => Err(format!("malformed VISCA error: {}", hex(response))),
+        _ => Err(format!("unexpected command reply: {}", hex(response))),
     }
+}
 
-    // Read Completion (90 5x FF)
-    std::thread::sleep(Duration::from_millis(150));
-    let n = stream
-        .read(&mut buf)
-        .map_err(|e| format!("read completion: {e}"))?;
-    let completion = &buf[..n];
+fn receive_command_reply(
+    stream: &mut FramedViscaStream,
+    stage: &str,
+) -> Result<CommandReply, String> {
+    let response = stream.recv_frame().map_err(|error| match error.kind() {
+        io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut => {
+            format!("inconclusive: no complete {stage} before timeout")
+        }
+        _ => format!("read {stage}: {error}"),
+    })?;
+    parse_command_reply(&response)
+}
 
-    if n >= 3 && completion[0] == 0x90 && (completion[1] & 0xF0) == 0x50 {
-        Ok(())
-    } else if n >= 3 && completion[0] == 0x90 && completion[1] == 0x60 {
-        let code = completion.get(2).copied().unwrap_or(0);
-        Err(format!("error 0x{code:02X} on completion"))
-    } else {
-        Err(format!("unexpected completion: {}", hex(completion)))
+/// Read the ACK + Completion flow. Coalesced frames remain buffered and are
+/// returned by the second `recv_frame` call; fragmented frames are reassembled.
+fn send_command_and_wait(stream: &mut FramedViscaStream, bytes: &[u8]) -> Result<(), String> {
+    stream.send(bytes).map_err(|e| format!("send: {e}"))?;
+
+    match receive_command_reply(stream, "ACK or completion")? {
+        CommandReply::Completion(_) => Ok(()),
+        CommandReply::Error { socket, code } => {
+            Err(format!("camera error 0x{code:02X} on socket {socket}"))
+        }
+        CommandReply::Ack(ack_socket) => match receive_command_reply(stream, "completion")? {
+            CommandReply::Completion(completion_socket)
+                if completion_socket == ack_socket || completion_socket == 0 =>
+            {
+                Ok(())
+            }
+            CommandReply::Completion(completion_socket) => Err(format!(
+                "completion socket {completion_socket} did not match ACK socket {ack_socket}"
+            )),
+            CommandReply::Error { socket, code } => Err(format!(
+                "camera error 0x{code:02X} on socket {socket} after ACK on socket {ack_socket}"
+            )),
+            CommandReply::Ack(socket) => Err(format!("unexpected second ACK on socket {socket}")),
+        },
     }
 }
 
 /// Test a single camera and return (inquiry_ok, set_results, restore_ok).
 fn test_camera(name: &str, addr: &str) -> CameraResult {
     println!("\n  Connecting to {addr}...");
-    let mut stream = TcpStream::connect(addr).map_err(|e| format!("connect: {e}"))?;
-    stream
-        .set_read_timeout(Some(Duration::from_secs(3)))
-        .unwrap();
-    stream
-        .set_write_timeout(Some(Duration::from_secs(3)))
-        .unwrap();
+    let mut stream = connect_camera(addr)?;
     println!("  Connected to {name}");
 
     // Step 1: Query current exposure mode
     println!("  [1] Querying current exposure mode...");
     let inquiry_bytes = [0x81, 0x09, 0x04, 0x39, 0xFF];
     let response = send_and_receive(&mut stream, &inquiry_bytes)?;
-    let original_mode = match parse_inquiry_response(&response) {
-        Ok(data) => {
-            let mode = data[0];
+    let original_mode = match parse_exposure_mode_response(&response) {
+        Ok(mode) => {
             println!(
                 "      Current mode: 0x{mode:02X} ({})",
                 exposure_mode_name(mode)
@@ -184,6 +276,7 @@ fn test_camera(name: &str, addr: &str) -> CameraResult {
             return Ok((false, vec![], false));
         }
     };
+    drop(stream);
 
     // Step 2: Test all 5 exposure modes
     println!("  [2] Testing exposure mode SET commands...");
@@ -197,22 +290,34 @@ fn test_camera(name: &str, addr: &str) -> CameraResult {
         let set_cmd = [0x81, 0x01, 0x04, 0x39, mode_byte, 0xFF];
         print!("      SET {mode_name:<20} (0x{mode_byte:02X}): ");
 
+        // Isolate each mutation on a fresh connection. If one exchange times
+        // out or is malformed, a late response cannot be mistaken for the next
+        // command's ACK or inquiry reply.
+        let mut stream = match connect_camera(addr) {
+            Ok(stream) => stream,
+            Err(error) => {
+                println!("FAILED: {error}");
+                set_results.push((mode_name, false));
+                continue;
+            }
+        };
+
         match send_command_and_wait(&mut stream, &set_cmd) {
             Ok(()) => {
                 // Verify by re-querying
                 std::thread::sleep(Duration::from_millis(200));
                 let verify = send_and_receive(&mut stream, &inquiry_bytes);
-                match verify
-                    .and_then(|r| parse_inquiry_response(&r).map_err(|e| format!("verify: {e}")))
-                {
-                    Ok(data) => {
-                        if data[0] == mode_byte {
-                            println!("OK (verified 0x{:02X})", data[0]);
+                match verify.and_then(|response| {
+                    parse_exposure_mode_response(&response)
+                        .map_err(|error| format!("verify: {error}"))
+                }) {
+                    Ok(readback) => {
+                        if readback == mode_byte {
+                            println!("OK (verified 0x{readback:02X})");
                             set_results.push((mode_name, true));
                         } else {
                             println!(
-                                "SET succeeded but readback=0x{:02X} (expected 0x{mode_byte:02X})",
-                                data[0]
+                                "SET succeeded but readback=0x{readback:02X} (expected 0x{mode_byte:02X})"
                             );
                             set_results.push((mode_name, false));
                         }
@@ -237,22 +342,49 @@ fn test_camera(name: &str, addr: &str) -> CameraResult {
         exposure_mode_name(original_mode)
     );
     let restore_cmd = [0x81, 0x01, 0x04, 0x39, original_mode, 0xFF];
-    let restore_ok = match send_command_and_wait(&mut stream, &restore_cmd) {
-        Ok(()) => {
-            println!("      Restored successfully");
-            true
-        }
-        Err(e) => {
-            println!("      Restore FAILED: {e}");
-            false
-        }
-    };
+    let restore_ok = connect_camera(addr)
+        .and_then(|mut restore_stream| {
+            send_command_and_wait(&mut restore_stream, &restore_cmd)?;
+            std::thread::sleep(Duration::from_millis(200));
+            let response = send_and_receive(&mut restore_stream, &inquiry_bytes)?;
+            let readback = parse_exposure_mode_response(&response)
+                .map_err(|error| format!("restore verification: {error}"))?;
+            if readback == original_mode {
+                Ok(())
+            } else {
+                Err(format!(
+                    "restore readback was 0x{readback:02X}, expected 0x{original_mode:02X}"
+                ))
+            }
+        })
+        .map_or_else(
+            |error| {
+                println!("      Restore FAILED: {error}");
+                false
+            },
+            |()| {
+                println!("      Restored and verified successfully");
+                true
+            },
+        );
 
     Ok((true, set_results, restore_ok))
 }
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut arguments = std::env::args().skip(1);
+    if arguments.next().as_deref() != Some("--apply") || arguments.next().is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "this lab tool mutates every camera in CAMERAS; review the targets, then run `cargo run --example validate_ae_commands -- --apply`",
+        )
+        .into());
+    }
+
     println!("=== CAM_AE SET / CAM_AEModeInq Validation ===");
+    println!("WARNING: this mutates exposure mode on every configured lab camera.");
+    println!("Original modes are restored and verified when execution reaches the restore step;");
+    println!("interruption or transport/camera failure can still leave a camera changed.\n");
     println!("Testing exposure mode inquiry and set commands on all cameras.\n");
 
     let mut summary: Vec<(String, bool, ModeResults, bool)> = Vec::new();
@@ -309,4 +441,21 @@ fn main() {
 
     println!("{:-<70}", "");
     println!("\n=== Validation Complete ===");
+
+    let all_checks_passed = summary
+        .iter()
+        .all(|(_, inquiry_ok, set_results, restore_ok)| {
+            *inquiry_ok
+                && *restore_ok
+                && set_results.len() == EXPOSURE_MODES.len()
+                && set_results.iter().all(|(_, passed)| *passed)
+        });
+    if !all_checks_passed {
+        return Err(io::Error::other(
+            "one or more exposure checks failed; inspect the summary and verify every camera's restored state",
+        )
+        .into());
+    }
+
+    Ok(())
 }

--- a/examples/validate_inquiries.rs
+++ b/examples/validate_inquiries.rs
@@ -1,40 +1,149 @@
-//! Validate VISCA inquiry support against a real camera.
+//! Lab tool for validating VISCA inquiry support against a real camera.
 //!
 //! This script sends raw VISCA inquiry bytes and reports what the camera responds with.
-//! Use this to validate whether specific inquiries are actually supported.
+//! It deliberately bypasses the high-level camera API so protocol behavior can be
+//! inspected directly. A timeout is inconclusive; it is not proof that an inquiry
+//! is unsupported.
 //!
 //! Run with:
 //! ```sh
 //! cargo run --example validate_inquiries
 //! ```
 
-use std::io::{Read, Write};
-use std::net::TcpStream;
-use std::time::Duration;
+use std::{
+    error::Error,
+    io::{self, Read, Write},
+    net::TcpStream,
+    time::Duration,
+};
 
 const CAMERA_IP: &str = "192.168.0.110:5678";
+const VISCA_TERMINATOR: u8 = 0xFF;
+const MAX_FRAME_SIZE: usize = 4096;
 
-fn main() {
+/// TCP is a byte stream, so a read can contain a partial VISCA frame or several
+/// coalesced frames. Keep unread bytes between calls and return exactly one
+/// terminator-delimited frame at a time.
+struct FramedViscaStream {
+    stream: TcpStream,
+    pending: Vec<u8>,
+}
+
+impl FramedViscaStream {
+    fn connect(address: &str) -> io::Result<Self> {
+        let stream = TcpStream::connect(address)?;
+        stream.set_read_timeout(Some(Duration::from_secs(2)))?;
+        stream.set_write_timeout(Some(Duration::from_secs(2)))?;
+
+        Ok(Self {
+            stream,
+            pending: Vec::new(),
+        })
+    }
+
+    fn send(&mut self, frame: &[u8]) -> io::Result<()> {
+        self.stream.write_all(frame)
+    }
+
+    fn recv_frame(&mut self) -> io::Result<Vec<u8>> {
+        loop {
+            if let Some(end) = self
+                .pending
+                .iter()
+                .position(|byte| *byte == VISCA_TERMINATOR)
+            {
+                return Ok(self.pending.drain(..=end).collect());
+            }
+
+            if self.pending.len() >= MAX_FRAME_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "VISCA response exceeded the lab tool's frame limit",
+                ));
+            }
+
+            let mut chunk = [0_u8; 256];
+            let read = self.stream.read(&mut chunk)?;
+            if read == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "camera closed the connection before a complete VISCA frame",
+                ));
+            }
+
+            self.pending.extend_from_slice(&chunk[..read]);
+            if self.pending.len() > MAX_FRAME_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "VISCA response exceeded the lab tool's frame limit",
+                ));
+            }
+        }
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|byte| format!("{byte:02X}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn visca_error_name(code: u8) -> &'static str {
+    match code {
+        0x02 => "Syntax Error",
+        0x03 => "Command Buffer Full",
+        0x04 => "Command Cancelled",
+        0x05 => "No Socket",
+        0x41 => "Command Not Executable",
+        _ => "Unknown",
+    }
+}
+
+fn report_response(response: &[u8], expected: &str) {
+    print!("Response: {}", hex(response));
+
+    if response.last() != Some(&VISCA_TERMINATOR) {
+        println!(" [MALFORMED: missing terminator]");
+        return;
+    }
+    if response.len() < 3 {
+        println!(" [MALFORMED: response is too short]");
+        return;
+    }
+    if response[0] != 0x90 {
+        println!(" [MALFORMED: unexpected source 0x{:02X}]", response[0]);
+        return;
+    }
+
+    if response[1] == 0x50 {
+        let payload = &response[2..response.len() - 1];
+        if payload.is_empty() {
+            println!(" [MALFORMED: empty data reply]");
+        } else {
+            println!(" [DATA REPLY - SUPPORTED]");
+            println!("{:35} Expected: {expected}", "");
+        }
+    } else if response[1] & 0xF0 == 0x60 {
+        let payload = &response[2..response.len() - 1];
+        match payload {
+            [code] => println!(" [ERROR 0x{code:02X}] {}", visca_error_name(*code)),
+            _ => println!(" [MALFORMED: VISCA error must contain one error code]"),
+        }
+    } else if response[1] & 0xF0 == 0x40 {
+        println!(" [ACK - unexpected for inquiry]");
+    } else if response[1] & 0xF0 == 0x50 {
+        println!(" [COMPLETION - unexpected for inquiry]");
+    } else {
+        println!(" [MALFORMED: unknown response class]");
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
     println!("=== VISCA Inquiry Validation ===\n");
-    println!("Connecting to camera at {CAMERA_IP}...");
-
-    let mut stream = match TcpStream::connect(CAMERA_IP) {
-        Ok(s) => {
-            println!("Connected!\n");
-            s
-        }
-        Err(e) => {
-            eprintln!("Failed to connect: {e}");
-            return;
-        }
-    };
-
-    stream
-        .set_read_timeout(Some(Duration::from_secs(2)))
-        .unwrap();
-    stream
-        .set_write_timeout(Some(Duration::from_secs(2)))
-        .unwrap();
+    println!("Lab target: {CAMERA_IP}");
+    println!("Each inquiry uses a fresh TCP connection so an incomplete response cannot desynchronize later probes.\n");
 
     // Test inquiries - format: (name, bytes, expected_response_description)
     let inquiries = [
@@ -59,7 +168,7 @@ fn main() {
             vec![0x81, 0x09, 0x04, 0x39, 0xFF],
             "mode byte",
         ),
-        // Phase 1 inquiries - NEED VALIDATION
+        // Candidate imaging inquiries requiring bench validation.
         (
             "Sharpness Position (0x42)",
             vec![0x81, 0x09, 0x04, 0x42, 0xFF],
@@ -75,7 +184,7 @@ fn main() {
             vec![0x81, 0x09, 0x04, 0x58, 0xFF],
             "UNKNOWN - mode?",
         ),
-        // Phase 2 inquiries - NEED VALIDATION
+        // Additional candidate inquiries requiring bench validation.
         (
             "Auto Slow Shutter (0x5A)",
             vec![0x81, 0x09, 0x04, 0x5A, 0xFF],
@@ -94,62 +203,27 @@ fn main() {
     for (name, bytes, expected) in inquiries {
         print!("{name:<35} ");
 
+        // A fresh connection makes a timeout or malformed response local to
+        // this probe instead of allowing a late frame to be mistaken for the
+        // response to the next inquiry.
+        let mut stream = FramedViscaStream::connect(CAMERA_IP)?;
+
         // Send inquiry
-        if let Err(e) = stream.write_all(&bytes) {
+        if let Err(e) = stream.send(&bytes) {
             println!("SEND ERROR: {e}");
             continue;
         }
 
-        // Small delay to let camera respond
-        std::thread::sleep(Duration::from_millis(100));
-
-        // Read response
-        let mut buf = [0u8; 64];
-        match stream.read(&mut buf) {
-            Ok(0) => {
-                println!("NO RESPONSE (connection closed)");
-            }
-            Ok(n) => {
-                let response = &buf[..n];
-                print!("Response: ");
-                for b in response {
-                    print!("{:02X} ", b);
-                }
-
-                // Interpret response
-                if n >= 2 {
-                    if response[0] == 0x90 && response[1] == 0x50 {
-                        print!(" [DATA REPLY - SUPPORTED]");
-                    } else if response[0] == 0x90 && response[1] == 0x60 {
-                        let error_code = if n > 2 { response[2] } else { 0 };
-                        print!(" [ERROR 0x{:02X}]", error_code);
-                        match error_code {
-                            0x02 => print!(" Syntax Error"),
-                            0x03 => print!(" Command Buffer Full"),
-                            0x04 => print!(" Command Cancelled"),
-                            0x05 => print!(" No Socket"),
-                            0x41 => print!(" Command Not Executable"),
-                            _ => print!(" Unknown"),
-                        }
-                    } else if response[0] == 0x90 && (response[1] & 0xF0) == 0x40 {
-                        print!(" [ACK - unexpected for inquiry]");
-                    }
-                }
-                println!();
-
-                // Show expected format
-                if response[0] == 0x90 && response[1] == 0x50 {
-                    println!("{:35} Expected: {expected}", "");
-                }
-            }
+        match stream.recv_frame() {
+            Ok(response) => report_response(&response, expected),
             Err(e)
                 if e.kind() == std::io::ErrorKind::WouldBlock
                     || e.kind() == std::io::ErrorKind::TimedOut =>
             {
-                println!("TIMEOUT (no response within 2s)");
+                println!("INCONCLUSIVE (no complete response within 2s)");
             }
             Err(e) => {
-                println!("READ ERROR: {e}");
+                println!("INCONCLUSIVE (read error: {e})");
             }
         }
 
@@ -163,5 +237,9 @@ fn main() {
     println!("\nLegend:");
     println!("  [DATA REPLY - SUPPORTED] = Camera responded with data (inquiry works)");
     println!("  [ERROR 0xNN] = Camera rejected the command");
-    println!("  TIMEOUT = Camera didn't respond (inquiry likely not supported)");
+    println!(
+        "  INCONCLUSIVE = No complete response; transport, timing, or support may be the cause"
+    );
+
+    Ok(())
 }

--- a/grafton-visca-macros/README.md
+++ b/grafton-visca-macros/README.md
@@ -2,18 +2,19 @@
 
 [![Crates.io](https://img.shields.io/crates/v/grafton-visca-macros.svg)](https://crates.io/crates/grafton-visca-macros)
 [![Documentation](https://docs.rs/grafton-visca-macros/badge.svg)](https://docs.rs/grafton-visca-macros)
-[![License](https://img.shields.io/crates/l/grafton-visca-macros.svg)](../LICENSE-MIT)
+[![License](https://img.shields.io/crates/l/grafton-visca-macros.svg)](https://github.com/GrantSparks/grafton-visca#license)
 
 Procedural macros for the grafton-visca crate, providing derive macros to eliminate boilerplate in VISCA protocol implementations.
 
 ## Overview
 
-This crate provides four macros that work together to create type-safe, efficient VISCA protocol implementations:
+This crate provides three downstream derive macros for type-safe VISCA protocol
+implementations and one attribute macro used internally by the main crate:
 
 - **`ViscaInquiry`** - Generate inquiry command implementations with parser support
 - **`ViscaEnum`** - Automatic enum/u8 conversions for protocol values
 - **`ViscaValue`** - Value wrapper types with VISCA encoding
-- **`delegate_to_session`** - Auto-generate CameraSession forwarding implementations
+- **`delegate_to_session`** - Internal main-crate maintenance macro that generates `CameraSession` forwarding implementations
 
 ## ViscaInquiry
 
@@ -135,7 +136,11 @@ The macro generates methods for:
 
 ## delegate_to_session
 
-Attribute macro for auto-generating CameraSession forwarding implementations.
+This attribute macro is an implementation tool for the matching
+`grafton-visca` source tree. It auto-generates `CameraSession` forwarding
+implementations for the main crate's control traits. It is public only because
+procedural macros cannot be scoped crate-private; downstream applications should
+not build APIs around it.
 
 ### Usage
 
@@ -146,8 +151,8 @@ use grafton_visca_macros::delegate_to_session;
 pub trait ZoomControl {
     type Mode: Mode;
 
-    fn zoom_stop(&self) -> <Self::Mode as Mode>::Ret<'_, Result<(), Error>>;
-    fn zoom_tele_std(&self) -> <Self::Mode as Mode>::Ret<'_, Result<(), Error>>;
+    fn zoom_stop(&self) -> <Self::Mode as Mode>::Fut<'_, Result<(), Error>>;
+    fn zoom_tele_std(&self) -> <Self::Mode as Mode>::Fut<'_, Result<(), Error>>;
     // ... more methods
 }
 ```
@@ -156,11 +161,11 @@ The macro generates forwarding implementations that delegate from `CameraSession
 
 ## Integration with grafton-visca
 
-These macros are re-exported by the main grafton-visca crate:
+The supported downstream derive macros are re-exported by the main
+`grafton-visca` crate:
 
 ```rust
 use grafton_visca::{ViscaInquiry, ViscaEnum, ViscaValue};
-use grafton_visca::camera::delegate_to_session;
 ```
 
 ## Benefits
@@ -215,7 +220,7 @@ impl ZoomPosition {
 
 ## Requirements
 
-- Rust 1.80 or later
+- Rust 1.88 or later
 - The `response` attribute in `ViscaInquiry` must reference existing `InquiryKind` variants, or `Raw` for a raw custom inquiry whose `ResponseParser` is implemented manually
 - Downstream `ViscaInquiry` derives use the standard five-byte VISCA inquiry form
 - Enums using `ViscaEnum` must have explicit discriminant values
@@ -223,14 +228,23 @@ impl ZoomPosition {
 
 ## Version Compatibility
 
-This crate follows the same versioning as the main `grafton-visca` crate. Always use matching versions:
+This crate follows the same versioning as the main `grafton-visca` crate. Most
+users need only the derives re-exported by the main crate. Direct macro-crate
+users must use matching versions:
 
 ```toml
 [dependencies]
-grafton-visca = "1"
-grafton-visca-macros = "1"
+grafton-visca = "=1.1.0"
+grafton-visca-macros = "=1.1.0"
 ```
+
+During a release, this macro crate is published and indexed before the
+same-version main crate. See the repository's `RELEASING.md` for the guarded
+two-crate sequence.
 
 ## License
 
-Licensed under MIT OR Apache-2.0 dual license. See the LICENSE-MIT and LICENSE-APACHE files in the repository root.
+Licensed under MIT OR Apache-2.0 dual license. See
+[LICENSE-MIT](https://github.com/GrantSparks/grafton-visca/blob/main/LICENSE-MIT)
+and
+[LICENSE-APACHE](https://github.com/GrantSparks/grafton-visca/blob/main/LICENSE-APACHE).

--- a/grafton-visca-macros/src/lib.rs
+++ b/grafton-visca-macros/src/lib.rs
@@ -9,7 +9,6 @@
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
-#![doc(html_root_url = "https://docs.rs/grafton-visca/0.5.0")]
 
 use syn::{parse_macro_input, DeriveInput};
 
@@ -190,11 +189,11 @@ pub fn derive_visca_enum(input: TokenStream) -> TokenStream {
     TokenStream::from(visca_enum::derive_visca_enum_impl(input))
 }
 
-/// Attribute macro for auto-generating CameraSession forwarding implementations
+/// Internal attribute macro for generating `CameraSession` forwarding implementations.
 ///
-/// This macro eliminates boilerplate by automatically generating forwarding
-/// implementations of control traits for `CameraSession`, which simply delegate
-/// to the inner `Camera` instance with proper error handling.
+/// This macro is public only because procedural macros cannot be scoped
+/// crate-private. It is an implementation tool for the matching main
+/// `grafton-visca` crate, not a stable downstream extension API.
 ///
 /// # Usage
 ///
@@ -207,8 +206,8 @@ pub fn derive_visca_enum(input: TokenStream) -> TokenStream {
 /// pub trait ZoomControl {
 ///     type Mode: Mode;
 ///
-///     fn zoom_stop(&self) -> <Self::Mode as Mode>::Ret<'_, Result<(), Error>>;
-///     fn zoom_tele_std(&self) -> <Self::Mode as Mode>::Ret<'_, Result<(), Error>>;
+///     fn zoom_stop(&self) -> <Self::Mode as Mode>::Fut<'_, Result<(), Error>>;
+///     fn zoom_tele_std(&self) -> <Self::Mode as Mode>::Fut<'_, Result<(), Error>>;
 ///     // ... more methods
 /// }
 /// ```
@@ -221,20 +220,18 @@ pub fn derive_visca_enum(input: TokenStream) -> TokenStream {
 ///    - Forwards calls from `CameraSession<M, P, Tr, Exec>` to the inner camera
 ///    - Preserves the generic Mode type `M`
 ///
-/// 2. **Blocking variant** (when `feature != "async"`):
+/// 2. **Blocking variant** (when `feature != "mode-async"`):
 ///    - Forwards calls from `CameraSession<Blocking, P, Tr, ()>` to the inner camera
 ///    - Uses the concrete `Blocking` mode type
 ///
-/// Each forwarding method:
-/// - Guards access with `.as_ref().expect("Cannot access camera after session is closed")`
-/// - Adds `#[inline]` for optimization
-/// - Adds `#[allow(clippy::expect_used)]` to suppress lints
-/// - Preserves all original method attributes and documentation
+/// Each forwarding method uses the open session's `camera()`/`camera_mut()`
+/// accessor, adds `#[inline]`, and preserves the original method attributes and
+/// documentation.
 ///
 /// # Requirements
 ///
 /// - The trait must have a `type Mode: Mode` associated type
-/// - Methods should use `<Self::Mode as Mode>::Ret<'_, T>` for return types
+/// - Methods should use `<Self::Mode as Mode>::Fut<'_, T>` for return types
 /// - The trait should be implemented for `Camera` (the actual logic)
 ///
 /// # Benefits

--- a/src/camera/builder.rs
+++ b/src/camera/builder.rs
@@ -30,7 +30,8 @@
 //! // Use accessor-style API
 //! camera.power().on().await?;
 //! camera.zoom().tele().await?;
-//! camera.await_idle().await?;
+//! camera.await_idle(std::time::Duration::from_secs(10)).await?;
+//! camera.shutdown().await?;
 //!
 //! // Advanced BYO-transport path.
 //! let runtime = TokioRuntime::from_current()?;
@@ -223,8 +224,8 @@ where
 {
     /// Create a new camera builder with the specified executor.
     ///
-    /// This is the primary way to create async cameras, ensuring
-    /// that the executor is configured upfront.
+    /// This is the advanced caller-owned transport path. Prefer `Connect` or
+    /// `CameraConfig` for the crate's standard transports.
     pub fn with_executor(executor: impl Into<Arc<E>>) -> Self {
         Self {
             camera_id: CameraId::default(),

--- a/src/camera/camera_impl.rs
+++ b/src/camera/camera_impl.rs
@@ -763,11 +763,13 @@ where
         })
     }
 
-    /// Send a command and return immediately with ID and response future.
+    /// Submit a command and return its ID and response future after queue acceptance.
     ///
     /// This method allows for mid-flight cancellation by returning the command ID
-    /// immediately along with a future that can be awaited separately. This is useful
-    /// for scenarios where you need to cancel a command while it's still in progress.
+    /// with a future that can be awaited separately. This is useful for scenarios
+    /// where you need to cancel a command while it is still in progress. Awaiting
+    /// this method includes runtime queue acceptance; it does not guarantee that
+    /// the transport send has already occurred.
     ///
     /// # Errors
     ///
@@ -818,7 +820,7 @@ where
         // Eager preparation: encode before async operations
         let prepared_command = Arc::new(EncodedCommand::new(command, camera_id)?);
 
-        // Return the ID and future directly without awaiting
+        // Await scheduler acceptance, then return the ID and response future.
         let (id, fut) = self
             .runtime
             .send_command_with_id_prepared(prepared_command, camera_id, None)
@@ -834,11 +836,15 @@ where
     /// bound to that exact command's response, without awaiting completion. Drive
     /// it with `await_applied` / `await_settled`, or `cancel` / `detach` it.
     ///
-    /// Built-in commands derive targeted-vs-continuous semantics and affected
+    /// Built-in commands derive targeted-versus-applied-only semantics and affected
     /// axes from the command itself. Custom commands without operation metadata
     /// retain the additive 1.1 fallback of targeted motion across all axes. Use
     /// [`submit_continuous`](Self::submit_continuous) to explicitly classify a
-    /// custom continuous drive or stop.
+    /// custom applied-only command.
+    ///
+    /// `submit` manages command lifecycle; it does not add profile capability or
+    /// range validation beyond the command's own encoding checks. Prefer typed
+    /// noun controls when converting ergonomic, profile-sensitive inputs.
     ///
     /// # Errors
     /// Returns an error if the command cannot be submitted (for example, an
@@ -860,12 +866,13 @@ where
         self.submit_op::<(), C>(command, metadata).await
     }
 
-    /// Submit a continuous drive or stop command and return an async handle.
+    /// Submit a custom applied-only command and return an async handle.
     ///
     /// Like [`submit`](Self::submit) but the handle is marked
-    /// [continuous](crate::camera::OpKind::Continuous): `await_settled` returns
+    /// [applied-only](crate::camera::OpKind::Continuous): `await_settled` returns
     /// [`Error::NotSupported`] because there is no
-    /// well-defined physical-settle event for a continuous drive or a stop.
+    /// well-defined physical-settle event. Built-in commands already provide
+    /// exact metadata and should normally use [`submit`](Self::submit).
     ///
     /// # Errors
     /// Returns an error if the command cannot be submitted.
@@ -1030,14 +1037,19 @@ where
     /// decide when to block for completion (`await_applied` / `await_settled`),
     /// to `cancel`, or to `detach`.
     ///
-    /// Built-in commands derive targeted-vs-continuous semantics and affected
+    /// Built-in commands derive targeted-versus-applied-only semantics and affected
     /// axes from the command itself. Custom commands without operation metadata
     /// retain the additive 1.1 fallback of targeted motion across all axes. Use
     /// [`submit_continuous`](Self::submit_continuous) to explicitly classify a
-    /// custom continuous drive or stop.
+    /// custom applied-only command.
+    ///
+    /// `submit` manages command lifecycle; it does not add profile capability or
+    /// range validation beyond the command's own encoding checks. Prefer typed
+    /// noun controls when converting ergonomic, profile-sensitive inputs.
     ///
     /// # Errors
-    /// Returns an error if the command cannot be encoded or the runner is busy.
+    /// Returns an error if the command is an inquiry, cannot be encoded or
+    /// initially dispatched, or the runner is busy.
     pub fn submit<C>(
         &self,
         command: &C,
@@ -1059,12 +1071,13 @@ where
         ))
     }
 
-    /// Submit a continuous drive or stop command and return a blocking handle.
+    /// Submit a custom applied-only command and return a blocking handle.
     ///
     /// Like [`submit`](Self::submit) but the handle is marked
-    /// [continuous](crate::camera::OpKind::Continuous): `await_settled` returns
+    /// [applied-only](crate::camera::OpKind::Continuous): `await_settled` returns
     /// [`Error::NotSupported`] because there is no
-    /// well-defined physical-settle event for a continuous drive or a stop.
+    /// well-defined physical-settle event. Built-in commands already provide
+    /// exact metadata and should normally use [`submit`](Self::submit).
     ///
     /// # Errors
     /// Returns an error if the command cannot be encoded or the runner is busy.

--- a/src/camera/camera_impl.rs
+++ b/src/camera/camera_impl.rs
@@ -834,9 +834,11 @@ where
     /// bound to that exact command's response, without awaiting completion. Drive
     /// it with `await_applied` / `await_settled`, or `cancel` / `detach` it.
     ///
-    /// The handle is treated as a [targeted](crate::camera::OpKind::Targeted)
-    /// operation; use [`submit_continuous`](Self::submit_continuous) for a
-    /// continuous drive or a stop.
+    /// Built-in commands derive targeted-vs-continuous semantics and affected
+    /// axes from the command itself. Custom commands without operation metadata
+    /// retain the additive 1.1 fallback of targeted motion across all axes. Use
+    /// [`submit_continuous`](Self::submit_continuous) to explicitly classify a
+    /// custom continuous drive or stop.
     ///
     /// # Errors
     /// Returns an error if the command cannot be submitted (for example, an
@@ -850,8 +852,12 @@ where
         Tr: AsyncTransport + Send + Sync,
         Exec: Executor + Send + Sync + Clone,
     {
-        self.submit_op::<(), C>(command, crate::camera::OpKind::Targeted)
-            .await
+        let metadata = command.operation_metadata().unwrap_or_else(|| {
+            // Compatibility for custom commands accepted by the additive 1.1
+            // submit surface. Built-in operations always provide exact metadata.
+            crate::camera::OperationMetadata::targeted(crate::camera::Axes::ALL)
+        });
+        self.submit_op::<(), C>(command, metadata).await
     }
 
     /// Submit a continuous drive or stop command and return an async handle.
@@ -872,19 +878,25 @@ where
         Tr: AsyncTransport + Send + Sync,
         Exec: Executor + Send + Sync + Clone,
     {
-        self.submit_op::<(), C>(command, crate::camera::OpKind::Continuous)
-            .await
+        let axes = command
+            .operation_metadata()
+            .map_or(crate::camera::Axes::NONE, |metadata| metadata.axes);
+        self.submit_op::<(), C>(
+            command,
+            crate::camera::OperationMetadata::applied_only(axes),
+        )
+        .await
     }
 
     /// Shared submission primitive: enqueue a command and build a typed handle.
     ///
-    /// This is the single implementation underlying [`submit`](Self::submit), the
-    /// noun-scoped `submit_*` helpers, and the (deprecated) `_op` methods, so none
-    /// of them duplicate the enqueue-and-wrap logic.
+    /// This is the single implementation underlying [`submit`](Self::submit)
+    /// and the (deprecated) `_op` methods, so they do not duplicate the
+    /// enqueue-and-wrap logic.
     pub(crate) async fn submit_op<Cat, C>(
         &self,
         command: &C,
-        kind: crate::camera::OpKind,
+        metadata: crate::camera::OperationMetadata,
     ) -> Result<crate::camera::InFlight<'_, Cat, P, Exec>, Error>
     where
         C: ViscaCommand,
@@ -897,7 +909,8 @@ where
             self.camera_id(),
             self.runtime(),
             response_future,
-            kind,
+            metadata,
+            self,
         ))
     }
 
@@ -1010,16 +1023,18 @@ where
 
     /// Submit a movement/actuation command and return a genuine blocking handle.
     ///
-    /// This is the blocking half of the mode-honest `submit` primitive: it queues
-    /// the command with the runner (allocating its id) but performs **no**
-    /// transport I/O. Use the returned [`BlockingInFlight`](crate::camera::BlockingInFlight)
-    /// to decide when to block for completion (`await_applied` / `await_settled`),
+    /// This is the blocking half of the mode-honest `submit` primitive: it
+    /// allocates an id, enqueues the command, and performs its initial transport
+    /// send before returning. It does **not** receive-pump an ACK or completion.
+    /// Use the returned [`BlockingInFlight`](crate::camera::BlockingInFlight) to
+    /// decide when to block for completion (`await_applied` / `await_settled`),
     /// to `cancel`, or to `detach`.
     ///
-    /// The handle is treated as a [targeted](crate::camera::OpKind::Targeted)
-    /// operation whose settle is observed across all axes; use
-    /// [`submit_continuous`](Self::submit_continuous) for a continuous drive or a
-    /// stop.
+    /// Built-in commands derive targeted-vs-continuous semantics and affected
+    /// axes from the command itself. Custom commands without operation metadata
+    /// retain the additive 1.1 fallback of targeted motion across all axes. Use
+    /// [`submit_continuous`](Self::submit_continuous) to explicitly classify a
+    /// custom continuous drive or stop.
     ///
     /// # Errors
     /// Returns an error if the command cannot be encoded or the runner is busy.
@@ -1030,12 +1045,17 @@ where
     where
         C: ViscaCommand,
     {
+        let metadata = command.operation_metadata().unwrap_or_else(|| {
+            // Compatibility for custom commands accepted by the additive 1.1
+            // submit surface. Built-in operations always provide exact metadata.
+            crate::camera::OperationMetadata::targeted(crate::camera::Axes::ALL)
+        });
         let id = self.submit_command(command)?;
         Ok(crate::camera::BlockingInFlight::new(
             id,
             self,
-            crate::camera::OpKind::Targeted,
-            crate::camera::Axes::ALL,
+            metadata.kind,
+            metadata.axes,
         ))
     }
 
@@ -1055,28 +1075,35 @@ where
     where
         C: ViscaCommand,
     {
+        let axes = command
+            .operation_metadata()
+            .map_or(crate::camera::Axes::NONE, |metadata| metadata.axes);
         let id = self.submit_command(command)?;
         Ok(crate::camera::BlockingInFlight::new(
             id,
             self,
             crate::camera::OpKind::Continuous,
-            crate::camera::Axes::NONE,
+            axes,
         ))
     }
 
-    /// Queue a command with the blocking runner without pumping I/O.
+    /// Submit and initially dispatch a command without pumping receive I/O.
     ///
-    /// Crate-internal primitive shared by [`submit`](Self::submit) and the
-    /// noun-scoped blocking `submit_*` helpers.
+    /// Crate-internal primitive shared by [`submit`](Self::submit) and ordinary
+    /// built-in operation methods.
     pub(crate) fn submit_command<C>(&self, command: &C) -> Result<crate::camera::CommandId, Error>
     where
         C: ViscaCommand,
     {
+        let transport_cell = self.transport();
+        let mut transport = transport_cell
+            .try_borrow_mut()
+            .map_err(|_| Error::TransportBusy)?;
         let mut runner = self
             .blocking_runner
             .try_borrow_mut()
             .map_err(|_| Error::TransportBusy)?;
-        runner.start_command(command, self.camera_id)
+        runner.start_command(&mut *transport, command, self.camera_id)
     }
 
     /// Drive a specific queued command to its protocol completion, synchronously.
@@ -1104,12 +1131,26 @@ where
     ///
     /// Crate-internal; backs [`BlockingInFlight::cancel`](crate::camera::BlockingInFlight::cancel).
     pub(crate) fn cancel_command_id(&self, id: crate::camera::CommandId) -> Result<(), Error> {
+        let transport_cell = self.transport();
+        let mut transport = transport_cell
+            .try_borrow_mut()
+            .map_err(|_| Error::TransportBusy)?;
         let mut runner = self
             .blocking_runner
             .try_borrow_mut()
             .map_err(|_| Error::TransportBusy)?;
-        runner.cancel(id);
-        Ok(())
+        runner.cancel_with_transport(&mut *transport, id)
+    }
+
+    /// Stop retaining the completion outcome for a blocking command without
+    /// cancelling the command itself.
+    ///
+    /// Used by `BlockingInFlight` drop/detach so a command may continue to run
+    /// while the runner avoids storing an outcome that can no longer be observed.
+    pub(crate) fn detach_command_id(&self, id: crate::camera::CommandId) {
+        if let Ok(mut runner) = self.blocking_runner.try_borrow_mut() {
+            runner.detach(id);
+        }
     }
 
     /// Send a typed command and return the response.

--- a/src/camera/controls/focus.rs
+++ b/src/camera/controls/focus.rs
@@ -254,7 +254,7 @@ where
     Ok(position)
 }
 
-fn focus_position_command<P, T>(position: T) -> Result<Focus, Error>
+pub(crate) fn focus_position_command<P, T>(position: T) -> Result<Focus, Error>
 where
     P: crate::capabilities::Focus + Default,
     T: TryInto<FocusPosition>,
@@ -302,7 +302,7 @@ where
                 Err(e) => return self.error(e),
             }
         };
-        self.execute(cmd)
+        self.execute_operation(cmd)
     }
 
     fn focus_far(&self, speed: SpeedLevel) -> M::Fut<'_, Result<(), Error>> {
@@ -315,11 +315,11 @@ where
                 Err(e) => return self.error(e),
             }
         };
-        self.execute(cmd)
+        self.execute_operation(cmd)
     }
 
     fn focus_stop(&self) -> M::Fut<'_, Result<(), Error>> {
-        self.execute(Focus::Stop)
+        self.execute_operation(Focus::Stop)
     }
 
     fn set_focus<T>(&self, position: T) -> M::Fut<'_, Result<(), Error>>
@@ -328,13 +328,13 @@ where
         T::Error: Into<Error>,
     {
         match focus_position_command::<P, T>(position) {
-            Ok(command) => self.execute(command),
+            Ok(command) => self.execute_operation(command),
             Err(e) => self.error(e),
         }
     }
 
     fn focus_infinity(&self) -> M::Fut<'_, Result<(), Error>> {
-        self.execute(Focus::Infinity)
+        self.execute_operation(Focus::Infinity)
     }
 
     fn set_focus_near_limit<T>(&self, position: T) -> M::Fut<'_, Result<(), Error>>
@@ -436,11 +436,11 @@ where
     ///
     /// // Using percentage
     /// let handle = camera.set_focus_op(Percentage(50.0)).await?;
-    /// handle.await_completion(Duration::from_secs(5)).await?;
+    /// handle.await_applied(Duration::from_secs(5)).await?;
     ///
     /// // Using normalized value
     /// let handle = camera.set_focus_op(UnitInterval::new(0.5)?).await?;
-    /// handle.await_completion(Duration::from_secs(5)).await?;
+    /// handle.await_applied(Duration::from_secs(5)).await?;
     /// ```
     ///
     /// # Errors
@@ -450,7 +450,7 @@ where
     /// - The command fails to send
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
     )]
     pub async fn set_focus_op<T>(
         &self,
@@ -462,7 +462,10 @@ where
     {
         let cmd = focus_position_command::<P, T>(position)?;
 
-        self.submit_op::<crate::camera::FocusOperation, _>(&cmd, crate::camera::OpKind::Targeted)
+        let metadata = crate::command::ViscaCommand::operation_metadata(&cmd).ok_or_else(|| {
+            Error::InvalidState("built-in focus operation is missing metadata".into())
+        })?;
+        self.submit_op::<crate::camera::FocusOperation, _>(&cmd, metadata)
             .await
     }
 }

--- a/src/camera/controls/focus.rs
+++ b/src/camera/controls/focus.rs
@@ -412,7 +412,7 @@ where
     }
 }
 
-// Separate implementation for async-mode _op methods on async Camera
+// Profile-aware 1.x compatibility shims for the concrete async Camera.
 #[cfg(feature = "mode-async")]
 impl<P, Tr, Exec> crate::camera::Camera<crate::mode::Async, P, Tr, Exec>
 where
@@ -422,26 +422,13 @@ where
 {
     /// Set focus to a specific position and return an operation handle.
     ///
-    /// This method accepts any type that can be converted to `FocusPosition`, providing
-    /// a flexible API for setting focus using different units. Returns an `InFlight`
-    /// handle for fine-grained control over timeouts and cancellation.
+    /// This method accepts any type that can be converted to `FocusPosition` and
+    /// applies profile-aware range validation before submission. It remains the
+    /// ergonomic handle-producing conversion path throughout 1.x. If an
+    /// equivalent command has already been profile-validated, prefer `submit`.
     ///
     /// # Arguments
     /// * `position` - Target focus position (accepts multiple types via `TryInto<FocusPosition>`)
-    ///
-    /// # Examples
-    /// ```ignore
-    /// use grafton_visca::units::{Percentage, UnitInterval};
-    /// use std::time::Duration;
-    ///
-    /// // Using percentage
-    /// let handle = camera.set_focus_op(Percentage(50.0)).await?;
-    /// handle.await_applied(Duration::from_secs(5)).await?;
-    ///
-    /// // Using normalized value
-    /// let handle = camera.set_focus_op(UnitInterval::new(0.5)?).await?;
-    /// handle.await_applied(Duration::from_secs(5)).await?;
-    /// ```
     ///
     /// # Errors
     /// Returns an error if:
@@ -450,7 +437,7 @@ where
     /// - The command fails to send
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "profile-aware 1.x compatibility shim; prefer `submit(cmd)` only when the equivalent command is already profile-validated; this method is removed in the 2.0 operation redesign"
     )]
     pub async fn set_focus_op<T>(
         &self,

--- a/src/camera/controls/pan_tilt.rs
+++ b/src/camera/controls/pan_tilt.rs
@@ -251,7 +251,7 @@ where
     Ok(())
 }
 
-fn pan_tilt_absolute_command<P>(
+pub(crate) fn pan_tilt_absolute_command<P>(
     pan: impl Into<Degrees>,
     tilt: impl Into<Degrees>,
     speed: SpeedLevel,
@@ -270,7 +270,7 @@ where
     })
 }
 
-fn pan_tilt_relative_command<P>(
+pub(crate) fn pan_tilt_relative_command<P>(
     pan: impl Into<Degrees>,
     tilt: impl Into<Degrees>,
     speed: SpeedLevel,
@@ -305,11 +305,11 @@ where
             pan_speed: PanSpeed::from(SpeedLevel::Medium),
             tilt_speed: TiltSpeed::from(SpeedLevel::Medium),
         };
-        self.execute(cmd)
+        self.execute_operation(cmd)
     }
 
     fn pan_tilt_home(&self) -> M::Fut<'_, Result<(), Error>> {
-        self.execute(PanTiltCommand::Home)
+        self.execute_operation(PanTiltCommand::Home)
     }
 
     fn pan_tilt_absolute(
@@ -319,7 +319,7 @@ where
         speed: SpeedLevel,
     ) -> M::Fut<'_, Result<(), Error>> {
         match pan_tilt_absolute_command::<P>(pan, tilt, speed) {
-            Ok(command) => self.execute(command),
+            Ok(command) => self.execute_operation(command),
             Err(e) => self.error(e),
         }
     }
@@ -331,7 +331,7 @@ where
         speed: SpeedLevel,
     ) -> M::Fut<'_, Result<(), Error>> {
         match pan_tilt_relative_command::<P>(pan, tilt, speed) {
-            Ok(command) => self.execute(command),
+            Ok(command) => self.execute_operation(command),
             Err(e) => self.error(e),
         }
     }
@@ -351,11 +351,11 @@ where
             pan_speed,
             tilt_speed,
         };
-        self.execute(cmd)
+        self.execute_operation(cmd)
     }
 
     fn pan_tilt_reset(&self) -> M::Fut<'_, Result<(), Error>> {
-        self.execute(PanTiltCommand::Reset)
+        self.execute_operation(PanTiltCommand::Reset)
     }
 
     fn pan_tilt_limit_set(
@@ -405,17 +405,18 @@ where
         &self,
         command: PanTiltCommand,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::PanTiltOperation, P, Exec>, Error> {
-        self.submit_op::<crate::camera::PanTiltOperation, _>(
-            &command,
-            crate::camera::OpKind::Targeted,
-        )
-        .await
+        let metadata =
+            crate::command::ViscaCommand::operation_metadata(&command).ok_or_else(|| {
+                Error::InvalidState("built-in pan/tilt operation is missing metadata".into())
+            })?;
+        self.submit_op::<crate::camera::PanTiltOperation, _>(&command, metadata)
+            .await
     }
 
     /// Move to an absolute pan/tilt position and return an operation handle.
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
     )]
     pub async fn pan_tilt_absolute_op(
         &self,
@@ -430,7 +431,7 @@ where
     /// Move relative to the current position and return an operation handle.
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
     )]
     pub async fn pan_tilt_relative_op(
         &self,
@@ -454,14 +455,14 @@ where
     /// use std::time::Duration;
     ///
     /// let handle = camera.pan_tilt_home_op().await?;
-    /// handle.await_completion(Duration::from_secs(30)).await?;
+    /// handle.await_applied(Duration::from_secs(30)).await?;
     /// ```
     ///
     /// # Errors
     /// Returns an error if the command fails to send.
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
     )]
     pub async fn pan_tilt_home_op(
         &self,
@@ -481,14 +482,14 @@ where
     /// use std::time::Duration;
     ///
     /// let handle = camera.pan_tilt_reset_op().await?;
-    /// handle.await_completion(Duration::from_secs(30)).await?;
+    /// handle.await_applied(Duration::from_secs(30)).await?;
     /// ```
     ///
     /// # Errors
     /// Returns an error if the command fails to send.
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
     )]
     pub async fn pan_tilt_reset_op(
         &self,

--- a/src/camera/controls/pan_tilt.rs
+++ b/src/camera/controls/pan_tilt.rs
@@ -393,7 +393,7 @@ where
     }
 }
 
-// Separate implementation for async-mode _op methods on async Camera
+// Profile-aware 1.x compatibility shims for the concrete async Camera.
 #[cfg(feature = "mode-async")]
 impl<P, Tr, Exec> crate::camera::Camera<crate::mode::Async, P, Tr, Exec>
 where
@@ -416,7 +416,7 @@ where
     /// Move to an absolute pan/tilt position and return an operation handle.
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "1.x compatibility shim; if you already have an equivalent profile-validated command, prefer `submit(cmd)`; this method is removed in the 2.0 operation redesign"
     )]
     pub async fn pan_tilt_absolute_op(
         &self,
@@ -431,7 +431,7 @@ where
     /// Move relative to the current position and return an operation handle.
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "1.x compatibility shim; if you already have an equivalent profile-validated command, prefer `submit(cmd)`; this method is removed in the 2.0 operation redesign"
     )]
     pub async fn pan_tilt_relative_op(
         &self,
@@ -445,24 +445,26 @@ where
 
     /// Move to the home position and return an operation handle.
     ///
-    /// This is the `_op` variant that returns an InFlight handle for fine-grained
-    /// control over timeouts and cancellation. The movement speed is determined
-    /// by the camera's default settings.
+    /// This 1.x compatibility shim preserves the original category marker. New
+    /// code can submit the directly constructible `PanTilt::Home` command and
+    /// choose applied or settled completion explicitly.
     ///
     /// # Example
     ///
     /// ```ignore
     /// use std::time::Duration;
     ///
-    /// let handle = camera.pan_tilt_home_op().await?;
-    /// handle.await_applied(Duration::from_secs(30)).await?;
+    /// use grafton_visca::command::PanTilt;
+    ///
+    /// let handle = camera.submit(&PanTilt::Home).await?;
+    /// handle.await_settled(Duration::from_secs(30)).await?;
     /// ```
     ///
     /// # Errors
     /// Returns an error if the command fails to send.
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "use `submit(&PanTilt::Home)` and drive the returned handle with `await_applied` / `await_settled`; this shim is removed in the 2.0 operation redesign"
     )]
     pub async fn pan_tilt_home_op(
         &self,
@@ -472,24 +474,26 @@ where
 
     /// Reset pan/tilt mechanism and return an operation handle.
     ///
-    /// This is the `_op` variant that returns an InFlight handle for fine-grained
-    /// control over timeouts and cancellation. This recalibrates the pan/tilt motors
-    /// and may take several seconds to complete.
+    /// This 1.x compatibility shim preserves the original category marker. New
+    /// code can submit the directly constructible `PanTilt::Reset` command. Reset
+    /// recalibrates the pan/tilt motors and may take several seconds to settle.
     ///
     /// # Example
     ///
     /// ```ignore
     /// use std::time::Duration;
     ///
-    /// let handle = camera.pan_tilt_reset_op().await?;
-    /// handle.await_applied(Duration::from_secs(30)).await?;
+    /// use grafton_visca::command::PanTilt;
+    ///
+    /// let handle = camera.submit(&PanTilt::Reset).await?;
+    /// handle.await_settled(Duration::from_secs(30)).await?;
     /// ```
     ///
     /// # Errors
     /// Returns an error if the command fails to send.
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "use `submit(&PanTilt::Reset)` and drive the returned handle with `await_applied` / `await_settled`; this shim is removed in the 2.0 operation redesign"
     )]
     pub async fn pan_tilt_reset_op(
         &self,

--- a/src/camera/controls/presets.rs
+++ b/src/camera/controls/presets.rs
@@ -210,7 +210,7 @@ where
     }
 }
 
-// Separate implementation for async-mode _op methods on async Camera
+// Profile-aware 1.x compatibility shim for the concrete async Camera.
 #[cfg(feature = "mode-async")]
 impl<P, Tr, Exec> crate::camera::Camera<crate::mode::Async, P, Tr, Exec>
 where
@@ -219,9 +219,13 @@ where
     Exec: crate::executor::Executor + Send + Sync + Clone + 'static,
 {
     /// Recall a preset position and return an operation handle.
+    ///
+    /// This remains the profile-validating handle-producing preset path
+    /// throughout 1.x; there is no public profile-aware preset command builder
+    /// to pass to `submit`. Its replacement is part of the 2.0 operation redesign.
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "profile-aware 1.x compatibility shim retained until the 2.0 operation redesign; there is no equivalent public preset command builder in 1.x"
     )]
     pub async fn preset_recall_op(
         &self,

--- a/src/camera/controls/presets.rs
+++ b/src/camera/controls/presets.rs
@@ -155,7 +155,7 @@ fn validate_preset<P: Presets>(preset: PresetNumber) -> Result<(), Error> {
     Ok(())
 }
 
-fn preset_command<P: Presets>(
+pub(crate) fn preset_command<P: Presets>(
     action: PresetAction,
     preset: PresetNumber,
 ) -> Result<PresetCommand, Error> {
@@ -178,7 +178,7 @@ where
 
     fn preset_recall(&self, preset: PresetNumber) -> M::Fut<'_, Result<(), Error>> {
         match preset_command::<P>(PresetAction::Recall, preset) {
-            Ok(command) => self.execute(command),
+            Ok(command) => self.execute_operation(command),
             Err(e) => self.error(e),
         }
     }
@@ -221,7 +221,7 @@ where
     /// Recall a preset position and return an operation handle.
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
     )]
     pub async fn preset_recall_op(
         &self,
@@ -229,7 +229,10 @@ where
     ) -> Result<crate::camera::InFlight<'_, crate::camera::PresetOperation, P, Exec>, Error> {
         let cmd = preset_command::<P>(PresetAction::Recall, preset)?;
 
-        self.submit_op::<crate::camera::PresetOperation, _>(&cmd, crate::camera::OpKind::Targeted)
+        let metadata = crate::command::ViscaCommand::operation_metadata(&cmd).ok_or_else(|| {
+            Error::InvalidState("built-in preset operation is missing metadata".into())
+        })?;
+        self.submit_op::<crate::camera::PresetOperation, _>(&cmd, metadata)
             .await
     }
 }

--- a/src/camera/controls/zoom.rs
+++ b/src/camera/controls/zoom.rs
@@ -368,7 +368,7 @@ where
     }
 }
 
-// Separate implementation for async-mode _op methods on async Camera
+// Profile-aware 1.x compatibility shims for the concrete async Camera.
 #[cfg(feature = "mode-async")]
 impl<P, Tr, Exec> crate::camera::Camera<crate::mode::Async, P, Tr, Exec>
 where
@@ -402,7 +402,7 @@ where
     /// Set zoom to a raw VISCA position and return an operation handle.
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "profile-aware 1.x compatibility shim; prefer `submit(cmd)` only when the equivalent command is already profile-validated; this method is removed in the 2.0 operation redesign"
     )]
     pub async fn set_zoom_op(
         &self,
@@ -415,7 +415,7 @@ where
     /// Set zoom to a normalized optical position and return an operation handle.
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "profile-aware 1.x compatibility shim; prefer `submit(cmd)` only when the equivalent command is already profile-validated; this method is removed in the 2.0 operation redesign"
     )]
     pub async fn set_zoom_normalized_op(
         &self,
@@ -440,7 +440,7 @@ where
     /// Set zoom to a normalized position in a documented domain and return an operation handle.
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "profile-aware 1.x compatibility shim; prefer `submit(cmd)` only when the equivalent command is already profile-validated; this method is removed in the 2.0 operation redesign"
     )]
     pub async fn set_zoom_normalized_in_domain_op(
         &self,

--- a/src/camera/controls/zoom.rs
+++ b/src/camera/controls/zoom.rs
@@ -202,7 +202,7 @@ where
     }
 }
 
-fn zoom_tele_command<P>(speed: Option<ZoomSpeed>) -> Result<ZoomCommand, Error>
+pub(crate) fn zoom_tele_command<P>(speed: Option<ZoomSpeed>) -> Result<ZoomCommand, Error>
 where
     P: crate::capabilities::zoom::Zoom,
 {
@@ -215,7 +215,7 @@ where
     }
 }
 
-fn zoom_wide_command<P>(speed: Option<ZoomSpeed>) -> Result<ZoomCommand, Error>
+pub(crate) fn zoom_wide_command<P>(speed: Option<ZoomSpeed>) -> Result<ZoomCommand, Error>
 where
     P: crate::capabilities::zoom::Zoom,
 {
@@ -280,19 +280,19 @@ where
     type Mode = M;
 
     fn zoom_stop(&self) -> M::Fut<'_, Result<(), Error>> {
-        self.execute(ZoomCommand::Stop)
+        self.execute_operation(ZoomCommand::Stop)
     }
 
     fn zoom_tele(&self, speed: Option<ZoomSpeed>) -> M::Fut<'_, Result<(), Error>> {
         match zoom_tele_command::<P>(speed) {
-            Ok(command) => self.execute(command),
+            Ok(command) => self.execute_operation(command),
             Err(err) => self.error(err),
         }
     }
 
     fn zoom_wide(&self, speed: Option<ZoomSpeed>) -> M::Fut<'_, Result<(), Error>> {
         match zoom_wide_command::<P>(speed) {
-            Ok(command) => self.execute(command),
+            Ok(command) => self.execute_operation(command),
             Err(err) => self.error(err),
         }
     }
@@ -313,14 +313,14 @@ where
 
     fn set_zoom(&self, position: ZoomPosition) -> M::Fut<'_, Result<(), Error>> {
         match zoom_position_command::<P>(position) {
-            Ok(command) => self.execute(command),
+            Ok(command) => self.execute_operation(command),
             Err(e) => self.error(e),
         }
     }
 
     fn set_zoom_normalized(&self, position: UnitInterval) -> M::Fut<'_, Result<(), Error>> {
         match zoom_normalized_command::<P>(position) {
-            Ok(command) => self.execute(command),
+            Ok(command) => self.execute_operation(command),
             Err(e) => self.error(e),
         }
     }
@@ -362,7 +362,7 @@ where
         domain: ZoomDomain,
     ) -> M::Fut<'_, Result<(), Error>> {
         match zoom_normalized_in_domain_command::<P>(position, domain) {
-            Ok(command) => self.execute(command),
+            Ok(command) => self.execute_operation(command),
             Err(e) => self.error(e),
         }
     }
@@ -379,38 +379,13 @@ where
     pub(crate) async fn start_zoom_operation(
         &self,
         command: ZoomCommand,
-        kind: crate::camera::OpKind,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::ZoomOperation, P, Exec>, Error> {
-        self.submit_op::<crate::camera::ZoomOperation, _>(&command, kind)
+        let metadata =
+            crate::command::ViscaCommand::operation_metadata(&command).ok_or_else(|| {
+                Error::InvalidState("built-in zoom operation is missing metadata".into())
+            })?;
+        self.submit_op::<crate::camera::ZoomOperation, _>(&command, metadata)
             .await
-    }
-
-    /// Start zooming in and return an operation handle.
-    #[cfg(feature = "dyn-api")]
-    pub(crate) async fn zoom_tele_op(
-        &self,
-        speed: Option<ZoomSpeed>,
-    ) -> Result<crate::camera::InFlight<'_, crate::camera::ZoomOperation, P, Exec>, Error> {
-        // Continuous drive: no well-defined settled state.
-        self.start_zoom_operation(
-            zoom_tele_command::<P>(speed)?,
-            crate::camera::OpKind::Continuous,
-        )
-        .await
-    }
-
-    /// Start zooming out and return an operation handle.
-    #[cfg(feature = "dyn-api")]
-    pub(crate) async fn zoom_wide_op(
-        &self,
-        speed: Option<ZoomSpeed>,
-    ) -> Result<crate::camera::InFlight<'_, crate::camera::ZoomOperation, P, Exec>, Error> {
-        // Continuous drive: no well-defined settled state.
-        self.start_zoom_operation(
-            zoom_wide_command::<P>(speed)?,
-            crate::camera::OpKind::Continuous,
-        )
-        .await
     }
 }
 
@@ -427,33 +402,27 @@ where
     /// Set zoom to a raw VISCA position and return an operation handle.
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
     )]
     pub async fn set_zoom_op(
         &self,
         position: ZoomPosition,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::ZoomOperation, P, Exec>, Error> {
-        self.start_zoom_operation(
-            zoom_position_command::<P>(position)?,
-            crate::camera::OpKind::Targeted,
-        )
-        .await
+        self.start_zoom_operation(zoom_position_command::<P>(position)?)
+            .await
     }
 
     /// Set zoom to a normalized optical position and return an operation handle.
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
     )]
     pub async fn set_zoom_normalized_op(
         &self,
         position: UnitInterval,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::ZoomOperation, P, Exec>, Error> {
-        self.start_zoom_operation(
-            zoom_normalized_command::<P>(position)?,
-            crate::camera::OpKind::Targeted,
-        )
-        .await
+        self.start_zoom_operation(zoom_normalized_command::<P>(position)?)
+            .await
     }
 }
 
@@ -471,18 +440,15 @@ where
     /// Set zoom to a normalized position in a documented domain and return an operation handle.
     #[deprecated(
         since = "1.1.0",
-        note = "use `submit(cmd)` (or the noun-scoped `submit_*` helper) and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
+        note = "use `submit(cmd)` and drive the returned handle with `await_applied` / `await_settled`; the `_op` methods are removed in 2.0"
     )]
     pub async fn set_zoom_normalized_in_domain_op(
         &self,
         position: UnitInterval,
         domain: ZoomDomain,
     ) -> Result<crate::camera::InFlight<'_, crate::camera::ZoomOperation, P, Exec>, Error> {
-        self.start_zoom_operation(
-            zoom_normalized_in_domain_command::<P>(position, domain)?,
-            crate::camera::OpKind::Targeted,
-        )
-        .await
+        self.start_zoom_operation(zoom_normalized_in_domain_command::<P>(position, domain)?)
+            .await
     }
 }
 

--- a/src/camera/inflight.rs
+++ b/src/camera/inflight.rs
@@ -1,7 +1,8 @@
-//! Typed operation handles for long-running camera commands.
+//! Operation handles for camera commands with explicit lifecycle control.
 //!
-//! This module provides `InFlight<C>` handles that are returned by long-running
-//! control methods (like pan/tilt, zoom, focus movements). These handles enable:
+//! [`Camera::submit`](crate::camera::Camera::submit) is the primary 1.x producer
+//! of async handles; blocking cameras expose the same submission vocabulary.
+//! These handles enable:
 //!
 //! - **Socket-safe cancellation**: Cancel commands by ID without needing to know
 //!   which socket they're using. The runtime handles socket resolution automatically.
@@ -11,10 +12,11 @@
 //!
 //! # Design
 //!
-//! The design uses zero-sized type (ZST) markers to preserve the command category
-//! in the type system while the handle stores the command's own response future.
-//! Cancellation stays ID-based, and completion waits are tied to the exact VISCA
-//! response channel returned when the command was submitted.
+//! The primary `submit` path uses `C = ()`. Zero-sized category markers remain
+//! for concrete `_op` compatibility shims and dyn erasure/telemetry. In 1.x,
+//! applied-versus-settled behavior comes from command-derived runtime metadata,
+//! not from the category marker. Cancellation stays ID-based, and completion
+//! waits are tied to the exact VISCA response channel returned at submission.
 //!
 //! # Example
 //!
@@ -71,13 +73,13 @@ use core::num::NonZeroU32;
 ///
 /// # Obtaining a CommandId
 ///
-/// `CommandId`s are returned by async camera methods such as `Camera::start_command_with_id`
-/// and `InFlight::id` (requires `mode-async` feature).
+/// IDs are exposed by `InFlight::id` and async `Camera::start_command_with_id`
+/// when `mode-async` is enabled, and by `BlockingInFlight::id` in blocking mode.
 ///
 /// # Cancellation
 ///
-/// Use the returned `CommandId` with `Camera::cancel` to cancel a running command
-/// (requires `mode-async` feature).
+/// Async callers may pass the ID to `Camera::cancel`. Both handle types also
+/// provide their mode-specific `cancel` operation.
 ///
 /// # Example
 ///
@@ -156,10 +158,10 @@ pub struct Preset;
 /// - [`OpKind::Targeted`] — a move that reaches a destination and physically
 ///   settles (absolute/relative/home/reset, set-position, preset recall).
 ///   `await_settled` is meaningful for these.
-/// - [`OpKind::Continuous`] — a continuous drive or an instantaneous stop, where
-///   "physical motion ended" is not a well-defined event (continuous `tele`/
-///   `wide` zoom, directional pan/tilt, or a `stop`). For these, `await_settled`
-///   returns [`Error::NotSupported`].
+/// - [`OpKind::Continuous`] — the 1.x name for any applied-only operation with no
+///   meaningful physical-settle state. This includes continuous drives, stops,
+///   instantaneous triggers, and configuration commands. For these,
+///   `await_settled` returns [`Error::NotSupported`].
 ///
 /// Throughout 1.x this distinction is runtime data on the handle. The planned
 /// 2.0 typed consuming-handle design can promote it into the type system so an
@@ -168,7 +170,7 @@ pub struct Preset;
 pub enum OpKind {
     /// A targeted move that reaches a destination and physically settles.
     Targeted,
-    /// A continuous drive or an instantaneous stop with no well-defined settle.
+    /// An applied-only operation with no well-defined physical-settle state.
     Continuous,
 }
 
@@ -224,7 +226,7 @@ pub(crate) trait AsyncSettleWaiter: Send + Sync {
 #[cfg(feature = "mode-async")]
 pub type ResponseFuture = Pin<Box<dyn Future<Output = Result<Response, Error>> + Send + 'static>>;
 
-/// A typed handle to an in-flight camera command.
+/// A handle to a submitted async camera command.
 ///
 /// This handle provides:
 /// - **Command ID access** for debugging and telemetry
@@ -238,11 +240,11 @@ pub type ResponseFuture = Pin<Box<dyn Future<Output = Result<Response, Error>> +
 /// # Type Parameters
 ///
 /// - `'a`: Lifetime of the camera/session reference
-/// - `C`: Category marker (PanTilt, Zoom, Focus, or Preset)
+/// - `C`: Compatibility category marker; primary `submit` handles use `()`
 /// - `P`: Camera profile type
 /// - `Exec`: Async executor type
 #[cfg(feature = "mode-async")]
-#[must_use = "this operation handle should be awaited, cancelled, or explicitly detached; dropping it detaches the already-dispatched command"]
+#[must_use = "this operation handle should be awaited, cancelled, or explicitly detached; dropping it leaves the submitted command scheduler-owned"]
 pub struct InFlight<'a, C, P, Exec>
 where
     P: Profile,
@@ -326,6 +328,12 @@ where
     ///
     /// # Errors
     ///
+    /// Queued commands may be removed without a protocol frame. Once a command
+    /// has a socket, the scheduler emits the socket-specific cancel request.
+    /// `Ok(())` means the request was recorded or sent; it is not camera
+    /// acknowledgement and does not prove physical motion stopped. This method
+    /// borrows the handle, so its exact response may still be awaited.
+    ///
     /// Returns an error if the cancellation request cannot be sent to the runtime.
     pub async fn cancel(&self) -> Result<()> {
         self.runtime.cancel(self.camera_id, self.id).await
@@ -338,6 +346,10 @@ where
     /// available on **every** handle, including continuous drives and stops — a
     /// deadman `STOP` uses exactly this. The `timeout` bounds how long to wait
     /// for the camera's response.
+    ///
+    /// The response wait is one-shot. Once this method starts—including when it
+    /// times out—the exact response future is consumed and another completion
+    /// wait returns [`Error::InvalidState`].
     ///
     /// # Returns
     ///
@@ -379,9 +391,10 @@ where
     /// Explicitly detach: give up the handle without awaiting or canceling.
     ///
     /// This is the intentional fire-and-forget escape hatch. The already-
-    /// dispatched command keeps running on the camera; only this handle's ability
-    /// to observe completion or cancel it is discarded. Semantically identical to
-    /// dropping the handle, but explicit (and it silences the `#[must_use]` lint).
+    /// submitted command remains scheduler-owned and may still be dispatched and
+    /// complete; only this handle's ability to observe completion or cancel it is
+    /// discarded. Semantically identical to dropping the handle, but explicit
+    /// (and it silences the `#[must_use]` lint).
     #[inline]
     pub fn detach(self) {
         // Nothing to do: dropping the handle performs no cancellation, matching
@@ -396,14 +409,17 @@ where
     /// settled signal, so this is equivalent to
     /// [`await_applied`](Self::await_applied). Profiles without that signal poll
     /// only the affected axes, using the remainder of the same timeout budget.
+    /// The response wait is one-shot once settling begins, including on timeout.
+    /// An early [`Error::NotSupported`] for an applied-only operation does not
+    /// consume that response wait, so `await_applied` remains available.
     ///
     /// [`SUPPORTS_OPERATION_COMPLETE`]: crate::capabilities::ProfileMetadata::SUPPORTS_OPERATION_COMPLETE
     ///
     /// # Errors
     ///
-    /// Returns [`Error::NotSupported`] if this handle represents a continuous
-    /// drive or a stop (there is no well-defined settled state); [`Error::Timeout`]
-    /// on deadline; other communication / camera errors otherwise.
+    /// Returns [`Error::NotSupported`] if this handle represents an applied-only
+    /// operation (there is no well-defined settled state); [`Error::Timeout`] on
+    /// deadline; other communication / camera errors otherwise.
     ///
     pub async fn await_settled(&self, timeout: Duration) -> Result<()> {
         if self.kind == OpKind::Continuous {
@@ -447,7 +463,7 @@ where
             .response_future
             .into_inner()
             .map_err(|_| Error::LockPoisoned("InFlight response_future"))?
-            .ok_or_else(|| Error::InvalidState("await_completion called more than once".into()))?;
+            .ok_or_else(|| Error::InvalidState("completion wait called more than once".into()))?;
 
         Ok((
             self.id,
@@ -494,7 +510,7 @@ where
 /// - [`await_settled`](Self::await_settled) resolves when physical motion has
 ///   ended — via the operation-complete message on profiles that support it,
 ///   otherwise via position polling. It is meaningful only for
-///   [`OpKind::Targeted`] handles; on a continuous/stop handle it returns
+///   [`OpKind::Targeted`] handles; on any applied-only handle it returns
 ///   [`Error::NotSupported`].
 ///
 /// # Safety / lifecycle
@@ -559,7 +575,7 @@ where
     ///
     /// This drives the blocking runner synchronously on the caller's thread until
     /// the command completes or `timeout` elapses. It is available on every
-    /// handle, including continuous drives and stops.
+    /// handle, including every applied-only operation.
     ///
     /// # Errors
     ///
@@ -579,10 +595,15 @@ where
     ///
     /// Before ACK, cancellation is deferred until the scheduler learns the
     /// command's socket. After ACK, the socket cancel is sent immediately.
+    /// `Ok(())` means the cancellation was recorded or sent; it is not camera
+    /// acknowledgement and does not prove physical motion stopped. Blocking
+    /// cancellation consumes the handle.
     ///
     /// # Errors
     ///
-    /// Returns [`Error::TransportBusy`] if the runner is concurrently borrowed.
+    /// Returns [`Error::TransportBusy`] if the runner is concurrently borrowed,
+    /// or a transport error if an immediately eligible cancel frame cannot be
+    /// sent.
     pub fn cancel(self) -> Result<()> {
         self.camera.cancel_command_id(self.id)
     }
@@ -630,8 +651,8 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`Error::NotSupported`] if this handle represents a continuous
-    /// drive or a stop (there is no well-defined settled state). Returns
+    /// Returns [`Error::NotSupported`] if this handle represents an applied-only
+    /// operation (there is no well-defined settled state). Returns
     /// [`Error::Timeout`] if motion does not settle within `timeout`, or a
     /// communication / camera error otherwise.
     pub fn await_settled(self, timeout: Duration) -> Result<()> {

--- a/src/camera/inflight.rs
+++ b/src/camera/inflight.rs
@@ -47,7 +47,7 @@
 use core::{future::Future, marker::PhantomData, pin::Pin, time::Duration};
 
 #[cfg(feature = "mode-async")]
-use std::sync::Mutex;
+use std::{panic::AssertUnwindSafe, sync::Mutex};
 
 #[cfg(feature = "mode-async")]
 use crate::{
@@ -264,8 +264,11 @@ where
     /// Axes affected by this operation, used for position-based settling.
     axes: crate::camera::Axes,
     /// Concrete-camera bridge for position polling on profiles without an
-    /// operation-complete message.
-    settle_waiter: &'a dyn AsyncSettleWaiter,
+    /// operation-complete message. The assertion is confined to this immutable
+    /// reference: callers cannot mutate or recover camera state through the
+    /// erased bridge, and the public handle carried both unwind auto traits in
+    /// 1.0 before fallback settling was added.
+    settle_waiter: AssertUnwindSafe<&'a dyn AsyncSettleWaiter>,
     /// Zero-sized marker for the category.
     _c: PhantomData<C>,
 }
@@ -308,7 +311,7 @@ where
             response_future: Mutex::new(Some(response_future)),
             kind: metadata.kind,
             axes: metadata.axes,
-            settle_waiter,
+            settle_waiter: AssertUnwindSafe(settle_waiter),
             _c: PhantomData,
         }
     }
@@ -446,6 +449,7 @@ where
         }
 
         self.settle_waiter
+            .0
             .await_axes_settled(self.axes, remaining)
             .await
     }

--- a/src/camera/inflight.rs
+++ b/src/camera/inflight.rs
@@ -19,20 +19,24 @@
 //! # Example
 //!
 //! ```ignore
-//! use grafton_visca::{camera::Connect, camera::profiles::PtzOpticsG2};
+//! use grafton_visca::{
+//!     camera::{Connect, profiles::PtzOpticsG2},
+//!     command::PanTilt,
+//! };
 //! use std::time::Duration;
 //!
 //! # async fn example() -> Result<(), grafton_visca::Error> {
 //! let camera = Connect::open_tcp_async::<PtzOpticsG2, _>("192.168.0.110", runtime).await?;
 //!
-//! // Start a pan/tilt operation and get a typed handle
-//! let handle = camera.pan_tilt().pan_tilt_absolute_op(45.0, 15.0, SpeedLevel::Fast).await?;
+//! // Submit a targeted pan/tilt operation and get a typed handle.
+//! let handle = camera.submit(&PanTilt::Home).await?;
 //!
-//! // Wait for the command's own completion response
-//! handle.await_completion(Duration::from_secs(5)).await?;
+//! // Wait for protocol completion and physical settling.
+//! handle.await_settled(Duration::from_secs(5)).await?;
 //!
-//! // Or cancel the operation
-//! handle.cancel().await?;
+//! // For an operation that should not continue, request socket-safe cancellation
+//! // instead of awaiting it.
+//! // handle.cancel().await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -157,15 +161,63 @@ pub struct Preset;
 ///   `wide` zoom, directional pan/tilt, or a `stop`). For these, `await_settled`
 ///   returns [`Error::NotSupported`].
 ///
-/// In Phase 1 this distinction is carried as runtime data on the handle. Phase 2
-/// promotes it into the marker type `C` so a wrong `await_settled` call becomes a
-/// compile error.
+/// Throughout 1.x this distinction is runtime data on the handle. The planned
+/// 2.0 typed consuming-handle design can promote it into the type system so an
+/// invalid `await_settled` call becomes a compile error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OpKind {
     /// A targeted move that reaches a destination and physically settles.
     Targeted,
     /// A continuous drive or an instantaneous stop with no well-defined settle.
     Continuous,
+}
+
+/// Runtime metadata describing how an actuation command completes.
+///
+/// Built-in movement commands provide this metadata through
+/// [`ViscaCommand::operation_metadata`](crate::command::ViscaCommand::operation_metadata),
+/// making command kind and affected axes a single source of truth shared by
+/// blocking, async, and dynamic operation handles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OperationMetadata {
+    /// Whether the command has a meaningful physical settled state.
+    pub kind: OpKind,
+    /// Physical axes affected by the command.
+    pub axes: crate::camera::Axes,
+}
+
+impl OperationMetadata {
+    /// Metadata for a targeted operation that eventually settles.
+    #[must_use]
+    pub const fn targeted(axes: crate::camera::Axes) -> Self {
+        Self {
+            kind: OpKind::Targeted,
+            axes,
+        }
+    }
+
+    /// Metadata for a continuous drive, stop, or other applied-only operation.
+    #[must_use]
+    pub const fn applied_only(axes: crate::camera::Axes) -> Self {
+        Self {
+            kind: OpKind::Continuous,
+            axes,
+        }
+    }
+}
+
+/// Object-safe bridge used by async handles for position-based settle waits.
+///
+/// Keeping this private avoids adding the transport type to the public
+/// `InFlight` generic parameters while still routing fallback polling through
+/// the concrete camera that submitted the command.
+#[cfg(feature = "mode-async")]
+pub(crate) trait AsyncSettleWaiter: Send + Sync {
+    fn await_axes_settled(
+        &self,
+        axes: crate::camera::Axes,
+        timeout: Duration,
+    ) -> crate::mode::BoxFuture<'_, Result<()>>;
 }
 
 /// Type alias for boxed response futures returned by `start_command_with_id`.
@@ -190,7 +242,7 @@ pub type ResponseFuture = Pin<Box<dyn Future<Output = Result<Response, Error>> +
 /// - `P`: Camera profile type
 /// - `Exec`: Async executor type
 #[cfg(feature = "mode-async")]
-#[must_use = "an InFlight handle does nothing unless you await_applied/await_settled, cancel, or detach it (dropping it detaches: the already-dispatched command keeps running, it is not stopped)"]
+#[must_use = "this operation handle should be awaited, cancelled, or explicitly detached; dropping it detaches the already-dispatched command"]
 pub struct InFlight<'a, C, P, Exec>
 where
     P: Profile,
@@ -207,6 +259,11 @@ where
     response_future: Mutex<Option<ResponseFuture>>,
     /// Whether this operation has a well-defined settled state.
     kind: OpKind,
+    /// Axes affected by this operation, used for position-based settling.
+    axes: crate::camera::Axes,
+    /// Concrete-camera bridge for position polling on profiles without an
+    /// operation-complete message.
+    settle_waiter: &'a dyn AsyncSettleWaiter,
     /// Zero-sized marker for the category.
     _c: PhantomData<C>,
 }
@@ -217,6 +274,15 @@ where
     P: Profile + 'static,
     Exec: Executor + Send + Sync + 'static,
 {
+    fn take_response_future(&self) -> Result<ResponseFuture> {
+        self.response_future
+            .lock()
+            .ok()
+            .ok_or(Error::LockPoisoned("InFlight response_future"))?
+            .take()
+            .ok_or_else(|| Error::InvalidState("operation handle already awaited".into()))
+    }
+
     /// Create a new in-flight handle with the response future.
     ///
     /// The response future completes when the camera sends a VISCA completion
@@ -230,14 +296,17 @@ where
         camera_id: CameraId,
         runtime: &'a crate::runtime::RuntimeHandle<P, Exec>,
         response_future: ResponseFuture,
-        kind: OpKind,
+        metadata: OperationMetadata,
+        settle_waiter: &'a dyn AsyncSettleWaiter,
     ) -> Self {
         Self {
             id,
             camera_id,
             runtime,
             response_future: Mutex::new(Some(response_future)),
-            kind,
+            kind: metadata.kind,
+            axes: metadata.axes,
+            settle_waiter,
             _c: PhantomData,
         }
     }
@@ -284,17 +353,15 @@ where
     /// - The internal mutex is poisoned (`Error::LockPoisoned`)
     /// - Other communication or camera errors occur
     pub async fn await_applied(&self, timeout: Duration) -> Result<()> {
-        // Take the response future from the mutex (can only be awaited once)
-        let future = self
-            .response_future
-            .lock()
-            .ok()
-            .ok_or(Error::LockPoisoned("InFlight response_future"))?
-            .take()
-            .ok_or_else(|| Error::InvalidState("await_applied called more than once".into()))?;
+        let future = self.take_response_future()?;
 
         // Use the executor's timeout mechanism to enforce the deadline
         self.runtime.timeout(timeout, future).await?.map(|_| ())
+    }
+
+    /// Await the exact response using the scheduler-owned category deadline.
+    pub(crate) async fn await_applied_default(&self) -> Result<()> {
+        self.take_response_future()?.await.map(|_| ())
     }
 
     /// Deprecated alias for [`await_applied`](Self::await_applied).
@@ -327,7 +394,8 @@ where
     /// set-position, preset recall). On profiles that report
     /// [`SUPPORTS_OPERATION_COMPLETE`], the operation-complete message *is* the
     /// settled signal, so this is equivalent to
-    /// [`await_applied`](Self::await_applied).
+    /// [`await_applied`](Self::await_applied). Profiles without that signal poll
+    /// only the affected axes, using the remainder of the same timeout budget.
     ///
     /// [`SUPPORTS_OPERATION_COMPLETE`]: crate::capabilities::ProfileMetadata::SUPPORTS_OPERATION_COMPLETE
     ///
@@ -337,18 +405,33 @@ where
     /// drive or a stop (there is no well-defined settled state); [`Error::Timeout`]
     /// on deadline; other communication / camera errors otherwise.
     ///
-    /// # Phase 1 limitation
-    ///
-    /// On profiles **without** an operation-complete message this resolves when
-    /// the command is *applied*; for a strict position-based settle, follow up
-    /// with [`Camera::await_axes_idle`](crate::camera::Camera::await_axes_idle).
-    /// A handle-internal position poll (as already implemented for blocking mode)
-    /// is planned alongside the finer targeted/continuous markers.
     pub async fn await_settled(&self, timeout: Duration) -> Result<()> {
         if self.kind == OpKind::Continuous {
             return Err(Error::NotSupported);
         }
-        self.await_applied(timeout).await
+
+        // One caller-supplied budget covers both exact-command completion and
+        // any position-polling fallback.
+        let started = self.runtime.executor().now();
+        self.await_applied(timeout).await?;
+
+        if P::SUPPORTS_OPERATION_COMPLETE {
+            return Ok(());
+        }
+
+        let elapsed = self
+            .runtime
+            .executor()
+            .now()
+            .saturating_duration_since(started);
+        let remaining = timeout.saturating_sub(elapsed);
+        if remaining.is_zero() {
+            return Err(Error::Timeout);
+        }
+
+        self.settle_waiter
+            .await_axes_settled(self.axes, remaining)
+            .await
     }
 
     /// Consume this handle and return the parts needed for type-erased handling.
@@ -357,14 +440,24 @@ where
     /// command response future from the static API instead of approximating
     /// completion with category-level idle polling.
     #[cfg(feature = "dyn-api")]
-    pub(crate) fn into_parts(self) -> Result<(CommandId, CameraId, ResponseFuture)> {
+    pub(crate) fn into_parts(
+        self,
+    ) -> Result<(CommandId, CameraId, ResponseFuture, OperationMetadata)> {
         let response_future = self
             .response_future
             .into_inner()
             .map_err(|_| Error::LockPoisoned("InFlight response_future"))?
             .ok_or_else(|| Error::InvalidState("await_completion called more than once".into()))?;
 
-        Ok((self.id, self.camera_id, response_future))
+        Ok((
+            self.id,
+            self.camera_id,
+            response_future,
+            OperationMetadata {
+                kind: self.kind,
+                axes: self.axes,
+            },
+        ))
     }
 }
 
@@ -377,6 +470,8 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InFlight")
             .field("id", &self.id)
+            .field("kind", &self.kind)
+            .field("axes", &self.axes)
             .field("category", &std::any::type_name::<C>())
             .finish()
     }
@@ -385,8 +480,7 @@ where
 /// A genuine, synchronous handle to an in-flight blocking command.
 ///
 /// This is the blocking-mode counterpart to the async `InFlight` handle. It is
-/// returned by [`Camera::submit`](crate::camera::Camera::submit) (and the
-/// noun-scoped blocking `submit_*` helpers) and provides the same *mode-honest*
+/// returned by [`Camera::submit`](crate::camera::Camera::submit) and provides the same *mode-honest*
 /// surface as the async handle — `await_applied`, `await_settled`, `cancel`,
 /// `detach` — but every method runs **synchronously on the caller's thread**. No
 /// async executor is ever spun up: `await_applied` drives the blocking runner's
@@ -405,13 +499,14 @@ where
 ///
 /// # Safety / lifecycle
 ///
-/// The handle is `#[must_use]`: dropping it without `await_applied`,
-/// `await_settled`, `cancel`, or `detach` triggers a lint. **Dropping never
-/// stops the command** — drop is equivalent to [`detach`](Self::detach): the
-/// queued command is left to be flushed by the next blocking operation. Use
-/// [`cancel`](Self::cancel) to discard it instead.
+/// The handle is `#[must_use]`, so directly ignoring a produced handle triggers
+/// a lint. Rust's lint does not track a handle after it has been bound to a
+/// variable. **Dropping never stops the command** — drop is equivalent to
+/// [`detach`](Self::detach): the already-dispatched command continues running,
+/// but its terminal outcome is no longer retained. Use [`cancel`](Self::cancel)
+/// to request a protocol-aware socket cancel instead.
 #[cfg(not(feature = "mode-async"))]
-#[must_use = "a BlockingInFlight handle does nothing unless you await_applied/await_settled, cancel, or detach it (dropping leaves the command queued, it does not stop it)"]
+#[must_use = "this blocking operation handle should be awaited, cancelled, or explicitly detached; dropping it detaches the already-dispatched command"]
 pub struct BlockingInFlight<'a, C, P, Tr>
 where
     P: Profile + Default,
@@ -475,10 +570,15 @@ where
         self.camera.await_command_applied(self.id, Some(deadline))
     }
 
+    /// Await the exact response using the scheduler-owned category deadline.
+    pub(crate) fn await_applied_default(self) -> Result<()> {
+        self.camera.await_command_applied(self.id, None)
+    }
+
     /// Cancel this command via the runner.
     ///
-    /// If the command is still queued (nothing sent yet), it is discarded and its
-    /// completion resolves as canceled.
+    /// Before ACK, cancellation is deferred until the scheduler learns the
+    /// command's socket. After ACK, the socket cancel is sent immediately.
     ///
     /// # Errors
     ///
@@ -489,14 +589,26 @@ where
 
     /// Explicitly detach: give up the handle without waiting or canceling.
     ///
-    /// This is the intentional fire-and-forget escape hatch. The queued command
-    /// is left in place to be flushed by the next blocking operation; it is not
-    /// stopped. Semantically identical to dropping the handle, but explicit (and
-    /// silences the `#[must_use]` lint).
+    /// This is the intentional fire-and-forget escape hatch. The already-sent
+    /// command continues running and its terminal outcome is discarded. It is
+    /// not stopped. Semantically identical to dropping the handle, but explicit
+    /// (and it satisfies the `#[must_use]` lint).
     #[inline]
     pub fn detach(self) {
-        // Nothing to do: the command stays queued in the runner. Dropping `self`
-        // performs no cancellation, matching the documented drop == detach rule.
+        self.camera.detach_command_id(self.id);
+    }
+}
+
+#[cfg(not(feature = "mode-async"))]
+impl<C, P, Tr> Drop for BlockingInFlight<'_, C, P, Tr>
+where
+    P: Profile + Default,
+    Tr: crate::transport::BlockingTransport + crate::transport::HasTransportConfig + Send + 'static,
+{
+    fn drop(&mut self) {
+        // Drop is detach, never cancel: the command remains scheduler-owned, but
+        // no terminal outcome is retained after its last handle disappears.
+        self.camera.detach_command_id(self.id);
     }
 }
 

--- a/src/camera/mod.rs
+++ b/src/camera/mod.rs
@@ -1,6 +1,6 @@
 //! Camera-first, profile-centric VISCA API.
 //!
-//! The primary 1.0 construction path is [`crate::camera::Connect`] for simple TCP, UDP,
+//! The primary 1.x construction path is [`crate::camera::Connect`] for simple TCP, UDP,
 //! and serial sessions, or [`crate::camera::CameraConfig`] when standard transports need explicit
 //! configuration. Once connected, use noun accessors such as
 //! `camera.power().on()` and `camera.zoom().position()`.

--- a/src/camera/mod.rs
+++ b/src/camera/mod.rs
@@ -40,7 +40,7 @@ pub use accessors::*;
 #[cfg(not(feature = "mode-async"))]
 pub use inflight::BlockingInFlight;
 pub use inflight::{
-    CommandId, Focus as FocusOperation, OpKind, PanTilt as PanTiltOperation,
+    CommandId, Focus as FocusOperation, OpKind, OperationMetadata, PanTilt as PanTiltOperation,
     Preset as PresetOperation, Zoom as ZoomOperation,
 };
 #[cfg(feature = "mode-async")]
@@ -91,6 +91,14 @@ where
     fn execute<C>(&self, command: C) -> M::Fut<'_, Result<(), crate::Error>>
     where
         C: crate::command::ViscaCommand + Send + Sync + Clone + std::fmt::Debug + 'static;
+
+    /// Execute a movement/actuation command through the shared operation path.
+    fn execute_operation<C>(&self, command: C) -> M::Fut<'_, Result<(), crate::Error>>
+    where
+        C: crate::command::ViscaCommand + Send + Sync + Clone + std::fmt::Debug + 'static,
+    {
+        self.execute(command)
+    }
 
     /// Query with a typed command and parse the response.
     fn query<C>(
@@ -148,6 +156,23 @@ where
         use crate::mode::Mode;
         let future = self.send_command(&command);
         crate::mode::Async::from_future(async move { future.await?.into_result() })
+    }
+
+    fn execute_operation<C>(
+        &self,
+        command: C,
+    ) -> <crate::mode::Async as crate::mode::Mode>::Fut<'_, Result<(), crate::Error>>
+    where
+        C: crate::command::ViscaCommand + Send + Sync + Clone + std::fmt::Debug + 'static,
+    {
+        use crate::mode::Mode;
+        let metadata = command
+            .operation_metadata()
+            .unwrap_or_else(|| OperationMetadata::targeted(Axes::ALL));
+        crate::mode::Async::from_future(async move {
+            let handle = self.submit_op::<(), _>(&command, metadata).await?;
+            handle.await_applied_default().await
+        })
     }
 
     fn query<C>(
@@ -224,6 +249,19 @@ where
         let future = self.send_command(&command);
         let result = future.block();
         std::future::ready(result.and_then(|r| r.into_result()))
+    }
+
+    fn execute_operation<C>(
+        &self,
+        command: C,
+    ) -> <crate::mode::Blocking as crate::mode::Mode>::Fut<'_, Result<(), crate::Error>>
+    where
+        C: crate::command::ViscaCommand + Send + Sync + Clone + std::fmt::Debug + 'static,
+    {
+        let result = self
+            .submit(&command)
+            .and_then(|handle| handle.await_applied_default());
+        std::future::ready(result)
     }
 
     fn query<C>(

--- a/src/camera/movement.rs
+++ b/src/camera/movement.rs
@@ -1067,13 +1067,17 @@ where
 
         let start = self.runtime().executor().now();
 
-        while self
-            .runtime()
-            .executor()
-            .now()
-            .saturating_duration_since(start)
-            < config.timeout
-        {
+        loop {
+            let elapsed = self
+                .runtime()
+                .executor()
+                .now()
+                .saturating_duration_since(start);
+            let remaining = config.timeout.saturating_sub(elapsed);
+            if remaining.is_zero() {
+                return Err(Error::Timeout);
+            }
+
             match completion_rx.try_recv() {
                 Ok(event) => {
                     if event.camera_id != self.camera_id() {
@@ -1092,12 +1096,26 @@ where
                         }
 
                         // Small settling delay after completion message
-                        self.sleep(Duration::from_millis(50)).await;
+                        self.sleep(Duration::from_millis(50).min(remaining)).await;
+
+                        let elapsed = self
+                            .runtime()
+                            .executor()
+                            .now()
+                            .saturating_duration_since(start);
+                        let remaining = config.timeout.saturating_sub(elapsed);
+                        if remaining.is_zero() {
+                            return Err(Error::Timeout);
+                        }
 
                         // Verify the monitored axes are actually idle
                         let is_moving = self
-                            .is_moving_axes_async(config.axes, &config.tolerance)
-                            .await?;
+                            .runtime()
+                            .timeout(
+                                remaining,
+                                self.is_moving_axes_async(config.axes, &config.tolerance),
+                            )
+                            .await??;
                         if !is_moving {
                             if config.debug {
                                 tracing::debug!("Camera confirmed idle after completion event");
@@ -1112,13 +1130,11 @@ where
                 }
                 Err(flume::TryRecvError::Empty) => {
                     // No events available, sleep briefly before checking again
-                    self.sleep(Duration::from_millis(50)).await;
+                    self.sleep(Duration::from_millis(50).min(remaining)).await;
                 }
                 Err(flume::TryRecvError::Disconnected) => return Err(Error::NotSupported),
             }
         }
-
-        Err(Error::Timeout)
     }
 
     /// Polling-based movement detection using configurable poll interval.
@@ -1138,10 +1154,16 @@ where
                 return Err(Error::Timeout);
             }
 
-            match self
-                .is_moving_axes_async(config.axes, &config.tolerance)
-                .await
-            {
+            let remaining = config.timeout.saturating_sub(elapsed);
+            let moving_result = self
+                .runtime()
+                .timeout(
+                    remaining,
+                    self.is_moving_axes_async(config.axes, &config.tolerance),
+                )
+                .await?;
+
+            match moving_result {
                 Ok(false) => {
                     if config.debug {
                         tracing::debug!("Movement completed (all monitored axes idle)");
@@ -1159,6 +1181,11 @@ where
             }
 
             // Sleep between polls, capped by remaining timeout
+            let elapsed = self
+                .runtime()
+                .executor()
+                .now()
+                .saturating_duration_since(start);
             let remaining = config.timeout.saturating_sub(elapsed);
             let sleep_time = config.poll_interval.min(remaining);
             if sleep_time > Duration::ZERO {
@@ -1174,5 +1201,21 @@ where
     pub async fn await_axes_idle(&self, axes: Axes, timeout: Duration) -> Result<(), Error> {
         self.await_with_config(&AwaitConfig::new(timeout).with_axes(axes))
             .await
+    }
+}
+
+#[cfg(feature = "mode-async")]
+impl<P, T, E> crate::camera::inflight::AsyncSettleWaiter for Camera<crate::mode::Async, P, T, E>
+where
+    P: Profile + ProfileMetadata + Default,
+    T: AsyncTransport + Send + Sync + 'static,
+    E: Executor + Send + Sync + Clone + 'static,
+{
+    fn await_axes_settled(
+        &self,
+        axes: Axes,
+        timeout: Duration,
+    ) -> crate::mode::BoxFuture<'_, Result<(), Error>> {
+        Box::pin(self.await_axes_idle(axes, timeout))
     }
 }

--- a/src/camera/session.rs
+++ b/src/camera/session.rs
@@ -232,10 +232,57 @@ where
 #[cfg(feature = "mode-async")]
 impl<P, T, E> CameraSession<crate::mode::Async, P, T, E, Open>
 where
-    P: Profile + crate::capabilities::ProfileMetadata + Default,
+    P: Profile + Default,
     T: crate::transport::AsyncTransport + Send + Sync + 'static,
     E: Executor,
 {
+    /// Submit a command and retain its exact async operation handle.
+    ///
+    /// This forwards the primary 1.x operation API through the open session
+    /// returned by [`Connect`](crate::camera::Connect) and
+    /// [`CameraConfig`](crate::camera::CameraConfig). Built-in commands derive
+    /// targeted-versus-applied-only behavior from command metadata.
+    ///
+    /// `submit` manages lifecycle; it does not add profile capability or range
+    /// validation beyond the command's own checks. Prefer typed noun controls
+    /// when converting ergonomic, profile-sensitive input.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the command is an inquiry, cannot be encoded, or
+    /// cannot be accepted by the runtime scheduler.
+    pub async fn submit<C>(
+        &self,
+        command: &C,
+    ) -> Result<crate::camera::InFlight<'_, (), P, E>, Error>
+    where
+        C: ViscaCommand,
+        E: Send + Sync + Clone + 'static,
+    {
+        self.camera.submit(command).await
+    }
+
+    /// Submit a custom applied-only command and retain its async handle.
+    ///
+    /// Built-in commands already carry exact metadata and should normally use
+    /// [`submit`](Self::submit). Use this override for a custom command with no
+    /// meaningful physical-settle state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the command cannot be encoded or accepted by the
+    /// runtime scheduler.
+    pub async fn submit_continuous<C>(
+        &self,
+        command: &C,
+    ) -> Result<crate::camera::InFlight<'_, (), P, E>, Error>
+    where
+        C: ViscaCommand,
+        E: Send + Sync + Clone + 'static,
+    {
+        self.camera.submit_continuous(command).await
+    }
+
     /// Wait for all movements to complete.
     ///
     /// Convenience method that waits for all motors (pan/tilt, zoom, focus) to stop.

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -292,8 +292,10 @@ pub trait ViscaCommand: Send + Sync {
     ///
     /// Built-in actuation commands override this so every API surface derives
     /// targeted-vs-applied-only behavior and affected axes from the command
-    /// itself. Custom commands may opt in; `None` preserves the low-level 1.1
-    /// `submit` fallback for commands without metadata.
+    /// itself. Custom commands may override this 1.x compatibility hook; `None`
+    /// preserves the conservative targeted/all-axes `submit` fallback. The hook
+    /// is hidden because the metadata shape is part of the planned 2.0 operation
+    /// redesign rather than a long-term extension contract.
     #[doc(hidden)]
     #[inline]
     fn operation_metadata(&self) -> Option<crate::camera::OperationMetadata> {

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -287,6 +287,18 @@ pub trait ViscaCommand: Send + Sync {
     fn behavior(&self) -> CommandBehavior {
         CommandBehavior::Command
     }
+
+    /// Return movement-operation completion metadata for this command.
+    ///
+    /// Built-in actuation commands override this so every API surface derives
+    /// targeted-vs-applied-only behavior and affected axes from the command
+    /// itself. Custom commands may opt in; `None` preserves the low-level 1.1
+    /// `submit` fallback for commands without metadata.
+    #[doc(hidden)]
+    #[inline]
+    fn operation_metadata(&self) -> Option<crate::camera::OperationMetadata> {
+        None
+    }
 }
 
 /// Inline buffer size for encoded commands - 24 bytes covers most commands without heap allocation.

--- a/src/command/focus.rs
+++ b/src/command/focus.rs
@@ -112,6 +112,22 @@ impl ViscaCommand for Focus {
     const MAX_SIZE: usize = 9;
     const TIMEOUT_CATEGORY: CommandCategory = CommandCategory::Movement;
 
+    fn operation_metadata(&self) -> Option<crate::camera::OperationMetadata> {
+        use crate::camera::{Axes, OperationMetadata};
+
+        Some(match self {
+            Self::Position(_) | Self::Infinity => OperationMetadata::targeted(Axes::FOCUS),
+            Self::Stop
+            | Self::Far
+            | Self::Near
+            | Self::FarWithSpeed(_)
+            | Self::NearWithSpeed(_) => OperationMetadata::applied_only(Axes::FOCUS),
+            Self::Auto | Self::Manual | Self::OnePushTrigger | Self::Toggle | Self::Snap => {
+                OperationMetadata::applied_only(Axes::NONE)
+            }
+        })
+    }
+
     fn write_into(
         &self,
         camera_id: crate::camera_id::CameraId,

--- a/src/command/pan_tilt.rs
+++ b/src/command/pan_tilt.rs
@@ -312,6 +312,23 @@ impl ViscaCommand for PanTilt {
     const MAX_SIZE: usize = 15;
     const TIMEOUT_CATEGORY: CommandCategory = CommandCategory::Movement;
 
+    fn operation_metadata(&self) -> Option<crate::camera::OperationMetadata> {
+        use crate::camera::{Axes, OperationMetadata};
+
+        Some(match self {
+            Self::Home
+            | Self::Reset
+            | Self::AbsolutePosition { .. }
+            | Self::RelativePosition { .. }
+            | Self::AbsolutePositionRaw { .. }
+            | Self::RelativePositionRaw { .. } => OperationMetadata::targeted(Axes::PAN_TILT),
+            Self::Move { .. } => OperationMetadata::applied_only(Axes::PAN_TILT),
+            Self::LimitSet { .. } | Self::LimitSetRaw { .. } | Self::LimitClear { .. } => {
+                OperationMetadata::applied_only(Axes::NONE)
+            }
+        })
+    }
+
     fn write_into(
         &self,
         camera_id: crate::camera_id::CameraId,

--- a/src/command/preset.rs
+++ b/src/command/preset.rs
@@ -96,6 +96,15 @@ impl ViscaCommand for PresetCommand {
     const MAX_SIZE: usize = 7;
     const TIMEOUT_CATEGORY: CommandCategory = CommandCategory::Preset;
 
+    fn operation_metadata(&self) -> Option<crate::camera::OperationMetadata> {
+        use crate::camera::{Axes, OperationMetadata};
+
+        Some(match self.action {
+            PresetAction::Recall => OperationMetadata::targeted(Axes::ALL),
+            PresetAction::Reset | PresetAction::Set => OperationMetadata::applied_only(Axes::NONE),
+        })
+    }
+
     fn write_into(
         &self,
         camera_id: crate::camera_id::CameraId,

--- a/src/command/zoom.rs
+++ b/src/command/zoom.rs
@@ -63,6 +63,19 @@ impl ViscaCommand for Zoom {
     const MAX_SIZE: usize = 10;
     const TIMEOUT_CATEGORY: CommandCategory = CommandCategory::Movement;
 
+    fn operation_metadata(&self) -> Option<crate::camera::OperationMetadata> {
+        use crate::camera::{Axes, OperationMetadata};
+
+        Some(match self {
+            Self::Position(_) => OperationMetadata::targeted(Axes::ZOOM),
+            Self::Stop
+            | Self::TeleStd
+            | Self::WideStd
+            | Self::TeleVariable(_)
+            | Self::WideVariable(_) => OperationMetadata::applied_only(Axes::ZOOM),
+        })
+    }
+
     fn write_into(
         &self,
         camera_id: crate::camera_id::CameraId,

--- a/src/dynapi.rs
+++ b/src/dynapi.rs
@@ -58,8 +58,8 @@
 //!
 //! # Timeout Behavior
 //!
-//! Movement methods that accept an optional `timeout` parameter use it as a
-//! deadline for the command's own VISCA completion response:
+//! Result-returning movement methods that accept an optional `timeout` use it as
+//! a deadline for the command's own VISCA completion response:
 //!
 //! - **`None`**: Uses the camera's default `TimeoutConfig` for the command category.
 //!   This is the recommended option for most use cases.
@@ -68,9 +68,10 @@
 //!   The wait resolves when the camera reports completion or an error for the
 //!   command. It does not infer physical movement completion from idle polling.
 //!
-//! To wait for physical motion to settle, use
-//! [`DynMotionControl::await_idle`](crate::dynapi::DynMotionControl::await_idle)
-//! or the axis-specific idle wait methods after issuing the command.
+//! The dyn `_op` variants are the object-safe 1.x handle surface. Their
+//! `InFlightDyn` values provide exact `await_applied` and physical
+//! `await_settled` waits. Use `DynMotionControl::await_idle` for category-wide
+//! checks or motion for which no handle was retained.
 //!
 //! ```ignore
 //! use std::time::Duration;
@@ -80,6 +81,12 @@
 //!
 //! // Use explicit 30-second timeout for this operation
 //! pt.pan_tilt_home(Some(Duration::from_secs(30))).await?;
+//!
+//! // Retain a handle when physical settling matters
+//! pt.pan_tilt_home_op()
+//!     .await?
+//!     .await_settled(Duration::from_secs(30))
+//!     .await?;
 //! ```
 //!
 //! # Drop and Cancellation Semantics
@@ -145,7 +152,8 @@
 //! | Cancel specific command | `InFlightDyn::cancel()` |
 //! | Emergency stop all motion | `DynMotionControl::stop_all_motion()` |
 //! | Timeout on specific operation | Pass `timeout` parameter to method |
-//! | Wait for physical idle | `camera.motion().await_idle(timeout)` |
+//! | Wait for one targeted operation to settle | `handle.await_settled(timeout)` |
+//! | Wait for category-wide physical idle | `camera.motion().await_idle(timeout)` |
 //! | Graceful shutdown | `stop_all_motion()`, then drop camera |
 //!
 //! # Capability Detection
@@ -205,6 +213,8 @@
 //! - An additional command-completion `timeout: Option<Duration>` parameter for
 //!   movement methods where per-call deadlines are useful
 //! - Structured runtime capability discovery through `DynCameraControl::capabilities()`
+//! - `_op` methods as the non-deprecated, object-safe 1.x handle entry points;
+//!   concrete `Camera::*_op` compatibility shims are a separate deprecated surface
 //!
 //! # Available Traits
 //!
@@ -330,9 +340,10 @@ pub(crate) trait RuntimeDyn: Send + Sync {
 
 /// Type-erased operation handle for dyn-api.
 ///
-/// This handle provides the same functionality as `InFlight<C, T>` but without
-/// generic type parameters, making it object-safe and suitable for use with
-/// trait objects.
+/// This handle provides the same lifecycle vocabulary as static `InFlight`
+/// without generic type parameters, making it object-safe and suitable for use
+/// with trait objects. Its targeted-versus-applied-only behavior remains
+/// command-derived runtime metadata throughout 1.x.
 ///
 /// # Example
 ///
@@ -353,7 +364,7 @@ pub(crate) trait RuntimeDyn: Send + Sync {
 /// }
 /// ```
 #[cfg(feature = "dyn-api")]
-#[must_use = "this dynamic operation handle should be awaited, cancelled, or explicitly detached; dropping it detaches the already-dispatched command"]
+#[must_use = "this dynamic operation handle should be awaited, cancelled, or explicitly detached; dropping it leaves the submitted command scheduler-owned"]
 pub struct InFlightDyn {
     /// The command ID assigned by the runtime.
     id: CommandId,
@@ -420,6 +431,10 @@ impl InFlightDyn {
     ///
     /// The cancel message is addressed to the camera ID that was used when
     /// this command was originally sent, ensuring correct multi-camera behavior.
+    /// Queued commands may be removed without a frame; commands with an assigned
+    /// socket use the protocol cancel path. `Ok(())` means the request was
+    /// recorded or sent, not that the camera acknowledged it or physical motion
+    /// stopped. The handle remains available for its one-shot response wait.
     ///
     /// # Errors
     ///
@@ -430,7 +445,8 @@ impl InFlightDyn {
 
     /// Wait for this exact command to be accepted and protocol-completed.
     ///
-    /// This is a one-shot wait. A second wait through `await_applied`,
+    /// This is a one-shot wait. Once it starts—including when it times out—the
+    /// exact response future is consumed. A second wait through `await_applied`,
     /// `await_settled`, or [`await_completion`](Self::await_completion) returns
     /// [`Error::InvalidState`].
     pub fn await_applied(&self, timeout: Duration) -> BoxFuture<'_, Result<(), Error>> {
@@ -458,9 +474,10 @@ impl InFlightDyn {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::NotSupported`] for continuous drives and stops, without
-    /// consuming the handle's response wait. Returns [`Error::Timeout`] when the
-    /// combined completion and settling budget expires.
+    /// Returns [`Error::NotSupported`] for any applied-only operation, without
+    /// consuming the handle's response wait. Once a supported wait starts,
+    /// including when it times out, the response wait is consumed. Returns
+    /// [`Error::Timeout`] when the combined completion and settling budget expires.
     pub fn await_settled(&self, timeout: Duration) -> BoxFuture<'_, Result<(), Error>> {
         Box::pin(async move {
             if self.metadata.kind == crate::camera::OpKind::Continuous {
@@ -476,9 +493,9 @@ impl InFlightDyn {
 
     /// Wait for this operation's command response to complete.
     ///
-    /// This compatibility name retains the original 1.0 dyn API. New code should
+    /// This 1.x compatibility alias retains the original dyn API. New code should
     /// use [`await_applied`](Self::await_applied) to state the completion level
-    /// explicitly.
+    /// explicitly. The alias is planned for removal in 2.0.
     ///
     /// This uses the same response future as the static `InFlight` API. It
     /// resolves when the camera reports completion or an error for this command.
@@ -501,10 +518,11 @@ impl InFlightDyn {
         self.await_applied_named(timeout, "await_completion")
     }
 
-    /// Explicitly detach this already-dispatched command.
+    /// Explicitly detach this submitted command.
     ///
     /// Detaching discards this handle's ability to observe completion or request
-    /// cancellation. It never stops physical movement.
+    /// cancellation. The command remains scheduler-owned and may still be
+    /// dispatched and complete. Detach never stops physical movement.
     #[inline]
     pub fn detach(self) {
         // Drop is detach for async operation handles.
@@ -666,12 +684,13 @@ pub trait DynMotionControl: Send + Sync {
 
 /// Object-safe pan/tilt control trait.
 ///
-/// All movement methods accept an optional timeout parameter. When `None`,
+/// Result-returning movement methods accept an optional timeout parameter. When `None`,
 /// the default timeout from `TimeoutConfig` is used. When `Some(duration)`,
 /// that specific timeout is applied to the operation.
 ///
-/// The `_op` variants return an [`InFlightDyn`] handle for fine-grained control
-/// over timeouts and cancellation.
+/// The non-deprecated dyn `_op` variants are the object-safe 1.x handle surface.
+/// They return [`InFlightDyn`] for applied/settled waits, cancellation, and
+/// detach. This is distinct from the deprecated concrete-camera `_op` shims.
 pub trait DynPanTiltControl: Send + Sync {
     /// Stop all pan/tilt movement immediately.
     fn pan_tilt_stop(&self) -> BoxFuture<'_, Result<(), Error>>;
@@ -681,8 +700,8 @@ pub trait DynPanTiltControl: Send + Sync {
 
     /// Move to the home position and return an operation handle.
     ///
-    /// This is the `_op` variant that returns an [`InFlightDyn`] handle for
-    /// fine-grained control over timeouts and cancellation.
+    /// This object-safe 1.x handle variant returns [`InFlightDyn`] for exact
+    /// applied/settled waits, cancellation, and detach.
     ///
     /// # Example
     ///
@@ -777,8 +796,8 @@ pub trait DynPanTiltControl: Send + Sync {
 
 /// Object-safe zoom control trait.
 ///
-/// The `_op` variants return an [`InFlightDyn`] handle for fine-grained control
-/// over timeouts and cancellation.
+/// The non-deprecated dyn `_op` variants are the object-safe 1.x handle surface
+/// and return [`InFlightDyn`] for applied/settled waits, cancellation, and detach.
 pub trait DynZoomControl: Send + Sync {
     /// Stop any zoom operation currently in progress.
     fn zoom_stop(&self) -> BoxFuture<'_, Result<(), Error>>;
@@ -831,8 +850,8 @@ pub trait DynZoomControl: Send + Sync {
 
 /// Object-safe focus control trait.
 ///
-/// The `_op` variants return an [`InFlightDyn`] handle for fine-grained control
-/// over timeouts and cancellation.
+/// The non-deprecated dyn `_op` variants are the object-safe 1.x handle surface
+/// and return [`InFlightDyn`] for applied/settled waits, cancellation, and detach.
 pub trait DynFocusControl: Send + Sync {
     /// Set auto focus mode.
     fn focus_auto(&self) -> BoxFuture<'_, Result<(), Error>>;
@@ -883,8 +902,8 @@ pub trait DynFocusControl: Send + Sync {
 
 /// Object-safe preset control trait.
 ///
-/// The `_op` variants return an [`InFlightDyn`] handle for fine-grained control
-/// over timeouts and cancellation.
+/// The non-deprecated dyn `_op` variants are the object-safe 1.x handle surface
+/// and return [`InFlightDyn`] for applied/settled waits, cancellation, and detach.
 pub trait DynPresetsControl: Send + Sync {
     /// Recall a preset position.
     fn preset_recall(

--- a/src/dynapi.rs
+++ b/src/dynapi.rs
@@ -1,11 +1,5 @@
 //! Dynamic trait object API with per-operation timeout support.
 //!
-// The hand-written dyn facade still bridges to the static `_op` methods, which
-// are deprecated in favour of `submit` (issue #539, Phase 1). It is slated for
-// descriptor-driven code generation in a follow-up pass; until then, silence the
-// internal deprecation warnings its bridging calls would otherwise emit.
-#![allow(deprecated)]
-//!
 //! This module provides object-safe trait definitions for runtime polymorphism
 //! with cameras. Unlike the static `Camera<M, P, Tr, Exec>` type, these traits
 //! can be used with `dyn` dispatch, enabling heterogeneous collections of cameras
@@ -226,8 +220,10 @@ use std::{
     time::Duration,
 };
 
+mod movement_registry;
+
 use crate::{
-    camera::{CommandId, ResponseFuture},
+    camera::{CommandId, OperationMetadata, ResponseFuture},
     command::{
         focus::{AutoFocusSensitivity, FocusZone},
         pan_tilt::{PanTiltDirection, PanTiltLimitCorner},
@@ -242,7 +238,7 @@ use crate::{
 };
 
 // ============================================================================
-// Phase 2: Type-erased Operation Handles
+// Type-erased operation handles
 // ============================================================================
 
 /// Operation category for type-erased handles.
@@ -273,6 +269,37 @@ impl std::fmt::Display for OperationCategory {
     }
 }
 
+/// Maps the static typed operation marker to its stable dyn category.
+///
+/// Keeping this mapping on the marker removes the possibility of a dyn adapter
+/// pairing a correctly typed static handle with the wrong runtime category.
+trait DynOperationCategoryMarker {
+    const DYN_CATEGORY: OperationCategory;
+}
+
+#[derive(Clone, Copy)]
+enum DynOperationRequirement {
+    None,
+    Typed(crate::capabilities::TypedSupportSurface, &'static str),
+    ZoomDomain(ZoomDomain),
+}
+
+impl DynOperationCategoryMarker for crate::camera::PanTiltOperation {
+    const DYN_CATEGORY: OperationCategory = OperationCategory::PanTilt;
+}
+
+impl DynOperationCategoryMarker for crate::camera::ZoomOperation {
+    const DYN_CATEGORY: OperationCategory = OperationCategory::Zoom;
+}
+
+impl DynOperationCategoryMarker for crate::camera::FocusOperation {
+    const DYN_CATEGORY: OperationCategory = OperationCategory::Focus;
+}
+
+impl DynOperationCategoryMarker for crate::camera::PresetOperation {
+    const DYN_CATEGORY: OperationCategory = OperationCategory::Preset;
+}
+
 /// Internal trait for type-erased runtime operations.
 ///
 /// This trait enables `InFlightDyn` to perform cancellation and completion
@@ -289,6 +316,15 @@ pub(crate) trait RuntimeDyn: Send + Sync {
         &self,
         timeout: Duration,
         response_future: ResponseFuture,
+    ) -> BoxFuture<'_, Result<(), Error>>;
+
+    /// Wait for exact command completion and, when the profile needs it, use
+    /// the remaining budget to poll the operation's affected axes.
+    fn await_response_settled(
+        &self,
+        timeout: Duration,
+        response_future: ResponseFuture,
+        metadata: OperationMetadata,
     ) -> BoxFuture<'_, Result<(), Error>>;
 }
 
@@ -307,8 +343,8 @@ pub(crate) trait RuntimeDyn: Send + Sync {
 /// async fn move_and_wait(pt: &dyn DynPanTiltControl) -> Result<(), Error> {
 ///     let handle = pt.pan_tilt_home_op().await?;
 ///
-///     // Wait for the movement to complete
-///     handle.await_completion(Duration::from_secs(30)).await?;
+///     // Wait for physical movement to settle
+///     handle.await_settled(Duration::from_secs(30)).await?;
 ///
 ///     // Or cancel the operation
 ///     // handle.cancel().await?;
@@ -317,6 +353,7 @@ pub(crate) trait RuntimeDyn: Send + Sync {
 /// }
 /// ```
 #[cfg(feature = "dyn-api")]
+#[must_use = "this dynamic operation handle should be awaited, cancelled, or explicitly detached; dropping it detaches the already-dispatched command"]
 pub struct InFlightDyn {
     /// The command ID assigned by the runtime.
     id: CommandId,
@@ -324,6 +361,8 @@ pub struct InFlightDyn {
     camera_id: crate::CameraId,
     /// The operation category for this handle.
     category: OperationCategory,
+    /// Command-derived completion behavior and affected axes.
+    metadata: OperationMetadata,
     /// Reference to the runtime for cancellation and completion waiting.
     runtime: Arc<dyn RuntimeDyn>,
     /// Response future for the command this handle represents.
@@ -340,6 +379,7 @@ impl InFlightDyn {
         id: CommandId,
         camera_id: crate::CameraId,
         category: OperationCategory,
+        metadata: OperationMetadata,
         runtime: Arc<dyn RuntimeDyn>,
         response_future: ResponseFuture,
     ) -> Self {
@@ -347,9 +387,19 @@ impl InFlightDyn {
             id,
             camera_id,
             category,
+            metadata,
             runtime,
             response_future: Mutex::new(Some(response_future)),
         }
+    }
+
+    fn take_response_future(&self, method: &'static str) -> Result<ResponseFuture, Error> {
+        self.response_future
+            .lock()
+            .ok()
+            .ok_or(Error::LockPoisoned("InFlightDyn response_future"))?
+            .take()
+            .ok_or_else(|| Error::InvalidState(format!("{method} called more than once").into()))
     }
 
     /// Get the command ID assigned by the runtime.
@@ -378,7 +428,57 @@ impl InFlightDyn {
         self.runtime.cancel(self.camera_id, self.id)
     }
 
+    /// Wait for this exact command to be accepted and protocol-completed.
+    ///
+    /// This is a one-shot wait. A second wait through `await_applied`,
+    /// `await_settled`, or [`await_completion`](Self::await_completion) returns
+    /// [`Error::InvalidState`].
+    pub fn await_applied(&self, timeout: Duration) -> BoxFuture<'_, Result<(), Error>> {
+        self.await_applied_named(timeout, "await_applied")
+    }
+
+    fn await_applied_named(
+        &self,
+        timeout: Duration,
+        method: &'static str,
+    ) -> BoxFuture<'_, Result<(), Error>> {
+        Box::pin(async move {
+            let response_future = self.take_response_future(method)?;
+            self.runtime
+                .await_response_completion(timeout, response_future)
+                .await
+        })
+    }
+
+    /// Wait until a targeted movement has physically settled.
+    ///
+    /// On profiles with operation-complete responses this is the exact command
+    /// completion wait. Other profiles use position polling on the affected axes.
+    /// One timeout budget covers both phases.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotSupported`] for continuous drives and stops, without
+    /// consuming the handle's response wait. Returns [`Error::Timeout`] when the
+    /// combined completion and settling budget expires.
+    pub fn await_settled(&self, timeout: Duration) -> BoxFuture<'_, Result<(), Error>> {
+        Box::pin(async move {
+            if self.metadata.kind == crate::camera::OpKind::Continuous {
+                return Err(Error::NotSupported);
+            }
+
+            let response_future = self.take_response_future("await_settled")?;
+            self.runtime
+                .await_response_settled(timeout, response_future, self.metadata)
+                .await
+        })
+    }
+
     /// Wait for this operation's command response to complete.
+    ///
+    /// This compatibility name retains the original 1.0 dyn API. New code should
+    /// use [`await_applied`](Self::await_applied) to state the completion level
+    /// explicitly.
     ///
     /// This uses the same response future as the static `InFlight` API. It
     /// resolves when the camera reports completion or an error for this command.
@@ -398,21 +498,16 @@ impl InFlightDyn {
     ///
     /// Returns an error if the wait fails or times out.
     pub fn await_completion(&self, timeout: Duration) -> BoxFuture<'_, Result<(), Error>> {
-        Box::pin(async move {
-            let response_future = self
-                .response_future
-                .lock()
-                .ok()
-                .ok_or(Error::LockPoisoned("InFlightDyn response_future"))?
-                .take()
-                .ok_or_else(|| {
-                    Error::InvalidState("await_completion called more than once".into())
-                })?;
+        self.await_applied_named(timeout, "await_completion")
+    }
 
-            self.runtime
-                .await_response_completion(timeout, response_future)
-                .await
-        })
+    /// Explicitly detach this already-dispatched command.
+    ///
+    /// Detaching discards this handle's ability to observe completion or request
+    /// cancellation. It never stops physical movement.
+    #[inline]
+    pub fn detach(self) {
+        // Drop is detach for async operation handles.
     }
 }
 
@@ -422,6 +517,8 @@ impl std::fmt::Debug for InFlightDyn {
         f.debug_struct("InFlightDyn")
             .field("id", &self.id)
             .field("category", &self.category)
+            .field("kind", &self.metadata.kind)
+            .field("axes", &self.metadata.axes)
             .finish()
     }
 }
@@ -593,7 +690,7 @@ pub trait DynPanTiltControl: Send + Sync {
     /// use std::time::Duration;
     ///
     /// let handle = pt.pan_tilt_home_op().await?;
-    /// handle.await_completion(Duration::from_secs(30)).await?;
+    /// handle.await_settled(Duration::from_secs(30)).await?;
     /// ```
     fn pan_tilt_home_op(&self) -> BoxFuture<'_, Result<InFlightDyn, Error>>;
 
@@ -919,16 +1016,112 @@ where
     fn erase_inflight<C>(
         &self,
         handle: crate::camera::InFlight<'_, C, P, Exec>,
-        category: OperationCategory,
-    ) -> Result<InFlightDyn, Error> {
-        let (id, camera_id, response_future) = handle.into_parts()?;
+    ) -> Result<InFlightDyn, Error>
+    where
+        C: DynOperationCategoryMarker,
+    {
+        let (id, camera_id, response_future, metadata) = handle.into_parts()?;
         Ok(InFlightDyn::new(
             id,
             camera_id,
-            category,
+            C::DYN_CATEGORY,
+            metadata,
             self.runtime_dyn(),
             response_future,
         ))
+    }
+
+    /// Apply a descriptor-built movement operation, optionally overriding the
+    /// scheduler-owned completion timeout with a dyn call-site timeout.
+    fn apply_dyn_operation<Cat, C>(
+        &self,
+        command: Result<C, Error>,
+        timeout: Option<Duration>,
+    ) -> BoxFuture<'_, Result<(), Error>>
+    where
+        Cat: DynOperationCategoryMarker + Send + Sync + 'static,
+        C: crate::command::ViscaCommand + 'static,
+    {
+        Box::pin(async move {
+            let command = command?;
+            let metadata = command.operation_metadata().ok_or_else(|| {
+                Error::InvalidState(
+                    "dyn movement registry command is missing operation metadata".into(),
+                )
+            })?;
+            let handle = self
+                .inner
+                .camera
+                .submit_op::<Cat, _>(&command, metadata)
+                .await?;
+            match timeout {
+                Some(timeout) => handle.await_applied(timeout).await,
+                None => handle.await_applied_default().await,
+            }
+        })
+    }
+
+    /// Start a descriptor-built operation and erase only its transport/profile
+    /// types; completion behavior remains command-derived on the handle.
+    fn start_dyn_operation<Cat, C>(
+        &self,
+        command: Result<C, Error>,
+    ) -> BoxFuture<'_, Result<InFlightDyn, Error>>
+    where
+        Cat: DynOperationCategoryMarker + Send + Sync + 'static,
+        C: crate::command::ViscaCommand + 'static,
+    {
+        Box::pin(async move {
+            let command = command?;
+            let metadata = command.operation_metadata().ok_or_else(|| {
+                Error::InvalidState(
+                    "dyn movement registry command is missing operation metadata".into(),
+                )
+            })?;
+            let handle = self
+                .inner
+                .camera
+                .submit_op::<Cat, _>(&command, metadata)
+                .await?;
+            self.erase_inflight(handle)
+        })
+    }
+
+    fn require_typed(
+        &self,
+        surface: crate::capabilities::TypedSupportSurface,
+        feature: &'static str,
+    ) -> Result<(), Error> {
+        if self.inner.capabilities.supports_typed(surface) {
+            Ok(())
+        } else {
+            Err(Error::FeatureNotSupported { feature })
+        }
+    }
+
+    fn validate_operation_requirement(
+        &self,
+        requirement: DynOperationRequirement,
+    ) -> Result<(), Error> {
+        match requirement {
+            DynOperationRequirement::None => Ok(()),
+            DynOperationRequirement::Typed(surface, feature) => {
+                self.require_typed(surface, feature)
+            }
+            DynOperationRequirement::ZoomDomain(domain) => {
+                self.require_typed(
+                    crate::capabilities::TypedSupportSurface::DirectZoom,
+                    "direct zoom positioning",
+                )?;
+                if domain == ZoomDomain::OpticalPlusDigital {
+                    self.require_typed(
+                        crate::capabilities::TypedSupportSurface::DigitalZoomRange,
+                        "digital zoom",
+                    )?;
+                }
+                Ok(())
+            }
+        }
     }
 }
 
@@ -959,6 +1152,39 @@ where
                 .timeout(timeout, response_future)
                 .await?
                 .map(|_| ())
+        })
+    }
+
+    fn await_response_settled(
+        &self,
+        timeout: Duration,
+        response_future: ResponseFuture,
+        metadata: OperationMetadata,
+    ) -> BoxFuture<'_, Result<(), Error>> {
+        Box::pin(async move {
+            let started = self.camera.runtime().executor().now();
+            self.camera
+                .runtime()
+                .timeout(timeout, response_future)
+                .await?
+                .map(|_| ())?;
+
+            if P::SUPPORTS_OPERATION_COMPLETE {
+                return Ok(());
+            }
+
+            let elapsed = self
+                .camera
+                .runtime()
+                .executor()
+                .now()
+                .saturating_duration_since(started);
+            let remaining = timeout.saturating_sub(elapsed);
+            if remaining.is_zero() {
+                return Err(Error::Timeout);
+            }
+
+            self.camera.await_axes_idle(metadata.axes, remaining).await
         })
     }
 }
@@ -1014,6 +1240,59 @@ where
     }
 }
 
+macro_rules! impl_dyn_registered_operation {
+    (
+        $method:ident($($arg:ident: $arg_ty:ty),*) => none:
+        $category:ty [$requirement:expr] = $build:expr
+    ) => {
+        fn $method(
+            &self,
+            $($arg: $arg_ty,)*
+            timeout: Option<Duration>,
+        ) -> BoxFuture<'_, Result<(), Error>> {
+            let command = self
+                .validate_operation_requirement($requirement)
+                .and_then(|()| $build);
+            self.apply_dyn_operation::<$category, _>(command, timeout)
+        }
+    };
+    (
+        $method:ident($($arg:ident: $arg_ty:ty),*) => $handle:ident:
+        $category:ty [$requirement:expr] = $build:expr
+    ) => {
+        fn $method(
+            &self,
+            $($arg: $arg_ty,)*
+            timeout: Option<Duration>,
+        ) -> BoxFuture<'_, Result<(), Error>> {
+            let command = self
+                .validate_operation_requirement($requirement)
+                .and_then(|()| $build);
+            self.apply_dyn_operation::<$category, _>(command, timeout)
+        }
+
+        fn $handle(
+            &self,
+            $($arg: $arg_ty),*
+        ) -> BoxFuture<'_, Result<InFlightDyn, Error>> {
+            let command = self
+                .validate_operation_requirement($requirement)
+                .and_then(|()| $build);
+            self.start_dyn_operation::<$category, _>(command)
+        }
+    };
+}
+
+macro_rules! impl_dyn_registered_operations {
+    ($($method:ident($($arg:ident: $arg_ty:ty),*) => $handle:ident: $category:ty [$requirement:expr] = $build:expr;)*) => {
+        $(
+            impl_dyn_registered_operation! {
+                $method($($arg: $arg_ty),*) => $handle: $category [$requirement] = $build
+            }
+        )*
+    };
+}
+
 // Implement DynPanTiltControl for DynCamera
 #[cfg(feature = "dyn-api")]
 impl<P, Tr, Exec> DynPanTiltControl for DynCamera<P, Tr, Exec>
@@ -1027,107 +1306,7 @@ where
         self.inner.camera.pan_tilt_stop()
     }
 
-    fn pan_tilt_home(&self, timeout: Option<Duration>) -> BoxFuture<'_, Result<(), Error>> {
-        match timeout {
-            Some(t) => Box::pin(async move {
-                let handle = self.inner.camera.pan_tilt_home_op().await?;
-                handle.await_applied(t).await
-            }),
-            None => {
-                use crate::camera::controls::pan_tilt::PanTiltControl;
-                self.inner.camera.pan_tilt_home()
-            }
-        }
-    }
-
-    fn pan_tilt_home_op(&self) -> BoxFuture<'_, Result<InFlightDyn, Error>> {
-        Box::pin(async move {
-            let handle = self.inner.camera.pan_tilt_home_op().await?;
-            self.erase_inflight(handle, OperationCategory::PanTilt)
-        })
-    }
-
-    fn pan_tilt_absolute(
-        &self,
-        pan_deg: f64,
-        tilt_deg: f64,
-        speed: SpeedLevel,
-        timeout: Option<Duration>,
-    ) -> BoxFuture<'_, Result<(), Error>> {
-        match timeout {
-            Some(t) => Box::pin(async move {
-                let handle = self
-                    .inner
-                    .camera
-                    .pan_tilt_absolute_op(pan_deg, tilt_deg, speed)
-                    .await?;
-                handle.await_applied(t).await
-            }),
-            None => {
-                use crate::camera::controls::pan_tilt::PanTiltControl;
-                self.inner
-                    .camera
-                    .pan_tilt_absolute(pan_deg, tilt_deg, speed)
-            }
-        }
-    }
-
-    fn pan_tilt_absolute_op(
-        &self,
-        pan_deg: f64,
-        tilt_deg: f64,
-        speed: SpeedLevel,
-    ) -> BoxFuture<'_, Result<InFlightDyn, Error>> {
-        Box::pin(async move {
-            let handle = self
-                .inner
-                .camera
-                .pan_tilt_absolute_op(pan_deg, tilt_deg, speed)
-                .await?;
-            self.erase_inflight(handle, OperationCategory::PanTilt)
-        })
-    }
-
-    fn pan_tilt_relative(
-        &self,
-        pan_deg: f64,
-        tilt_deg: f64,
-        speed: SpeedLevel,
-        timeout: Option<Duration>,
-    ) -> BoxFuture<'_, Result<(), Error>> {
-        match timeout {
-            Some(t) => Box::pin(async move {
-                let handle = self
-                    .inner
-                    .camera
-                    .pan_tilt_relative_op(pan_deg, tilt_deg, speed)
-                    .await?;
-                handle.await_applied(t).await
-            }),
-            None => {
-                use crate::camera::controls::pan_tilt::PanTiltControl;
-                self.inner
-                    .camera
-                    .pan_tilt_relative(pan_deg, tilt_deg, speed)
-            }
-        }
-    }
-
-    fn pan_tilt_relative_op(
-        &self,
-        pan_deg: f64,
-        tilt_deg: f64,
-        speed: SpeedLevel,
-    ) -> BoxFuture<'_, Result<InFlightDyn, Error>> {
-        Box::pin(async move {
-            let handle = self
-                .inner
-                .camera
-                .pan_tilt_relative_op(pan_deg, tilt_deg, speed)
-                .await?;
-            self.erase_inflight(handle, OperationCategory::PanTilt)
-        })
-    }
+    movement_registry::dyn_pan_tilt_operations!(impl_dyn_registered_operations);
 
     fn pan_tilt_move(
         &self,
@@ -1139,26 +1318,6 @@ where
         self.inner
             .camera
             .pan_tilt_move(direction, pan_speed, tilt_speed)
-    }
-
-    fn pan_tilt_reset(&self, timeout: Option<Duration>) -> BoxFuture<'_, Result<(), Error>> {
-        match timeout {
-            Some(t) => Box::pin(async move {
-                let handle = self.inner.camera.pan_tilt_reset_op().await?;
-                handle.await_applied(t).await
-            }),
-            None => {
-                use crate::camera::controls::pan_tilt::PanTiltControl;
-                self.inner.camera.pan_tilt_reset()
-            }
-        }
-    }
-
-    fn pan_tilt_reset_op(&self) -> BoxFuture<'_, Result<InFlightDyn, Error>> {
-        Box::pin(async move {
-            let handle = self.inner.camera.pan_tilt_reset_op().await?;
-            self.erase_inflight(handle, OperationCategory::PanTilt)
-        })
     }
 
     fn pan_tilt_limit_set(
@@ -1190,93 +1349,7 @@ where
         self.inner.camera.zoom_stop()
     }
 
-    fn zoom_tele(
-        &self,
-        speed: Option<ZoomSpeed>,
-        timeout: Option<Duration>,
-    ) -> BoxFuture<'_, Result<(), Error>> {
-        match timeout {
-            Some(t) => Box::pin(async move {
-                let handle = self.inner.camera.zoom_tele_op(speed).await?;
-                handle.await_applied(t).await
-            }),
-            None => {
-                use crate::camera::controls::zoom::ZoomControl;
-                self.inner.camera.zoom_tele(speed)
-            }
-        }
-    }
-
-    fn zoom_wide(
-        &self,
-        speed: Option<ZoomSpeed>,
-        timeout: Option<Duration>,
-    ) -> BoxFuture<'_, Result<(), Error>> {
-        match timeout {
-            Some(t) => Box::pin(async move {
-                let handle = self.inner.camera.zoom_wide_op(speed).await?;
-                handle.await_applied(t).await
-            }),
-            None => {
-                use crate::camera::controls::zoom::ZoomControl;
-                self.inner.camera.zoom_wide(speed)
-            }
-        }
-    }
-
-    fn set_zoom(
-        &self,
-        position: ZoomPosition,
-        timeout: Option<Duration>,
-    ) -> BoxFuture<'_, Result<(), Error>> {
-        if !self
-            .capabilities()
-            .supports_typed(crate::capabilities::TypedSupportSurface::DirectZoom)
-        {
-            return Box::pin(async {
-                Err(Error::FeatureNotSupported {
-                    feature: "direct zoom positioning",
-                })
-            });
-        }
-
-        match timeout {
-            Some(t) => Box::pin(async move {
-                let command = crate::camera::controls::zoom::zoom_position_command::<P>(position)?;
-                let handle = self
-                    .inner
-                    .camera
-                    .start_zoom_operation(command, crate::camera::OpKind::Targeted)
-                    .await?;
-                handle.await_applied(t).await
-            }),
-            None => match crate::camera::controls::zoom::zoom_position_command::<P>(position) {
-                Ok(command) => self.inner.camera.execute(command),
-                Err(error) => Box::pin(async move { Err(error) }),
-            },
-        }
-    }
-
-    fn set_zoom_op(&self, position: ZoomPosition) -> BoxFuture<'_, Result<InFlightDyn, Error>> {
-        Box::pin(async move {
-            if !self
-                .capabilities()
-                .supports_typed(crate::capabilities::TypedSupportSurface::DirectZoom)
-            {
-                return Err(Error::FeatureNotSupported {
-                    feature: "direct zoom positioning",
-                });
-            }
-
-            let command = crate::camera::controls::zoom::zoom_position_command::<P>(position)?;
-            let handle = self
-                .inner
-                .camera
-                .start_zoom_operation(command, crate::camera::OpKind::Targeted)
-                .await?;
-            self.erase_inflight(handle, OperationCategory::Zoom)
-        })
-    }
+    movement_registry::dyn_zoom_operations!(impl_dyn_registered_operations);
 
     fn set_digital_zoom(&self, enabled: bool) -> BoxFuture<'_, Result<(), Error>> {
         if !self
@@ -1294,95 +1367,6 @@ where
             .camera
             .execute(crate::command::zoom::DigitalZoom::new(enabled))
     }
-
-    fn set_zoom_normalized(
-        &self,
-        position: UnitInterval,
-        timeout: Option<Duration>,
-    ) -> BoxFuture<'_, Result<(), Error>> {
-        if !self
-            .capabilities()
-            .supports_typed(crate::capabilities::TypedSupportSurface::DirectZoom)
-        {
-            return Box::pin(async {
-                Err(Error::FeatureNotSupported {
-                    feature: "direct zoom positioning",
-                })
-            });
-        }
-
-        match timeout {
-            Some(t) => Box::pin(async move {
-                let command =
-                    crate::camera::controls::zoom::zoom_normalized_command::<P>(position)?;
-                let handle = self
-                    .inner
-                    .camera
-                    .start_zoom_operation(command, crate::camera::OpKind::Targeted)
-                    .await?;
-                handle.await_applied(t).await
-            }),
-            None => match crate::camera::controls::zoom::zoom_normalized_command::<P>(position) {
-                Ok(command) => self.inner.camera.execute(command),
-                Err(error) => Box::pin(async move { Err(error) }),
-            },
-        }
-    }
-
-    fn set_zoom_normalized_in_domain(
-        &self,
-        position: UnitInterval,
-        domain: ZoomDomain,
-        timeout: Option<Duration>,
-    ) -> BoxFuture<'_, Result<(), Error>> {
-        if !self
-            .capabilities()
-            .supports_typed(crate::capabilities::TypedSupportSurface::DirectZoom)
-        {
-            return Box::pin(async {
-                Err(Error::FeatureNotSupported {
-                    feature: "direct zoom positioning",
-                })
-            });
-        }
-
-        if domain == ZoomDomain::OpticalPlusDigital
-            && !self
-                .capabilities()
-                .supports_typed(crate::capabilities::TypedSupportSurface::DigitalZoomRange)
-        {
-            return Box::pin(async {
-                Err(Error::FeatureNotSupported {
-                    feature: "digital zoom",
-                })
-            });
-        }
-
-        match timeout {
-            Some(t) => Box::pin(async move {
-                let zoom = crate::camera::controls::zoom::zoom_from_normalized_for_profile::<P>(
-                    position, domain,
-                )?;
-                let command = crate::camera::controls::zoom::zoom_position_command::<P>(zoom)?;
-                let handle = self
-                    .inner
-                    .camera
-                    .start_zoom_operation(command, crate::camera::OpKind::Targeted)
-                    .await?;
-                handle.await_applied(t).await
-            }),
-            None => {
-                let command = crate::camera::controls::zoom::zoom_from_normalized_for_profile::<P>(
-                    position, domain,
-                )
-                .and_then(crate::camera::controls::zoom::zoom_position_command::<P>);
-                match command {
-                    Ok(command) => self.inner.camera.execute(command),
-                    Err(error) => Box::pin(async move { Err(error) }),
-                }
-            }
-        }
-    }
 }
 
 // Implement DynFocusControl for DynCamera
@@ -1393,6 +1377,8 @@ where
     Tr: crate::transport::AsyncTransport + Send + Sync + 'static,
     Exec: crate::executor::Executor,
 {
+    movement_registry::dyn_focus_operations!(impl_dyn_registered_operations);
+
     fn focus_auto(&self) -> BoxFuture<'_, Result<(), Error>> {
         use crate::camera::controls::focus::FocusControl;
         self.inner.camera.focus_auto()
@@ -1433,30 +1419,6 @@ where
         self.inner
             .camera
             .execute(crate::command::focus::Focus::OnePushTrigger)
-    }
-
-    fn set_focus(
-        &self,
-        position: FocusPosition,
-        timeout: Option<Duration>,
-    ) -> BoxFuture<'_, Result<(), Error>> {
-        match timeout {
-            Some(t) => Box::pin(async move {
-                let handle = self.inner.camera.set_focus_op(position).await?;
-                handle.await_applied(t).await
-            }),
-            None => {
-                use crate::camera::controls::focus::FocusControl;
-                self.inner.camera.set_focus(position)
-            }
-        }
-    }
-
-    fn set_focus_op(&self, position: FocusPosition) -> BoxFuture<'_, Result<InFlightDyn, Error>> {
-        Box::pin(async move {
-            let handle = self.inner.camera.set_focus_op(position).await?;
-            self.erase_inflight(handle, OperationCategory::Focus)
-        })
     }
 
     fn focus_infinity(&self) -> BoxFuture<'_, Result<(), Error>> {
@@ -1515,29 +1477,7 @@ where
     Tr: crate::transport::AsyncTransport + Send + Sync + 'static,
     Exec: crate::executor::Executor,
 {
-    fn preset_recall(
-        &self,
-        preset: PresetNumber,
-        timeout: Option<Duration>,
-    ) -> BoxFuture<'_, Result<(), Error>> {
-        match timeout {
-            Some(t) => Box::pin(async move {
-                let handle = self.inner.camera.preset_recall_op(preset).await?;
-                handle.await_applied(t).await
-            }),
-            None => {
-                use crate::camera::controls::presets::PresetsControl;
-                self.inner.camera.preset_recall(preset)
-            }
-        }
-    }
-
-    fn preset_recall_op(&self, preset: PresetNumber) -> BoxFuture<'_, Result<InFlightDyn, Error>> {
-        Box::pin(async move {
-            let handle = self.inner.camera.preset_recall_op(preset).await?;
-            self.erase_inflight(handle, OperationCategory::Preset)
-        })
-    }
+    movement_registry::dyn_preset_operations!(impl_dyn_registered_operations);
 
     fn preset_set(&self, preset: PresetNumber) -> BoxFuture<'_, Result<(), Error>> {
         use crate::camera::controls::presets::PresetsControl;
@@ -1643,5 +1583,30 @@ mod tests {
         assert_eq!(format!("{}", OperationCategory::Zoom), "Zoom");
         assert_eq!(format!("{}", OperationCategory::Focus), "Focus");
         assert_eq!(format!("{}", OperationCategory::Preset), "Preset");
+    }
+
+    #[test]
+    fn movement_registry_matches_independent_public_inventory() {
+        assert_eq!(
+            movement_registry::PAN_TILT_INVENTORY,
+            [
+                "pan_tilt_home",
+                "pan_tilt_absolute",
+                "pan_tilt_relative",
+                "pan_tilt_reset",
+            ]
+        );
+        assert_eq!(
+            movement_registry::ZOOM_INVENTORY,
+            [
+                "zoom_tele",
+                "zoom_wide",
+                "set_zoom",
+                "set_zoom_normalized",
+                "set_zoom_normalized_in_domain",
+            ]
+        );
+        assert_eq!(movement_registry::FOCUS_INVENTORY, ["set_focus"]);
+        assert_eq!(movement_registry::PRESET_INVENTORY, ["preset_recall"]);
     }
 }

--- a/src/dynapi/movement_registry.rs
+++ b/src/dynapi/movement_registry.rs
@@ -1,0 +1,111 @@
+//! Declarative inventory for the dyn movement methods that need operation handles.
+//!
+//! The public dyn traits remain written out explicitly so their rustdoc and stable
+//! 1.x signatures stay easy to review. Their repetitive adapters are generated
+//! from this registry and all route through the command-derived operation core.
+
+macro_rules! dyn_pan_tilt_operations {
+    ($consumer:ident) => {
+        $consumer! {
+            pan_tilt_home() => pan_tilt_home_op: crate::camera::PanTiltOperation
+                [DynOperationRequirement::None] =
+                Ok::<_, crate::Error>(crate::command::pan_tilt::PanTilt::Home);
+            pan_tilt_absolute(
+                pan_deg: f64,
+                tilt_deg: f64,
+                speed: crate::types::SpeedLevel
+            ) => pan_tilt_absolute_op: crate::camera::PanTiltOperation
+                [DynOperationRequirement::None] =
+                crate::camera::controls::pan_tilt::pan_tilt_absolute_command::<P>(
+                    pan_deg, tilt_deg, speed,
+                );
+            pan_tilt_relative(
+                pan_deg: f64,
+                tilt_deg: f64,
+                speed: crate::types::SpeedLevel
+            ) => pan_tilt_relative_op: crate::camera::PanTiltOperation
+                [DynOperationRequirement::None] =
+                crate::camera::controls::pan_tilt::pan_tilt_relative_command::<P>(
+                    pan_deg, tilt_deg, speed,
+                );
+            pan_tilt_reset() => pan_tilt_reset_op: crate::camera::PanTiltOperation
+                [DynOperationRequirement::None] =
+                Ok::<_, crate::Error>(crate::command::pan_tilt::PanTilt::Reset);
+        }
+    };
+}
+
+macro_rules! dyn_zoom_operations {
+    ($consumer:ident) => {
+        $consumer! {
+            zoom_tele(speed: Option<crate::types::ZoomSpeed>) => none:
+                crate::camera::ZoomOperation [DynOperationRequirement::None] =
+                crate::camera::controls::zoom::zoom_tele_command::<P>(speed);
+            zoom_wide(speed: Option<crate::types::ZoomSpeed>) => none:
+                crate::camera::ZoomOperation [DynOperationRequirement::None] =
+                crate::camera::controls::zoom::zoom_wide_command::<P>(speed);
+            set_zoom(position: crate::types::ZoomPosition) => set_zoom_op:
+                crate::camera::ZoomOperation [DynOperationRequirement::Typed(
+                        crate::capabilities::TypedSupportSurface::DirectZoom,
+                        "direct zoom positioning",
+                    )] = crate::camera::controls::zoom::zoom_position_command::<P>(position);
+            set_zoom_normalized(position: crate::UnitInterval) => none:
+                crate::camera::ZoomOperation [DynOperationRequirement::Typed(
+                        crate::capabilities::TypedSupportSurface::DirectZoom,
+                        "direct zoom positioning",
+                    )] = crate::camera::controls::zoom::zoom_normalized_command::<P>(position);
+            set_zoom_normalized_in_domain(
+                position: crate::UnitInterval,
+                domain: crate::ZoomDomain
+            ) => none: crate::camera::ZoomOperation
+                [DynOperationRequirement::ZoomDomain(domain)] =
+                crate::camera::controls::zoom::zoom_from_normalized_for_profile::<P>(
+                    position, domain,
+                )
+                .and_then(crate::camera::controls::zoom::zoom_position_command::<P>);
+        }
+    };
+}
+
+macro_rules! dyn_focus_operations {
+    ($consumer:ident) => {
+        $consumer! {
+            set_focus(position: crate::types::FocusPosition) => set_focus_op:
+                crate::camera::FocusOperation [DynOperationRequirement::None] =
+                crate::camera::controls::focus::focus_position_command::<P, _>(position);
+        }
+    };
+}
+
+macro_rules! dyn_preset_operations {
+    ($consumer:ident) => {
+        $consumer! {
+            preset_recall(preset: crate::command::preset::PresetNumber) => preset_recall_op:
+                crate::camera::PresetOperation [DynOperationRequirement::None] =
+                crate::camera::controls::presets::preset_command::<P>(
+                    crate::command::preset::PresetAction::Recall,
+                    preset,
+                );
+        }
+    };
+}
+
+pub(crate) use {
+    dyn_focus_operations, dyn_pan_tilt_operations, dyn_preset_operations, dyn_zoom_operations,
+};
+
+#[cfg(test)]
+macro_rules! define_inventory {
+    ($($method:ident($($arg:ident: $arg_ty:ty),*) => $handle:ident: $category:ty [$requirement:expr] = $build:expr;)*) => {
+        &[$(stringify!($method)),*]
+    };
+}
+
+#[cfg(test)]
+pub(crate) const PAN_TILT_INVENTORY: &[&str] = dyn_pan_tilt_operations!(define_inventory);
+#[cfg(test)]
+pub(crate) const ZOOM_INVENTORY: &[&str] = dyn_zoom_operations!(define_inventory);
+#[cfg(test)]
+pub(crate) const FOCUS_INVENTORY: &[&str] = dyn_focus_operations!(define_inventory);
+#[cfg(test)]
+pub(crate) const PRESET_INVENTORY: &[&str] = dyn_preset_operations!(define_inventory);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,19 +32,19 @@
 //! - **Camera-first API Architecture**: `Connect` and noun accessors across blocking and async modes
 //! - **Type-Safe Camera Profiles**: Compile-time validation with camera-specific profiles
 //! - **Feature-Gated Methods**: Choose blocking or async at compile time with zero runtime overhead
-//! - **Multi-Runtime Support**: Tokio and smol can coexist with priority-based selection
-//! - **Complete Command Coverage**: Full VISCA protocol support across all camera types
+//! - **Multi-Runtime Support**: Tokio and smol can coexist with explicit runtime selection
+//! - **Profile-Gated Command Coverage**: Typed controls follow documented model support
 //! - **Profile-Aware Conversions**: Automatic unit conversions based on camera model
 //! - **Comprehensive Inquiry**: Query camera state for all supported features
 //! - **Transport Abstraction**: TCP, UDP, Serial, and custom transport implementations
 //! - **Configuration APIs**: `CameraConfig` for standard transports and `CameraBuilder` for custom transports
 //! - **Unified Error Handling**: Consistent error mapping across all transport types
 //! - **Configurable Timeouts**: Per-category timeout configuration for different command types
-//! - **Command Cancellation**: Cancel specific commands or entire socket operations
-//! - **Async Completion Tracking**: Wait for camera movements to complete with await methods
+//! - **Mode-Honest Operation Handles**: Exact applied waits, physical settled waits,
+//!   cancellation, and detach across blocking, async, and dynamic APIs
 //! - **Serialization Support**: Optional serde/schemars integration for all value types
 //!
-//! ## 1.0 API Shape
+//! ## 1.x API Shape
 //!
 //! The primary API is camera-first:
 //!
@@ -196,12 +196,12 @@
 //!     // Create camera using convenience Connect helper
 //!     let camera = Connect::open_tcp_blocking::<PtzOpticsG2>("192.168.0.110")?;
 //!
-//!     // Use accessor-style API
-//!     camera.power().on()?;
-//!     camera.zoom().tele()?;
-//!     camera.pan_tilt().home()?;
+//!     // Quick starts are read-only by default.
+//!     let is_on = camera.power().state()?;
+//!     let zoom = camera.zoom().position()?;
+//!     println!("Power: {is_on}, zoom: 0x{:04X}", zoom.value());
 //!
-//!     Ok(())
+//!     camera.close()
 //! }
 //! ```
 //!
@@ -210,7 +210,7 @@
 //! use grafton_visca::{
 //!     camera::Connect,
 //!     camera::profiles::PtzOpticsG2,
-//!     runtime::{Runtime, TokioRuntime},
+//!     runtime::TokioRuntime,
 //!     Error,
 //! };
 //!
@@ -223,14 +223,11 @@
 //!         runtime
 //!     ).await?;
 //!
-//!     // Use accessor-style API with async
-//!     camera.power().on().await?;
-//!     camera.zoom().tele().await?;
-//!     camera.pan_tilt().home().await?;
+//!     let is_on = camera.power().state().await?;
+//!     let zoom = camera.zoom().position().await?;
+//!     println!("Power: {is_on}, zoom: 0x{:04X}", zoom.value());
 //!
-//!     // Wait for movements to complete
-//!     camera.await_idle().await?;
-//!
+//!     camera.close().await?;
 //!     Ok(())
 //! }
 //! ```
@@ -256,9 +253,10 @@
 //!         )
 //!             .await?;
 //!
-//!         camera.power().on().await?;
-//!         camera.zoom().tele().await?;
+//!         let is_on = camera.power().state().await?;
+//!         println!("Power: {is_on}");
 //!
+//!         camera.close().await?;
 //!         Ok(())
 //!     })
 //! }
@@ -284,14 +282,36 @@
 //!
 //!         let camera = config.open_async(SmolRuntime::new()).await?;
 //!
-//!         camera.power().on().await?;
-//!         camera.pan_tilt().home().await?;
-//!         camera.zoom().tele().await?;
+//!         let is_on = camera.power().state().await?;
+//!         println!("Power: {is_on}");
 //!
+//!         camera.close().await?;
 //!         Ok(())
 //!     })
 //! }
 //! ```
+//!
+//! ### Bounded Operation Handles
+//!
+//! Ordinary noun methods are the simplest command-completion API. Use `submit`
+//! when one command needs an exact deadline, cancellation, detach, or a physical
+//! settle signal:
+//!
+//! ```ignore
+//! use std::time::Duration;
+//! use grafton_visca::{camera::Connect, command::{PanTilt, Zoom}, profiles::PtzOpticsG2};
+//!
+//! let camera = Connect::open_tcp_blocking::<PtzOpticsG2>("192.168.0.110")?;
+//! camera.submit(&PanTilt::Home)?
+//!     .await_settled(Duration::from_secs(20))?;
+//! camera.submit(&Zoom::Stop)?
+//!     .await_applied(Duration::from_secs(2))?;
+//! camera.close()?;
+//! ```
+//!
+//! `submit` manages lifecycle; it does not add profile capability or range
+//! validation beyond the command's own checks. Prefer typed noun controls for
+//! profile-sensitive ergonomic input.
 //!
 //! ## Camera Profiles
 //!
@@ -391,20 +411,12 @@
 //!
 //! ### Runtime Requirements for Async
 //!
-//! **The async API REQUIRES a runtime to be configured.** Without a runtime, ALL async operations
-//! will fail with: `Error::InvalidState("No runtime configured for async operations")`.
+//! Async camera types always carry an executor/runtime selected at construction,
+//! so a camera cannot be created in an unconfigured runtime state. The runtime
+//! owns background scheduling, timing, transport I/O, and settle polling.
+//! There are two supported construction strategies:
 //!
-//! The runtime is essential for:
-//! - **Timeout handling** - All camera commands have configurable timeouts
-//! - **Power sequences** - Power on/off operations require delays
-//! - **Movement detection** - Polling for pan/tilt/zoom completion
-//! - **Background tasks** - Socket manager for concurrent operations
-//!
-//! ### Runtime Requirements for Async
-//!
-//! You have multiple options for configuring a runtime:
-//!
-//! #### Option 1: Use built-in runtime support (Easiest)
+//! #### Option 1: Use a built-in runtime adapter
 //!
 //! Choose your runtime(s) and enable the corresponding feature(s) in `Cargo.toml`:
 //!
@@ -418,8 +430,7 @@
 //! grafton-visca = { version = "1", features = ["runtime-tokio", "runtime-smol"] }
 //! ```
 //!
-//! Then pass the runtime explicitly, either through `Connect` for quick setup or
-//! `CameraBuilder::with_executor(...)` for advanced BYO-transport flows:
+//! Pass the runtime explicitly through `Connect` or `CameraConfig`:
 //!
 //! ```ignore
 //! // Tokio
@@ -433,91 +444,16 @@
 //! let camera = Connect::open_tcp_async::<PtzOpticsG2, _>("192.168.0.110", runtime).await?;
 //! ```
 //!
-//! #### Option 2: Provide your own runtime (Advanced)
+//! #### Option 2: Provide an executor and transport adapter
 //!
-//! For complete runtime independence, implement `Executor` and attach your own
-//! async transport with `CameraBuilder::from_transport(...)`:
+//! For complete runtime independence, implement `Executor` and
+//! `transport::AsyncTransport` plus `transport::HasTransportConfig`, then
+//! attach them with `CameraBuilder::with_executor`. The executor must provide
+//! real spawn, detach, sleep, timeout, and clock behavior from one coherent
+//! runtime; placeholder or mixed-runtime implementations are not valid.
 //!
-//! ```ignore
-//! use grafton_visca::{
-//!     CameraBuilder, Error, ExecError, Executor,
-//!     camera::profiles::PtzOpticsG2,
-//! };
-//! use std::{future::Future, pin::Pin, time::Duration};
-//!
-//! #[derive(Debug, Clone)]
-//! struct MyExecutor;
-//!
-//! impl Executor for MyExecutor {
-//!     type Join<T> = Pin<Box<dyn Future<Output = Result<T, ExecError>> + Send + 'static>>
-//!     where T: Send + 'static;
-//!
-//!     type Detach = ();
-//!
-//!     fn spawn_with_detach<F>(&self, fut: F) -> (Self::Join<F::Output>, Self::Detach)
-//!     where
-//!         F: Future + Send + 'static,
-//!         F::Output: Send + 'static,
-//!     {
-//!         // Spawn on your runtime here
-//!     }
-//!
-//!     fn block_on<F: Future>(&self, fut: F) -> F::Output {
-//!         todo!()
-//!     }
-//!
-//!     fn sleep(&self, duration: Duration) -> impl Future<Output = ()> + Send + '_ {
-//!         async move {
-//!             let _ = duration;
-//!         }
-//!     }
-//!
-//!     fn timeout<'a, F, T>(
-//!         &'a self,
-//!         duration: Duration,
-//!         fut: F,
-//!     ) -> impl Future<Output = Result<T, Error>> + Send + 'a
-//!     where
-//!         F: Future<Output = T> + Send + 'a,
-//!         T: Send + 'a,
-//!     {
-//!         async move {
-//!             let _ = duration;
-//!             Ok(fut.await)
-//!         }
-//!     }
-//! }
-//!
-//! async fn main() -> Result<(), Error> {
-//!     let transport = MyAsyncTransport::connect("192.168.0.110:5678").await?;
-//!     let camera = CameraBuilder::with_executor(MyExecutor)
-//!         .from_transport(transport)
-//!         .profile::<PtzOpticsG2>()
-//!         .open_async()
-//!         .await?;
-//!
-//!     camera.power().on().await?;
-//!     Ok(())
-//! }
-//! ```
-//!
-//! See `examples/runtime_agnostic.rs` for a complete end-to-end example.
-//!
-//! ### Common Runtime Errors and Solutions
-//!
-//! #### Error: `InvalidState("No runtime configured for async operations")`
-//! **Cause:** You're using async mode but haven't configured a runtime.
-//! **Solution:** Either:
-//! - Enable `runtime-tokio` and pass `TokioRuntime::from_current()?` to `Connect` or `CameraConfig`
-//! - Use `CameraBuilder::with_executor()` only when attaching your own transport/runtime implementation
-//!
-//! #### Error: `InvalidState("Operation requires runtime for timeout handling")`
-//! **Cause:** The operation needs timeout support but no runtime is available.
-//! **Solution:** Same as above - configure a runtime.
-//!
-//! #### Error: Socket manager initialization issues
-//! **Cause:** The socket manager requires a runtime to spawn background tasks.
-//! **Solution:** Ensure your runtime's `Spawner` implementation is working correctly.
+//! See `examples/runtime_agnostic.rs` for a runnable executor-contract example
+//! and [`CameraBuilder`] for the advanced caller-owned transport path.
 //!
 //! ### Blocking vs Async Mode
 //!

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,7 @@
 //! Prelude modules for convenient imports.
 //!
 //! This module provides separate preludes for async and blocking camera-first APIs.
-//! They are intended for application code that follows the 1.0 path:
+//! They are intended for application code that follows the 1.x path:
 //! `Connect` or `CameraConfig` for construction, then accessor-style controls.
 //!
 //! # High-Level API (Recommended)

--- a/src/runtime/blocking_runner.rs
+++ b/src/runtime/blocking_runner.rs
@@ -9,6 +9,7 @@ use tracing::{debug, trace, warn};
 
 use core::marker::PhantomData;
 use std::{
+    collections::{HashMap, HashSet},
     sync::atomic::{AtomicU32, Ordering},
     time::{Duration, Instant},
 };
@@ -17,11 +18,13 @@ use crate::{
     camera::CommandId,
     camera_id::CameraId,
     capabilities::Profile,
-    command::{response::Response, ViscaCommand},
+    command::{response::Response, system::CommandCancelCommand, CommandKind, ViscaCommand},
     error::{Error, Result},
     protocol::framer::ProtocolFramer,
     runtime::{
-        core::{PendingCommand, Priority, SchedulerAction, SchedulerCore, SchedulerEvent},
+        core::{
+            CancelOutcome, PendingCommand, Priority, SchedulerAction, SchedulerCore, SchedulerEvent,
+        },
         driver::{
             receive_one, scheduler::BlockingScheduler, send_one, ReceiveDisposition, SendResult,
         },
@@ -52,6 +55,14 @@ pub struct BlockingRunner<P: Profile> {
     framer: ProtocolFramer,
     /// Command ID generator.
     next_id: AtomicU32,
+    /// Terminal outcomes for observed commands that completed while another
+    /// command was driving the blocking scheduler.
+    completed: HashMap<CommandId, Result<Response>>,
+    /// Commands whose callers still own a completion handle.
+    ///
+    /// Keeping this separate from `completed` lets detached handles continue to
+    /// run without retaining an outcome that nobody can ever collect.
+    observed: HashSet<CommandId>,
     /// Profile type marker.
     _profile: PhantomData<P>,
 }
@@ -124,6 +135,8 @@ impl<P: Profile> BlockingRunnerBuilder<P> {
             buffer_manager: BufferManager::new(self.buffer_config),
             framer: ProtocolFramer::new_with_config(self.buffer_config),
             next_id: AtomicU32::new(1),
+            completed: HashMap::new(),
+            observed: HashSet::new(),
             _profile: PhantomData,
         }
     }
@@ -200,18 +213,16 @@ impl<P: Profile> BlockingRunner<P> {
             }
         }
 
-        let cmd_id = self.start_command(command, camera_id)?;
+        let cmd_id = self.enqueue(command, camera_id, true)?;
 
-        self.run_until_complete(transport, cmd_id, deadline)
+        self.await_command(transport, cmd_id, deadline)
     }
 
-    /// Queue a command for sending without pumping the scheduler loop.
+    /// Submit a cancelable command and perform its initial transport dispatch.
     ///
-    /// This allocates a [`CommandId`], encodes the command, and enqueues it in
-    /// the scheduler core. It performs **no** transport I/O — nothing is sent
-    /// and nothing is awaited. Call [`await_command`](Self::await_command) (or
-    /// the all-in-one [`send_command`](Self::send_command)) afterwards to drive
-    /// the command to completion.
+    /// This allocates a [`CommandId`], encodes and enqueues the command, and sends
+    /// its bytes. It deliberately performs no receive pump: ACK and completion
+    /// remain pending until [`await_command`](Self::await_command) drives them.
     ///
     /// Splitting submission from completion is what makes a genuine blocking
     /// operation handle possible: the caller can obtain the command's id here,
@@ -220,11 +231,36 @@ impl<P: Profile> BlockingRunner<P> {
     /// # Errors
     ///
     /// Returns an error if the command cannot be encoded.
-    pub fn start_command(
+    pub fn start_command<T: BlockingTransport + HasTransportConfig>(
         &mut self,
+        transport: &mut T,
         command: &impl ViscaCommand,
         camera_id: CameraId,
     ) -> Result<CommandId> {
+        let cmd_id = self.enqueue(command, camera_id, false)?;
+        match self.dispatch_queued_command(transport, cmd_id) {
+            Ok(()) => Ok(cmd_id),
+            Err(error) => {
+                self.core.cancel_command(cmd_id);
+                self.discard_result(cmd_id);
+                Err(error)
+            }
+        }
+    }
+
+    /// Encode and enqueue a command. `allow_inquiry` is reserved for the
+    /// run-to-completion inquiry path; operation handles reject inquiries before
+    /// allocating an ID or performing I/O.
+    fn enqueue(
+        &mut self,
+        command: &impl ViscaCommand,
+        camera_id: CameraId,
+        allow_inquiry: bool,
+    ) -> Result<CommandId> {
+        if !allow_inquiry && command.behavior().command_kind() == CommandKind::Inquiry {
+            return Err(Error::InquiryNotCancelable);
+        }
+
         // Allocate a unique command ID, skipping zero on wraparound
         let cmd_id = loop {
             let id = self.next_id.fetch_add(1, Ordering::SeqCst);
@@ -251,6 +287,8 @@ impl<P: Profile> BlockingRunner<P> {
         };
 
         self.core.queue_command(pending_cmd);
+        self.completed.remove(&cmd_id);
+        self.observed.insert(cmd_id);
 
         Ok(cmd_id)
     }
@@ -273,24 +311,146 @@ impl<P: Profile> BlockingRunner<P> {
         target_cmd_id: CommandId,
         deadline: Option<Deadline>,
     ) -> Result<Response> {
+        if let Some(outcome) = self.completed.remove(&target_cmd_id) {
+            self.observed.remove(&target_cmd_id);
+            return outcome;
+        }
+
+        if !self.observed.contains(&target_cmd_id) {
+            return Err(Error::InvalidState(
+                format!("command {target_cmd_id} is not awaiting a result").into(),
+            ));
+        }
+
         if let Some(ref d) = deadline {
             if d.is_expired() {
                 self.core.cancel_command(target_cmd_id);
+                self.discard_result(target_cmd_id);
                 return Err(Error::Timeout);
             }
         }
 
-        self.run_until_complete(transport, target_cmd_id, deadline)
+        let result = self.run_until_complete(transport, target_cmd_id, deadline);
+        self.discard_result(target_cmd_id);
+        result
     }
 
-    /// Cancel a queued or in-flight command by id.
+    /// Request cancellation without direct transport access.
     ///
-    /// If the command is still queued (no bytes sent), it is dropped from the
-    /// scheduler core and its completion wait resolves as canceled. If it has
-    /// already been sent, this clears the tracked state; the camera-side effect
-    /// depends on the protocol.
+    /// Queued commands are removed immediately and a pre-ACK command is marked
+    /// for cancel-on-ACK. This test-harness API intentionally has no way to send
+    /// a cancel for an already-assigned socket; camera handles use the
+    /// transport-aware path below.
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn cancel(&mut self, target_cmd_id: CommandId) {
-        self.core.cancel_command(target_cmd_id);
+        let _ = self.core.request_cancel_by_id(target_cmd_id);
+        self.discard_result(target_cmd_id);
+    }
+
+    /// Request cancellation and send a socket cancel immediately when the
+    /// scheduler has already observed the command's ACK.
+    pub(crate) fn cancel_with_transport<T: BlockingTransport>(
+        &mut self,
+        transport: &mut T,
+        target_cmd_id: CommandId,
+    ) -> Result<()> {
+        let outcome = self.core.request_cancel_by_id(target_cmd_id);
+        self.discard_result(target_cmd_id);
+
+        if let CancelOutcome::SendCancel { camera_id, socket } = outcome {
+            self.send_cancel_frame(transport, camera_id, socket)?;
+        }
+        Ok(())
+    }
+
+    /// Stop retaining a terminal result for a command without cancelling it.
+    ///
+    /// The scheduler continues to own and drive the command. If it completes
+    /// while another command is awaited, its result is discarded because no
+    /// handle remains to observe it.
+    pub(crate) fn detach(&mut self, target_cmd_id: CommandId) {
+        self.discard_result(target_cmd_id);
+    }
+
+    /// Dispatch queued commands until `target_cmd_id` has been sent, without
+    /// receiving any responses. At most one profile-spacing wait is performed
+    /// when no item is immediately sendable; a still-blocked target means both
+    /// VISCA command sockets are occupied and is reported as `CameraBusy`.
+    fn dispatch_queued_command<T: BlockingTransport + HasTransportConfig>(
+        &mut self,
+        transport: &mut T,
+        target_cmd_id: CommandId,
+    ) -> Result<()> {
+        let mut send_buf = BytesMut::with_capacity(self.buffer_manager.config().send_buffer_size);
+        let mut waited_for_spacing = false;
+
+        loop {
+            let now = Instant::now();
+            let Some(cmd) = self.core.next_item_to_send(now) else {
+                if !waited_for_spacing && !P::MIN_COMMAND_SPACING.is_zero() {
+                    std::thread::sleep(P::MIN_COMMAND_SPACING);
+                    waited_for_spacing = true;
+                    continue;
+                }
+                return Err(Error::CameraBusy);
+            };
+
+            let dispatched_id = cmd.id;
+            let mut scheduler = BlockingScheduler {
+                core: &mut self.core,
+                now,
+            };
+            let write_timeout = transport.transport_config().write_timeout;
+
+            match send_one(
+                transport,
+                &mut scheduler,
+                cmd,
+                &self.envelope,
+                &mut send_buf,
+                write_timeout,
+            ) {
+                SendResult::Ok if dispatched_id == target_cmd_id => return Ok(()),
+                SendResult::Ok => {
+                    waited_for_spacing = false;
+                }
+                SendResult::Err { error, action } => {
+                    if transport.send_semantics() == SendSemantics::Stream {
+                        let error = Error::StreamPoisoned {
+                            reason: format!("Send failed: {error}").into(),
+                        };
+                        self.core.clear_all();
+                        self.fail_observed_except(target_cmd_id, &error);
+                        return Err(error);
+                    }
+
+                    if let Some(SchedulerAction::CommandFailed { id, error }) = action {
+                        if id == target_cmd_id {
+                            return Err(error);
+                        }
+                        if self.observed.contains(&id) {
+                            self.completed.insert(id, Err(error));
+                        }
+                    }
+                    waited_for_spacing = false;
+                }
+            }
+        }
+    }
+
+    fn send_cancel_frame<T: BlockingTransport>(
+        &mut self,
+        transport: &mut T,
+        camera_id: CameraId,
+        socket: crate::ViscaSocket,
+    ) -> Result<()> {
+        let command = CommandCancelCommand::new(socket);
+        let mut command_buf = [0u8; CommandCancelCommand::MAX_SIZE];
+        let len = command.write_into(camera_id, &mut command_buf)?;
+        let mut send_buf = BytesMut::with_capacity(self.buffer_manager.config().send_buffer_size);
+        self.envelope
+            .frame_into(&command_buf[..len], CommandKind::Command, &mut send_buf);
+        transport.send_with_kind(&send_buf, CommandKind::Command)
     }
 
     /// Update the timeout configuration.
@@ -367,6 +527,44 @@ impl<P: Profile> BlockingRunner<P> {
         };
 
         recv_timeout
+    }
+
+    /// Retain a non-target terminal outcome only while its handle is observed.
+    /// Return target outcomes directly to the caller driving the scheduler.
+    fn complete_or_retain(
+        &mut self,
+        target_cmd_id: CommandId,
+        cmd_id: CommandId,
+        outcome: Result<Response>,
+    ) -> Option<Result<Response>> {
+        if cmd_id == target_cmd_id {
+            Some(outcome)
+        } else {
+            if self.observed.contains(&cmd_id) {
+                self.completed.insert(cmd_id, outcome);
+            }
+            None
+        }
+    }
+
+    /// Fail every observed command after a fatal transport failure, preserving
+    /// per-handle outcomes for commands other than the one currently awaited.
+    fn fail_all_observed(&mut self, target_cmd_id: CommandId, error: Error) -> Result<Response> {
+        self.fail_observed_except(target_cmd_id, &error);
+        Err(error)
+    }
+
+    fn fail_observed_except(&mut self, target_cmd_id: CommandId, error: &Error) {
+        for cmd_id in self.observed.iter().copied() {
+            if cmd_id != target_cmd_id {
+                self.completed.insert(cmd_id, Err(error.clone()));
+            }
+        }
+    }
+
+    fn discard_result(&mut self, cmd_id: CommandId) {
+        self.observed.remove(&cmd_id);
+        self.completed.remove(&cmd_id);
     }
 
     /// Run the scheduler until a specific command completes.
@@ -450,14 +648,17 @@ impl<P: Profile> BlockingRunner<P> {
                                 "Stream transport poisoned - failing command and exiting"
                             );
                             self.core.clear_all();
-                            return Err(Error::StreamPoisoned {
+                            let error = Error::StreamPoisoned {
                                 reason: reason.into(),
-                            });
+                            };
+                            return self.fail_all_observed(target_cmd_id, error);
                         }
                         // For datagram transports, check if this failure is for our target command
                         if let Some(SchedulerAction::CommandFailed { id, error }) = action {
-                            if id == target_cmd_id {
-                                return Err(error);
+                            if let Some(outcome) =
+                                self.complete_or_retain(target_cmd_id, id, Err(error))
+                            {
+                                return outcome;
                             }
                         }
                         // Stop draining and fall through to timeout/receive
@@ -470,8 +671,12 @@ impl<P: Profile> BlockingRunner<P> {
             let timeout_actions = self.core.check_timeouts(now);
             for action in timeout_actions {
                 match action {
-                    SchedulerAction::CommandFailed { id, error } if id == target_cmd_id => {
-                        return Err(error);
+                    SchedulerAction::CommandFailed { id, error } => {
+                        if let Some(outcome) =
+                            self.complete_or_retain(target_cmd_id, id, Err(error))
+                        {
+                            return outcome;
+                        }
                     }
                     SchedulerAction::RetryCommand { .. } => {}
                     _ => {}
@@ -485,9 +690,11 @@ impl<P: Profile> BlockingRunner<P> {
             match transport.recv_into_with_timeout(&mut read_buf, recv_timeout) {
                 Ok(0) => {
                     warn!("Connection closed by peer");
-                    return Err(Error::ConnectionClosed {
+                    let error = Error::ConnectionClosed {
                         reason: Some("peer closed connection".into()),
-                    });
+                    };
+                    self.core.clear_all();
+                    return self.fail_all_observed(target_cmd_id, error);
                 }
                 Ok(n) => {
                     trace!("Received {n} bytes from transport");
@@ -509,8 +716,11 @@ impl<P: Profile> BlockingRunner<P> {
                         }
                     }
 
-                    // Always drain frames after push attempt (even after resync)
-                    for frame_result in self.framer.drain_frames() {
+                    // Drain first so processing terminal actions can mutably
+                    // update outcome/cancel state without retaining a borrow of
+                    // the framer iterator.
+                    let frames: Vec<_> = self.framer.drain_frames().collect();
+                    for frame_result in frames {
                         let frame = match frame_result {
                             Ok(frame) => frame,
                             Err(e) => {
@@ -534,8 +744,10 @@ impl<P: Profile> BlockingRunner<P> {
                                 if let Some(SchedulerAction::CommandFailed { id, error }) =
                                     self.core.fail_after_receive_error(id, error)
                                 {
-                                    if id == target_cmd_id {
-                                        return Err(error);
+                                    if let Some(outcome) =
+                                        self.complete_or_retain(target_cmd_id, id, Err(error))
+                                    {
+                                        return outcome;
                                     }
                                 }
                                 continue;
@@ -553,15 +765,34 @@ impl<P: Profile> BlockingRunner<P> {
                         let actions = self.core.process_event(event, now);
                         for action in actions {
                             match action {
-                                SchedulerAction::CommandComplete { id, response, .. }
-                                    if id == target_cmd_id =>
-                                {
-                                    return Ok(response);
+                                SchedulerAction::CommandComplete { id, response, .. } => {
+                                    if let Some(outcome) =
+                                        self.complete_or_retain(target_cmd_id, id, Ok(response))
+                                    {
+                                        return outcome;
+                                    }
                                 }
-                                SchedulerAction::CommandFailed { id, error }
-                                    if id == target_cmd_id =>
-                                {
-                                    return Err(error);
+                                SchedulerAction::CommandFailed { id, error } => {
+                                    if let Some(outcome) =
+                                        self.complete_or_retain(target_cmd_id, id, Err(error))
+                                    {
+                                        return outcome;
+                                    }
+                                }
+                                SchedulerAction::SendCancel { camera_id, socket } => {
+                                    if let Err(error) =
+                                        self.send_cancel_frame(transport, camera_id, socket)
+                                    {
+                                        if transport.send_semantics() == SendSemantics::Stream {
+                                            self.core.clear_all();
+                                            return self.fail_all_observed(target_cmd_id, error);
+                                        }
+                                        warn!(
+                                            ?camera_id,
+                                            ?socket,
+                                            "Failed to send deferred socket cancel: {error}"
+                                        );
+                                    }
                                 }
                                 _ => {}
                             }
@@ -575,11 +806,12 @@ impl<P: Profile> BlockingRunner<P> {
                         .core
                         .process_event(SchedulerEvent::NetworkError(e), now);
                     for action in actions {
-                        match action {
-                            SchedulerAction::CommandFailed { id, error } if id == target_cmd_id => {
-                                return Err(error);
+                        if let SchedulerAction::CommandFailed { id, error } = action {
+                            if let Some(outcome) =
+                                self.complete_or_retain(target_cmd_id, id, Err(error))
+                            {
+                                return outcome;
                             }
-                            _ => {}
                         }
                     }
                 }
@@ -672,11 +904,9 @@ mod tests {
         }
     }
 
-    /// `start_command` queues a command (assigning an id) without any I/O, and
-    /// `cancel` removes it from the scheduler so nothing is left to send. This is
-    /// the submit/cancel half of the split that backs `BlockingInFlight`.
+    /// A command cancelled while it is still queued is removed without any I/O.
     #[test]
-    fn test_start_command_queues_then_cancel_dequeues() {
+    fn test_queued_cancel_dequeues_without_io() {
         use crate::command::bytes::VISCA_TERMINATOR;
 
         #[derive(Debug, Clone)]
@@ -700,10 +930,10 @@ mod tests {
             bytes: vec![0x81, 0x01, 0x04, 0x00, 0x02, VISCA_TERMINATOR],
         };
 
-        // start_command queues and returns a non-zero id, performing no I/O.
+        // Exercise the state before `start_command` performs initial dispatch.
         let id = runner
-            .start_command(&test_cmd, CameraId::CAMERA_1)
-            .expect("start_command should queue the command");
+            .enqueue(&test_cmd, CameraId::CAMERA_1, false)
+            .expect("enqueue should accept the command");
         assert!(id.get() >= 1);
 
         // cancel removes the queued command: nothing is left to send.

--- a/src/runtime/blocking_runner.rs
+++ b/src/runtime/blocking_runner.rs
@@ -10,6 +10,7 @@ use tracing::{debug, trace, warn};
 use core::marker::PhantomData;
 use std::{
     collections::{HashMap, HashSet},
+    panic::AssertUnwindSafe,
     sync::atomic::{AtomicU32, Ordering},
     time::{Duration, Instant},
 };
@@ -57,7 +58,13 @@ pub struct BlockingRunner<P: Profile> {
     next_id: AtomicU32,
     /// Terminal outcomes for observed commands that completed while another
     /// command was driving the blocking scheduler.
-    completed: HashMap<CommandId, Result<Response>>,
+    ///
+    /// The assertion is deliberately limited to immutable terminal values. An
+    /// opaque source inside [`Error`] may not advertise unwind safety, but no
+    /// scheduler state is reachable through a stored outcome. Keeping that
+    /// distinction here preserves the public blocking camera types' 1.0
+    /// `UnwindSafe` contract without asserting over the runner as a whole.
+    completed: HashMap<CommandId, AssertUnwindSafe<Result<Response>>>,
     /// Commands whose callers still own a completion handle.
     ///
     /// Keeping this separate from `completed` lets detached handles continue to
@@ -313,7 +320,7 @@ impl<P: Profile> BlockingRunner<P> {
     ) -> Result<Response> {
         if let Some(outcome) = self.completed.remove(&target_cmd_id) {
             self.observed.remove(&target_cmd_id);
-            return outcome;
+            return outcome.0;
         }
 
         if !self.observed.contains(&target_cmd_id) {
@@ -429,7 +436,7 @@ impl<P: Profile> BlockingRunner<P> {
                             return Err(error);
                         }
                         if self.observed.contains(&id) {
-                            self.completed.insert(id, Err(error));
+                            self.completed.insert(id, AssertUnwindSafe(Err(error)));
                         }
                     }
                     waited_for_spacing = false;
@@ -541,7 +548,7 @@ impl<P: Profile> BlockingRunner<P> {
             Some(outcome)
         } else {
             if self.observed.contains(&cmd_id) {
-                self.completed.insert(cmd_id, outcome);
+                self.completed.insert(cmd_id, AssertUnwindSafe(outcome));
             }
             None
         }
@@ -557,7 +564,8 @@ impl<P: Profile> BlockingRunner<P> {
     fn fail_observed_except(&mut self, target_cmd_id: CommandId, error: &Error) {
         for cmd_id in self.observed.iter().copied() {
             if cmd_id != target_cmd_id {
-                self.completed.insert(cmd_id, Err(error.clone()));
+                self.completed
+                    .insert(cmd_id, AssertUnwindSafe(Err(error.clone())));
             }
         }
     }

--- a/src/runtime/core/mod.rs
+++ b/src/runtime/core/mod.rs
@@ -555,16 +555,13 @@ pub enum SchedulerAction {
     /// should be sent immediately to the transport.
     SendCancel {
         /// Camera ID for addressing the cancel message.
-        #[cfg(any(feature = "mode-async", test))]
         camera_id: crate::camera_id::CameraId,
         /// Socket to cancel.
-        #[cfg(any(feature = "mode-async", test))]
         socket: ViscaSocket,
     },
 }
 
 /// Result of a cancellation request after scheduler processing.
-#[cfg(any(feature = "mode-async", test))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CancelOutcome {
     /// A queued command was removed before any VISCA bytes were sent.
@@ -1560,7 +1557,6 @@ impl SchedulerCore {
     }
 
     /// Remove a command from pending command/inquiry queues.
-    #[cfg(any(feature = "mode-async", test))]
     fn remove_queued_command(&mut self, cmd_id: CommandId) {
         let old_cmd_queue = std::mem::take(&mut self.command_queue);
         for cmd in old_cmd_queue.into_iter() {
@@ -1591,7 +1587,6 @@ impl SchedulerCore {
     ///
     /// This design eliminates the need for an out-of-band `pending_cancel_ids` map,
     /// ensuring cancels are bounded to command lifetime and cleaned up automatically.
-    #[cfg(any(feature = "mode-async", test))]
     pub fn request_cancel_by_id(&mut self, cmd_id: CommandId) -> CancelOutcome {
         // Check if the command is active and get its state
         let Some(state) = self.commands.get(&cmd_id) else {
@@ -2538,9 +2533,7 @@ impl SchedulerCore {
                     "Emitting SendCancel for command that had cancel_requested set"
                 );
                 Some(SchedulerAction::SendCancel {
-                    #[cfg(any(feature = "mode-async", test))]
                     camera_id: cmd_state.camera_id,
-                    #[cfg(any(feature = "mode-async", test))]
                     socket: assigned_socket,
                 })
             } else {

--- a/tests/api_contract/fail_must_use_async/ignored_operation_handle.rs
+++ b/tests/api_contract/fail_must_use_async/ignored_operation_handle.rs
@@ -1,0 +1,17 @@
+#![deny(unused_must_use)]
+
+use grafton_visca::{
+    camera::{profiles::PtzOpticsG2, AsyncCamera},
+    command::PanTilt,
+    runtime::{TokioRuntime, TransportHandle},
+};
+
+async fn ignore_operation_handle(
+    camera: &AsyncCamera<PtzOpticsG2, TransportHandle<TokioRuntime>, TokioRuntime>,
+) {
+    camera.submit(&PanTilt::Home).await.expect("submission");
+}
+
+fn main() {
+    let _ = ignore_operation_handle;
+}

--- a/tests/api_contract/fail_must_use_async/ignored_operation_handle.stderr
+++ b/tests/api_contract/fail_must_use_async/ignored_operation_handle.stderr
@@ -4,7 +4,7 @@ error: unused `InFlight` that must be used
 12 |     camera.submit(&PanTilt::Home).await.expect("submission");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this operation handle should be awaited, cancelled, or explicitly detached; dropping it detaches the already-dispatched command
+   = note: this operation handle should be awaited, cancelled, or explicitly detached; dropping it leaves the submitted command scheduler-owned
 note: the lint level is defined here
   --> tests/api_contract/fail_must_use_async/ignored_operation_handle.rs:1:9
    |

--- a/tests/api_contract/fail_must_use_async/ignored_operation_handle.stderr
+++ b/tests/api_contract/fail_must_use_async/ignored_operation_handle.stderr
@@ -1,0 +1,16 @@
+error: unused `InFlight` that must be used
+  --> tests/api_contract/fail_must_use_async/ignored_operation_handle.rs:12:5
+   |
+12 |     camera.submit(&PanTilt::Home).await.expect("submission");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this operation handle should be awaited, cancelled, or explicitly detached; dropping it detaches the already-dispatched command
+note: the lint level is defined here
+  --> tests/api_contract/fail_must_use_async/ignored_operation_handle.rs:1:9
+   |
+ 1 | #![deny(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the resulting value
+   |
+12 |     let _ = camera.submit(&PanTilt::Home).await.expect("submission");
+   |     +++++++

--- a/tests/api_contract/fail_must_use_blocking/ignored_operation_handle.rs
+++ b/tests/api_contract/fail_must_use_blocking/ignored_operation_handle.rs
@@ -1,0 +1,13 @@
+#![deny(unused_must_use)]
+
+use grafton_visca::{
+    command::PanTilt, profiles::PtzOpticsG2, transport::BlockingTransportHandle, BlockingCamera,
+};
+
+fn ignore_operation_handle(camera: &BlockingCamera<PtzOpticsG2, BlockingTransportHandle>) {
+    camera.submit(&PanTilt::Home).expect("submission");
+}
+
+fn main() {
+    let _ = ignore_operation_handle;
+}

--- a/tests/api_contract/fail_must_use_blocking/ignored_operation_handle.stderr
+++ b/tests/api_contract/fail_must_use_blocking/ignored_operation_handle.stderr
@@ -1,0 +1,16 @@
+error: unused `BlockingInFlight` that must be used
+ --> tests/api_contract/fail_must_use_blocking/ignored_operation_handle.rs:8:5
+  |
+8 |     camera.submit(&PanTilt::Home).expect("submission");
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this blocking operation handle should be awaited, cancelled, or explicitly detached; dropping it detaches the already-dispatched command
+note: the lint level is defined here
+ --> tests/api_contract/fail_must_use_blocking/ignored_operation_handle.rs:1:9
+  |
+1 | #![deny(unused_must_use)]
+  |         ^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the resulting value
+  |
+8 |     let _ = camera.submit(&PanTilt::Home).expect("submission");
+  |     +++++++

--- a/tests/api_contract/fail_must_use_dyn/ignored_dyn_operation_handle.rs
+++ b/tests/api_contract/fail_must_use_dyn/ignored_dyn_operation_handle.rs
@@ -1,0 +1,14 @@
+#![deny(unused_must_use)]
+
+use grafton_visca::dynapi::DynPanTiltControl;
+
+async fn ignore_dyn_operation_handle(pan_tilt: &dyn DynPanTiltControl) {
+    pan_tilt
+        .pan_tilt_home_op()
+        .await
+        .expect("dyn operation submission");
+}
+
+fn main() {
+    let _ = ignore_dyn_operation_handle;
+}

--- a/tests/api_contract/fail_must_use_dyn/ignored_dyn_operation_handle.stderr
+++ b/tests/api_contract/fail_must_use_dyn/ignored_dyn_operation_handle.stderr
@@ -7,7 +7,7 @@ error: unused `InFlightDyn` that must be used
 9 | |         .expect("dyn operation submission");
   | |___________________________________________^
   |
-  = note: this dynamic operation handle should be awaited, cancelled, or explicitly detached; dropping it detaches the already-dispatched command
+  = note: this dynamic operation handle should be awaited, cancelled, or explicitly detached; dropping it leaves the submitted command scheduler-owned
 note: the lint level is defined here
  --> tests/api_contract/fail_must_use_dyn/ignored_dyn_operation_handle.rs:1:9
   |

--- a/tests/api_contract/fail_must_use_dyn/ignored_dyn_operation_handle.stderr
+++ b/tests/api_contract/fail_must_use_dyn/ignored_dyn_operation_handle.stderr
@@ -1,0 +1,19 @@
+error: unused `InFlightDyn` that must be used
+ --> tests/api_contract/fail_must_use_dyn/ignored_dyn_operation_handle.rs:6:5
+  |
+6 | /     pan_tilt
+7 | |         .pan_tilt_home_op()
+8 | |         .await
+9 | |         .expect("dyn operation submission");
+  | |___________________________________________^
+  |
+  = note: this dynamic operation handle should be awaited, cancelled, or explicitly detached; dropping it detaches the already-dispatched command
+note: the lint level is defined here
+ --> tests/api_contract/fail_must_use_dyn/ignored_dyn_operation_handle.rs:1:9
+  |
+1 | #![deny(unused_must_use)]
+  |         ^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the resulting value
+  |
+6 |     let _ = pan_tilt
+  |     +++++++

--- a/tests/api_contract/pass/camera_first_configuration.rs
+++ b/tests/api_contract/pass/camera_first_configuration.rs
@@ -105,10 +105,13 @@ fn main() {
     #[cfg(feature = "runtime-tokio")]
     {
         async fn primary_tokio_path(addr: &str) -> Result<(), grafton_visca::Error> {
+            use grafton_visca::command::PanTilt;
+
             let runtime = grafton_visca::runtime::TokioRuntime::from_current()?;
             let camera = Connect::open_tcp_async::<PtzOpticsG2, _>(addr, runtime).await?;
             camera.power().state().await?;
             camera.zoom().stop().await?;
+            camera.submit(&PanTilt::Home).await?.detach();
             camera.close().await?;
             Ok(())
         }
@@ -119,10 +122,13 @@ fn main() {
     #[cfg(feature = "runtime-smol")]
     {
         async fn primary_smol_path(addr: &str) -> Result<(), grafton_visca::Error> {
+            use grafton_visca::command::PanTilt;
+
             let runtime = grafton_visca::runtime::SmolRuntime::new();
             let camera = Connect::open_tcp_async::<PtzOpticsG2, _>(addr, runtime).await?;
             camera.power().state().await?;
             camera.zoom().stop().await?;
+            camera.submit(&PanTilt::Home).await?.detach();
             camera.close().await?;
             Ok(())
         }

--- a/tests/api_contract/pass_dyn/dyn_api_surface.rs
+++ b/tests/api_contract/pass_dyn/dyn_api_surface.rs
@@ -4,12 +4,16 @@ use std::{marker::PhantomData, time::Duration};
 
 use grafton_visca::{
     capabilities::Capabilities,
+    command::{PanTiltDirection, PanTiltLimitCorner, PresetNumber},
     dynapi::{
         DynCameraControl, DynFocusControl, DynMotionControl, DynPanTiltControl, DynPresetsControl,
-        DynZoomControl, InFlightDyn, IntoDynCamera,
+        DynZoomControl, InFlightDyn, IntoDynCamera, OperationCategory,
     },
     mode::BoxFuture,
-    types::ZoomPosition,
+    types::{
+        FocusPosition, PanPosition, PanSpeed, SpeedLevel, TiltPosition, TiltSpeed, ZoomPosition,
+        ZoomSpeed,
+    },
     Error, StateCache, UnitInterval, ZoomDomain,
 };
 
@@ -32,6 +36,11 @@ fn assert_dyn_motion_surface(motion: &dyn DynMotionControl) {
 }
 
 fn assert_dyn_zoom_surface(zoom: &dyn DynZoomControl) {
+    let _: BoxFuture<'_, Result<(), Error>> = zoom.zoom_tele(
+        Some(ZoomSpeed::new(1).unwrap()),
+        Some(Duration::from_secs(1)),
+    );
+    let _: BoxFuture<'_, Result<(), Error>> = zoom.zoom_wide(None, None);
     let _: BoxFuture<'_, Result<(), Error>> =
         zoom.set_zoom(ZoomPosition::MIN, Some(Duration::from_secs(1)));
     let _: BoxFuture<'_, Result<InFlightDyn, Error>> = zoom.set_zoom_op(ZoomPosition::MIN);
@@ -44,6 +53,55 @@ fn assert_dyn_zoom_surface(zoom: &dyn DynZoomControl) {
     );
 }
 
+fn assert_dyn_pan_tilt_surface(
+    pan_tilt: &dyn DynPanTiltControl,
+    pan: PanPosition,
+    tilt: TiltPosition,
+) {
+    let timeout = Some(Duration::from_secs(1));
+    let _: BoxFuture<'_, Result<(), Error>> = pan_tilt.pan_tilt_home(timeout);
+    let _: BoxFuture<'_, Result<InFlightDyn, Error>> = pan_tilt.pan_tilt_home_op();
+    let _: BoxFuture<'_, Result<(), Error>> =
+        pan_tilt.pan_tilt_absolute(0.0, 0.0, SpeedLevel::Medium, timeout);
+    let _: BoxFuture<'_, Result<InFlightDyn, Error>> =
+        pan_tilt.pan_tilt_absolute_op(0.0, 0.0, SpeedLevel::Medium);
+    let _: BoxFuture<'_, Result<(), Error>> =
+        pan_tilt.pan_tilt_relative(0.0, 0.0, SpeedLevel::Medium, timeout);
+    let _: BoxFuture<'_, Result<InFlightDyn, Error>> =
+        pan_tilt.pan_tilt_relative_op(0.0, 0.0, SpeedLevel::Medium);
+    let _: BoxFuture<'_, Result<(), Error>> = pan_tilt.pan_tilt_reset(timeout);
+    let _: BoxFuture<'_, Result<InFlightDyn, Error>> = pan_tilt.pan_tilt_reset_op();
+    let _: BoxFuture<'_, Result<(), Error>> = pan_tilt.pan_tilt_move(
+        PanTiltDirection::Stop,
+        PanSpeed::new(1).unwrap(),
+        TiltSpeed::new(1).unwrap(),
+    );
+    let _: BoxFuture<'_, Result<(), Error>> =
+        pan_tilt.pan_tilt_limit_set(PanTiltLimitCorner::UpRight, pan, tilt);
+}
+
+fn assert_dyn_focus_surface(focus: &dyn DynFocusControl, position: FocusPosition) {
+    let _: BoxFuture<'_, Result<(), Error>> =
+        focus.set_focus(position, Some(Duration::from_secs(1)));
+    let _: BoxFuture<'_, Result<InFlightDyn, Error>> = focus.set_focus_op(position);
+}
+
+fn assert_dyn_preset_surface(presets: &dyn DynPresetsControl, preset: PresetNumber) {
+    let _: BoxFuture<'_, Result<(), Error>> =
+        presets.preset_recall(preset, Some(Duration::from_secs(1)));
+    let _: BoxFuture<'_, Result<InFlightDyn, Error>> = presets.preset_recall_op(preset);
+}
+
+fn assert_dyn_handle_surface(handle: InFlightDyn) {
+    let _: grafton_visca::camera::CommandId = handle.id();
+    let _: OperationCategory = handle.category();
+    let _: BoxFuture<'_, Result<(), Error>> = handle.cancel();
+    let _: BoxFuture<'_, Result<(), Error>> = handle.await_applied(Duration::from_secs(1));
+    let _: BoxFuture<'_, Result<(), Error>> = handle.await_settled(Duration::from_secs(1));
+    let _: BoxFuture<'_, Result<(), Error>> = handle.await_completion(Duration::from_secs(1));
+    handle.detach();
+}
+
 fn assert_into_dyn<T: IntoDynCamera>() {}
 
 fn main() {
@@ -52,5 +110,9 @@ fn main() {
     let _: PhantomData<fn(&dyn DynCameraControl)> = PhantomData;
     let _ = assert_dyn_camera_surface;
     let _ = assert_dyn_motion_surface;
+    let _ = assert_dyn_pan_tilt_surface;
     let _ = assert_dyn_zoom_surface;
+    let _ = assert_dyn_focus_surface;
+    let _ = assert_dyn_preset_surface;
+    let _ = assert_dyn_handle_surface;
 }

--- a/tests/api_stability_test.rs
+++ b/tests/api_stability_test.rs
@@ -764,6 +764,12 @@ fn test_public_compile_time_api_contracts() {
     cases.pass("tests/api_contract/pass_dyn/*.rs");
     #[cfg(feature = "test-utils")]
     cases.pass("tests/api_contract/pass_test_utils/*.rs");
+    #[cfg(feature = "runtime-tokio")]
+    cases.compile_fail("tests/api_contract/fail_must_use_async/*.rs");
+    #[cfg(feature = "dyn-api")]
+    cases.compile_fail("tests/api_contract/fail_must_use_dyn/*.rs");
+    #[cfg(not(feature = "mode-async"))]
+    cases.compile_fail("tests/api_contract/fail_must_use_blocking/*.rs");
 }
 
 #[test]

--- a/tests/api_stability_test.rs
+++ b/tests/api_stability_test.rs
@@ -1,4 +1,4 @@
-//! Public API contract tests for the 1.0 surface.
+//! Public API contract tests for the 1.x surface.
 //!
 //! These tests intentionally assert stable behavior and exported entry points.
 //! Changes here should reflect an explicit public contract decision.

--- a/tests/auto_trait_contracts.rs
+++ b/tests/auto_trait_contracts.rs
@@ -1,0 +1,40 @@
+//! Compile-time contracts for public auto traits promised by the 1.x API.
+//!
+//! These bounds are observable by downstream generic code even though Rustdoc
+//! does not list auto-trait implementations alongside ordinary methods.
+
+#[cfg(not(feature = "mode-async"))]
+#[test]
+fn blocking_camera_surface_remains_unwind_safe() {
+    use std::panic::UnwindSafe;
+
+    use grafton_visca::{
+        camera::{profiles::PtzOpticsG2, BlockingClient, Camera, CameraSession},
+        mode::Blocking,
+    };
+
+    struct Transport;
+    fn assert_unwind_safe<T: UnwindSafe>() {}
+
+    assert_unwind_safe::<Camera<Blocking, PtzOpticsG2, Transport>>();
+    assert_unwind_safe::<BlockingClient<PtzOpticsG2, Transport>>();
+    assert_unwind_safe::<CameraSession<Blocking, PtzOpticsG2, Transport>>();
+}
+
+#[cfg(feature = "runtime-tokio")]
+#[test]
+fn async_operation_handle_remains_unwind_safe() {
+    use std::panic::{RefUnwindSafe, UnwindSafe};
+
+    use grafton_visca::{
+        camera::{profiles::PtzOpticsG2, InFlight},
+        TokioExecutor,
+    };
+
+    type Handle = InFlight<'static, (), PtzOpticsG2, TokioExecutor>;
+    fn assert_unwind_safe<T: UnwindSafe>() {}
+    fn assert_ref_unwind_safe<T: RefUnwindSafe>() {}
+
+    assert_unwind_safe::<Handle>();
+    assert_ref_unwind_safe::<Handle>();
+}

--- a/tests/dyn_api_integration_test.rs
+++ b/tests/dyn_api_integration_test.rs
@@ -20,14 +20,14 @@ use std::{
 
 use grafton_visca::{
     camera::{
-        profiles::{PtzOpticsG2, SonyFR7},
+        profiles::{GenericVisca, PtzOpticsG2, SonyFR7},
         Camera, CameraBuilder,
     },
     capabilities::{Profile, TypedSupportSurface},
     command::{FocusZone, VISCA_TERMINATOR},
     dynapi::{
         DynCameraControl, DynFocusControl, DynMotionControl, DynPanTiltControl, DynPresetsControl,
-        DynZoomControl, IntoDynCamera,
+        DynZoomControl, IntoDynCamera, OperationCategory,
     },
     mode::Async,
     runtime::TokioRuntime,
@@ -80,6 +80,22 @@ impl Drop for AllocationCountingGuard {
 
 type TestCamera = Camera<Async, PtzOpticsG2, ScriptedTransport<TokioExecutor>, TokioRuntime>;
 type ProfileTestCamera<P> = Camera<Async, P, ScriptedTransport<TokioExecutor>, TokioRuntime>;
+
+const PAN_TILT_POSITION_INQUIRY: &[u8] = &[0x81, 0x09, 0x06, 0x12, VISCA_TERMINATOR];
+
+fn pan_tilt_position_response(pan: u16, tilt: u16) -> Vec<u8> {
+    let mut response = vec![0x90, 0x50];
+    for value in [pan, tilt] {
+        response.extend([
+            ((value >> 12) & 0x0f) as u8,
+            ((value >> 8) & 0x0f) as u8,
+            ((value >> 4) & 0x0f) as u8,
+            (value & 0x0f) as u8,
+        ]);
+    }
+    response.push(VISCA_TERMINATOR);
+    response
+}
 
 fn allocations_during(f: impl FnOnce()) -> usize {
     let _guard = ALLOCATION_TEST_LOCK
@@ -824,6 +840,150 @@ async fn test_dyn_inflight_await_completion_is_one_shot() {
     assert!(
         matches!(second, Err(Error::InvalidState(ref message)) if message.contains("await_completion called more than once")),
         "second completion wait should be rejected: {second:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_dyn_inflight_applied_aliases_share_one_shot_state() {
+    let camera = new_test_camera(vec![helpers::command_response(
+        patterns::pan_tilt::HOME.to_vec(),
+        1,
+    )])
+    .await;
+    let dyn_camera = camera.into_dyn();
+    let handle = dyn_camera
+        .pan_tilt()
+        .pan_tilt_home_op()
+        .await
+        .expect("operation handle");
+
+    handle
+        .await_applied(Duration::from_secs(1))
+        .await
+        .expect("applied wait");
+    let second = handle.await_completion(Duration::from_secs(1)).await;
+    assert!(
+        matches!(second, Err(Error::InvalidState(ref message)) if message.contains("await_completion called more than once")),
+        "compatibility alias should preserve its one-shot error: {second:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_dyn_handle_categories_are_inferred_from_static_markers() {
+    let camera = new_test_camera(vec![
+        helpers::auto_respond_step(),
+        helpers::auto_respond_step(),
+        helpers::auto_respond_step(),
+        helpers::auto_respond_step(),
+    ])
+    .await;
+    let dyn_camera = camera.into_dyn();
+
+    let pan_tilt = dyn_camera
+        .pan_tilt()
+        .pan_tilt_home_op()
+        .await
+        .expect("pan/tilt handle");
+    assert_eq!(pan_tilt.category(), OperationCategory::PanTilt);
+    pan_tilt
+        .await_applied(Duration::from_secs(1))
+        .await
+        .expect("pan/tilt applied");
+
+    let zoom = dyn_camera
+        .zoom()
+        .set_zoom_op(ZoomPosition::MIN)
+        .await
+        .expect("zoom handle");
+    assert_eq!(zoom.category(), OperationCategory::Zoom);
+    zoom.await_applied(Duration::from_secs(1))
+        .await
+        .expect("zoom applied");
+
+    let focus = dyn_camera
+        .focus()
+        .set_focus_op(FocusPosition::new(0x1000))
+        .await
+        .expect("focus handle");
+    assert_eq!(focus.category(), OperationCategory::Focus);
+    focus
+        .await_applied(Duration::from_secs(1))
+        .await
+        .expect("focus applied");
+
+    let preset = dyn_camera
+        .presets()
+        .preset_recall_op(PresetNumber::new(1).expect("preset"))
+        .await
+        .expect("preset handle");
+    assert_eq!(preset.category(), OperationCategory::Preset);
+    preset
+        .await_applied(Duration::from_secs(1))
+        .await
+        .expect("preset applied");
+}
+
+#[tokio::test]
+async fn test_dyn_await_settled_polls_command_derived_axes() {
+    let steps = vec![
+        helpers::command_response(patterns::pan_tilt::HOME.to_vec(), 1),
+        helpers::inquiry_response(
+            PAN_TILT_POSITION_INQUIRY.to_vec(),
+            1,
+            pan_tilt_position_response(0, 0),
+        ),
+        helpers::inquiry_response(
+            PAN_TILT_POSITION_INQUIRY.to_vec(),
+            1,
+            pan_tilt_position_response(0, 0),
+        ),
+    ];
+    let transport = ScriptedTransport::new(steps);
+    let observed = transport.clone();
+    let camera = new_profile_camera::<GenericVisca>(transport).await;
+    let dyn_camera = camera.into_dyn();
+
+    dyn_camera
+        .pan_tilt()
+        .pan_tilt_home_op()
+        .await
+        .expect("operation handle")
+        .await_settled(Duration::from_secs(1))
+        .await
+        .expect("polling settle");
+
+    assert_eq!(
+        observed.sent(),
+        vec![
+            patterns::pan_tilt::HOME.to_vec(),
+            PAN_TILT_POSITION_INQUIRY.to_vec(),
+            PAN_TILT_POSITION_INQUIRY.to_vec(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn test_dyn_await_settled_shares_timeout_with_polling() {
+    let transport = ScriptedTransport::new(vec![helpers::command_response(
+        patterns::pan_tilt::HOME.to_vec(),
+        1,
+    )]);
+    let camera = new_profile_camera::<GenericVisca>(transport).await;
+    let dyn_camera = camera.into_dyn();
+    let started = Instant::now();
+
+    let result = dyn_camera
+        .pan_tilt()
+        .pan_tilt_home_op()
+        .await
+        .expect("operation handle")
+        .await_settled(Duration::from_millis(40))
+        .await;
+
+    assert!(matches!(result, Err(Error::Timeout)));
+    assert!(
+        started.elapsed() < Duration::from_millis(500),
+        "settle polling must not start a fresh timeout budget"
     );
 }
 

--- a/tests/dyn_api_smol_integration_test.rs
+++ b/tests/dyn_api_smol_integration_test.rs
@@ -4,11 +4,11 @@
 
 mod common;
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use grafton_visca::{
     camera::{profiles::PtzOpticsG2, CameraBuilder},
-    dynapi::{DynCameraControl, IntoDynCamera},
+    dynapi::{DynCameraControl, IntoDynCamera, OperationCategory},
     testing::testkit::{helpers, ScriptedTransport},
     SmolExecutor,
 };
@@ -40,5 +40,35 @@ fn test_dyn_api_smol_pan_tilt_home() {
             .pan_tilt_home(None)
             .await
             .expect("smol dyn pan_tilt_home should succeed");
+    });
+}
+
+#[test]
+fn test_dyn_api_smol_operation_handle_settled() {
+    smol::block_on(async {
+        let executor = Arc::new(SmolExecutor::new());
+        let transport: ScriptedTransport<SmolExecutor> =
+            ScriptedTransport::new(vec![helpers::command_response(
+                patterns::pan_tilt::HOME.to_vec(),
+                1,
+            )])
+            .with_executor(executor.clone());
+
+        let camera = CameraBuilder::<SmolExecutor>::with_executor(executor)
+            .open_async::<PtzOpticsG2, _>(transport)
+            .await
+            .expect("Failed to create camera");
+        let dyn_camera = camera.into_dyn();
+        let handle = dyn_camera
+            .pan_tilt()
+            .pan_tilt_home_op()
+            .await
+            .expect("smol dyn handle");
+
+        assert_eq!(handle.category(), OperationCategory::PanTilt);
+        handle
+            .await_settled(Duration::from_secs(1))
+            .await
+            .expect("smol dyn settle");
     });
 }

--- a/tests/issue_539_async_handle_test.rs
+++ b/tests/issue_539_async_handle_test.rs
@@ -1,78 +1,265 @@
-//! Issue #539: async operation handle surface (`InFlight`) parity.
-//!
-//! Verifies the async half of the mode-honest `submit` primitive exposes the same
-//! surface as the blocking handle: `submit` / `submit_continuous` returning a
-//! handle driven by `await_applied` / `await_settled` / `detach`, with the
-//! continuous/stop guard on `await_settled`.
+//! Issue #539: async operation-handle completion parity.
 
-#![cfg(all(feature = "runtime-tokio", feature = "test-utils"))]
+#![cfg(all(feature = "mode-async", feature = "test-utils"))]
 
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-smol"))]
 use std::time::Duration;
 
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-smol"))]
+use grafton_visca::testing::testkit::{helpers, Step};
 use grafton_visca::{
-    camera::{profiles::PtzOpticsG2, CameraBuilder},
-    command::PanTilt as PanTiltCmd,
-    runtime::TokioRuntime,
-    testing::testkit::{helpers, ScriptedTransport, Step},
-    Error, TokioExecutor,
+    camera::{Axes, OperationMetadata},
+    command::{PanTilt as PanTiltCmd, ViscaCommand, Zoom},
 };
 
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-smol"))]
 const TIMEOUT: Duration = Duration::from_secs(2);
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-smol"))]
+const HOME: &[u8] = &[0x81, 0x01, 0x06, 0x04, 0xFF];
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-smol"))]
+const PAN_TILT_POSITION_INQUIRY: &[u8] = &[0x81, 0x09, 0x06, 0x12, 0xFF];
 
-fn ack_and_complete() -> Vec<Step> {
-    vec![Step::OnSend {
-        matches: None,
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-smol"))]
+fn ack_and_complete() -> Step {
+    Step::OnSend {
+        matches: Some(HOME.to_vec()),
         responses: vec![helpers::ack(1), helpers::complete(1)],
-    }]
+    }
 }
 
-async fn camera(
-    steps: Vec<Step>,
-) -> grafton_visca::camera::AsyncCamera<PtzOpticsG2, ScriptedTransport<TokioExecutor>, TokioRuntime>
-{
-    let transport: ScriptedTransport<TokioExecutor> = ScriptedTransport::new(steps);
-    let runtime = TokioRuntime::from_current().expect("runtime");
-    CameraBuilder::with_executor(runtime)
-        .open_async::<PtzOpticsG2, _>(transport)
-        .await
-        .expect("camera")
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-smol"))]
+fn pan_tilt_position(pan: u16, tilt: u16) -> Vec<u8> {
+    let mut response = vec![0x90, 0x50];
+    for value in [pan, tilt] {
+        response.extend([
+            ((value >> 12) & 0x0f) as u8,
+            ((value >> 8) & 0x0f) as u8,
+            ((value >> 4) & 0x0f) as u8,
+            (value & 0x0f) as u8,
+        ]);
+    }
+    response.push(0xff);
+    response
 }
 
-/// `submit(...).await_applied(...)` resolves when the command is applied.
-#[tokio::test]
-async fn test_async_submit_await_applied() {
-    let camera = camera(ack_and_complete()).await;
-
-    let handle = camera.submit(&PanTiltCmd::Home).await.expect("submit");
-    handle
-        .await_applied(TIMEOUT)
-        .await
-        .expect("command should be applied");
+#[cfg(any(feature = "runtime-tokio", feature = "runtime-smol"))]
+fn polling_settle_steps() -> Vec<Step> {
+    vec![
+        ack_and_complete(),
+        helpers::inquiry_response(
+            PAN_TILT_POSITION_INQUIRY.to_vec(),
+            1,
+            pan_tilt_position(0, 0),
+        ),
+        helpers::inquiry_response(
+            PAN_TILT_POSITION_INQUIRY.to_vec(),
+            1,
+            pan_tilt_position(0, 0),
+        ),
+    ]
 }
 
-/// `await_settled` on a continuous/stop handle is `Error::NotSupported`.
-#[tokio::test]
-async fn test_async_submit_continuous_await_settled_not_supported() {
-    let camera = camera(ack_and_complete()).await;
-
-    let handle = camera
-        .submit_continuous(&PanTiltCmd::Home)
-        .await
-        .expect("submit_continuous");
-    let result = handle.await_settled(TIMEOUT).await;
-
-    assert!(
-        matches!(result, Err(Error::NotSupported)),
-        "await_settled on a continuous handle must be NotSupported, got {result:?}"
+#[test]
+fn built_in_metadata_is_command_derived() {
+    assert_eq!(
+        PanTiltCmd::Home.operation_metadata(),
+        Some(OperationMetadata::targeted(Axes::PAN_TILT))
+    );
+    assert_eq!(
+        Zoom::TeleStd.operation_metadata(),
+        Some(OperationMetadata::applied_only(Axes::ZOOM))
+    );
+    assert_eq!(
+        Zoom::Position(grafton_visca::types::ZoomPosition::MIN).operation_metadata(),
+        Some(OperationMetadata::targeted(Axes::ZOOM))
     );
 }
 
-/// `detach()` is the explicit fire-and-forget; it consumes the handle and never
-/// stops the (already-dispatched) command.
-#[tokio::test]
-async fn test_async_detach_is_fire_and_forget() {
-    let camera = camera(ack_and_complete()).await;
+#[cfg(feature = "runtime-tokio")]
+mod tokio_tests {
+    use grafton_visca::{
+        camera::{profiles::GenericVisca, profiles::PtzOpticsG2, CameraBuilder},
+        runtime::TokioRuntime,
+        testing::testkit::ScriptedTransport,
+        Error, TokioExecutor,
+    };
 
-    let handle = camera.submit(&PanTiltCmd::Home).await.expect("submit");
-    handle.detach();
+    use super::*;
+
+    async fn build_camera<P>(
+        steps: Vec<Step>,
+    ) -> (
+        grafton_visca::camera::AsyncCamera<P, ScriptedTransport<TokioExecutor>, TokioRuntime>,
+        ScriptedTransport<TokioExecutor>,
+    )
+    where
+        P: grafton_visca::capabilities::Profile + Default,
+    {
+        let transport: ScriptedTransport<TokioExecutor> = ScriptedTransport::new(steps);
+        let observed = transport.clone();
+        let runtime = TokioRuntime::from_current().expect("runtime");
+        let camera = CameraBuilder::with_executor(runtime)
+            .open_async::<P, _>(transport)
+            .await
+            .expect("camera");
+        (camera, observed)
+    }
+
+    #[tokio::test]
+    async fn submit_await_applied_and_continuous_guard() {
+        let (camera, _) = build_camera::<PtzOpticsG2>(vec![ack_and_complete()]).await;
+        camera
+            .submit(&PanTiltCmd::Home)
+            .await
+            .expect("submit")
+            .await_applied(TIMEOUT)
+            .await
+            .expect("applied");
+
+        let (camera, _) = build_camera::<PtzOpticsG2>(vec![]).await;
+        let result = camera
+            .submit(&Zoom::TeleStd)
+            .await
+            .expect("submit continuous command")
+            .await_settled(TIMEOUT)
+            .await;
+        assert!(matches!(result, Err(Error::NotSupported)));
+    }
+
+    #[tokio::test]
+    async fn submit_rejects_inquiries_before_io() {
+        let (camera, transport) = build_camera::<PtzOpticsG2>(vec![]).await;
+        let result = camera
+            .submit(&grafton_visca::command::PanTiltPositionInquiry)
+            .await;
+        assert!(matches!(result, Err(Error::InquiryNotCancelable)));
+        assert!(transport.sent().is_empty());
+    }
+
+    #[tokio::test]
+    async fn settled_uses_exact_completion_when_profile_supports_it() {
+        let (camera, transport) = build_camera::<PtzOpticsG2>(vec![ack_and_complete()]).await;
+        camera
+            .submit(&PanTiltCmd::Home)
+            .await
+            .expect("submit")
+            .await_settled(TIMEOUT)
+            .await
+            .expect("settled");
+        assert_eq!(transport.sent(), vec![HOME.to_vec()]);
+    }
+
+    #[tokio::test]
+    async fn settled_polls_only_affected_axes_without_operation_complete() {
+        let (camera, transport) = build_camera::<GenericVisca>(polling_settle_steps()).await;
+        camera
+            .submit(&PanTiltCmd::Home)
+            .await
+            .expect("submit")
+            .await_settled(TIMEOUT)
+            .await
+            .expect("settled");
+
+        let sent = transport.sent();
+        assert_eq!(sent.len(), 3);
+        assert_eq!(sent[0], HOME);
+        assert_eq!(sent[1], PAN_TILT_POSITION_INQUIRY);
+        assert_eq!(sent[2], PAN_TILT_POSITION_INQUIRY);
+    }
+
+    #[tokio::test]
+    async fn settled_deadline_bounds_a_stalled_position_inquiry() {
+        let (camera, _) = build_camera::<GenericVisca>(vec![ack_and_complete()]).await;
+        let started = std::time::Instant::now();
+        let result = camera
+            .submit(&PanTiltCmd::Home)
+            .await
+            .expect("submit")
+            .await_settled(Duration::from_millis(40))
+            .await;
+
+        assert!(matches!(result, Err(Error::Timeout)));
+        assert!(
+            started.elapsed() < Duration::from_millis(500),
+            "the position inquiry must share the handle deadline"
+        );
+    }
+
+    #[tokio::test]
+    async fn settled_propagates_the_exact_command_error() {
+        let (camera, _) = build_camera::<PtzOpticsG2>(vec![helpers::errors::syntax_error(1)]).await;
+        let result = camera
+            .submit(&PanTiltCmd::Home)
+            .await
+            .expect("submit")
+            .await_settled(TIMEOUT)
+            .await;
+
+        assert!(
+            matches!(result, Err(Error::SyntaxError)),
+            "the operation's own camera error must propagate: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn detach_is_explicit_fire_and_forget() {
+        let (camera, _) = build_camera::<PtzOpticsG2>(vec![ack_and_complete()]).await;
+        camera
+            .submit(&PanTiltCmd::Home)
+            .await
+            .expect("submit")
+            .detach();
+    }
+}
+
+#[cfg(all(feature = "runtime-smol", not(feature = "runtime-tokio")))]
+mod smol_tests {
+    use std::sync::Arc;
+
+    use grafton_visca::{
+        camera::{profiles::GenericVisca, profiles::PtzOpticsG2, CameraBuilder},
+        testing::testkit::ScriptedTransport,
+        SmolExecutor,
+    };
+
+    use super::*;
+
+    #[test]
+    fn smol_applied_and_settled_profile_paths() {
+        smol::block_on(async {
+            let executor = Arc::new(SmolExecutor::new());
+            let transport =
+                ScriptedTransport::new(vec![ack_and_complete()]).with_executor(executor.clone());
+            let observed = transport.clone();
+            let camera = CameraBuilder::<SmolExecutor>::with_executor(executor)
+                .open_async::<PtzOpticsG2, _>(transport)
+                .await
+                .expect("camera");
+            camera
+                .submit(&PanTiltCmd::Home)
+                .await
+                .expect("submit")
+                .await_settled(TIMEOUT)
+                .await
+                .expect("settled from completion");
+            assert_eq!(observed.sent(), vec![HOME.to_vec()]);
+
+            let executor = Arc::new(SmolExecutor::new());
+            let transport =
+                ScriptedTransport::new(polling_settle_steps()).with_executor(executor.clone());
+            let observed = transport.clone();
+            let camera = CameraBuilder::<SmolExecutor>::with_executor(executor)
+                .open_async::<GenericVisca, _>(transport)
+                .await
+                .expect("camera");
+            camera
+                .submit(&PanTiltCmd::Home)
+                .await
+                .expect("submit")
+                .await_settled(TIMEOUT)
+                .await
+                .expect("settled by polling");
+            assert_eq!(observed.sent().len(), 3);
+        });
+    }
 }

--- a/tests/issue_539_blocking_handle_test.rs
+++ b/tests/issue_539_blocking_handle_test.rs
@@ -7,8 +7,8 @@
 //!   executor at all), returning the ordinary `Result`.
 //! - Multiple submitted commands each complete through their own handle.
 //! - `await_settled` returns `Error::NotSupported` for a continuous/stop handle.
-//! - `cancel()` discards a queued command before it is ever sent.
-//! - Dropping a handle never stops the command (drop == detach).
+//! - Cancellation before/after ACK sends the correct socket cancel.
+//! - Dropping or detaching a handle never stops the already-dispatched command.
 
 #![cfg(all(not(feature = "mode-async"), feature = "test-utils"))]
 
@@ -17,15 +17,49 @@ mod common;
 use std::time::Duration;
 
 use grafton_visca::{
-    command::PanTilt as PanTiltCmd,
+    camera::profiles::GenericVisca,
+    command::{PanTilt as PanTiltCmd, ZoomPositionInquiry},
     prelude::blocking::*,
-    testing::testkit::{helpers, ScriptedBlockingTransport},
+    testing::testkit::{helpers, ScriptedBlockingTransport, Step},
     Error,
 };
 
 use crate::common::patterns;
 
 const TIMEOUT: Duration = Duration::from_secs(2);
+const CANCEL_SOCKET_1: &[u8] = &[0x81, 0x21, 0xFF];
+const CANCEL_SOCKET_2: &[u8] = &[0x81, 0x22, 0xFF];
+const PAN_TILT_POSITION_INQUIRY: &[u8] = &[0x81, 0x09, 0x06, 0x12, 0xFF];
+
+fn pan_tilt_position(pan: u16, tilt: u16) -> Vec<u8> {
+    let mut response = vec![0x90, 0x50];
+    for value in [pan, tilt] {
+        response.extend([
+            ((value >> 12) & 0x0f) as u8,
+            ((value >> 8) & 0x0f) as u8,
+            ((value >> 4) & 0x0f) as u8,
+            (value & 0x0f) as u8,
+        ]);
+    }
+    response.push(0xff);
+    response
+}
+
+fn polling_settle_steps() -> Vec<Step> {
+    vec![
+        helpers::command_response(patterns::pan_tilt::HOME.to_vec(), 1),
+        helpers::inquiry_response(
+            PAN_TILT_POSITION_INQUIRY.to_vec(),
+            1,
+            pan_tilt_position(0, 0),
+        ),
+        helpers::inquiry_response(
+            PAN_TILT_POSITION_INQUIRY.to_vec(),
+            1,
+            pan_tilt_position(0, 0),
+        ),
+    ]
+}
 
 /// `submit().await_applied()` runs entirely on the caller's thread and returns
 /// `Ok(())` once the camera has protocol-completed the command. No async runtime
@@ -38,12 +72,9 @@ fn test_submit_await_applied_is_synchronous() {
     )]);
     let camera: Camera<PtzOpticsG2, _> = Camera::new(transport.clone()).unwrap();
 
-    // Nothing is sent until we block for completion.
+    // Submission performs initial dispatch, but does not receive-pump.
     let handle = camera.submit(&PanTiltCmd::Home).unwrap();
-    assert!(
-        transport.sent().is_empty(),
-        "submit must not perform any I/O before await_applied"
-    );
+    assert_eq!(transport.sent(), vec![patterns::pan_tilt::HOME.to_vec()]);
 
     let result = handle.await_applied(TIMEOUT);
     assert!(result.is_ok(), "await_applied should succeed: {result:?}");
@@ -53,26 +84,98 @@ fn test_submit_await_applied_is_synchronous() {
     assert_eq!(sent[0], patterns::pan_tilt::HOME);
 }
 
-/// Two commands submitted and awaited (sequentially, the single-threaded blocking
-/// analog of dual-socket parity) both complete through their own handles.
+/// Profiles with an exact operation-complete signal do not issue any fallback
+/// position inquiries when awaiting physical settle.
 #[test]
-fn test_multiple_submits_each_complete() {
+fn test_settled_uses_exact_completion_when_profile_supports_it() {
+    let transport = ScriptedBlockingTransport::new(vec![helpers::command_response(
+        patterns::pan_tilt::HOME.to_vec(),
+        1,
+    )]);
+    let camera: Camera<PtzOpticsG2, _> = Camera::new(transport.clone()).unwrap();
+
+    camera
+        .submit(&PanTiltCmd::Home)
+        .unwrap()
+        .await_settled(TIMEOUT)
+        .expect("operation-complete should be the settled signal");
+
+    assert_eq!(transport.sent(), vec![patterns::pan_tilt::HOME.to_vec()]);
+}
+
+/// Profiles without operation-complete poll only the axes declared by the
+/// command metadata. A pan/tilt home must not trigger zoom or focus inquiries.
+#[test]
+fn test_settled_polls_only_affected_axes_without_operation_complete() {
+    let transport = ScriptedBlockingTransport::new(polling_settle_steps());
+    let camera: Camera<GenericVisca, _> = Camera::new(transport.clone()).unwrap();
+
+    camera
+        .submit(&PanTiltCmd::Home)
+        .unwrap()
+        .await_settled(TIMEOUT)
+        .expect("equal pan/tilt samples should be settled");
+
+    assert_eq!(
+        transport.sent(),
+        vec![
+            patterns::pan_tilt::HOME.to_vec(),
+            PAN_TILT_POSITION_INQUIRY.to_vec(),
+            PAN_TILT_POSITION_INQUIRY.to_vec(),
+        ]
+    );
+}
+
+/// Command completion and position polling consume one caller-provided
+/// deadline. A stalled fallback inquiry must not start a fresh timeout budget.
+#[test]
+fn test_settled_deadline_bounds_a_stalled_position_inquiry() {
+    let transport = ScriptedBlockingTransport::new(vec![helpers::command_response(
+        patterns::pan_tilt::HOME.to_vec(),
+        1,
+    )]);
+    let camera: Camera<GenericVisca, _> = Camera::new(transport).unwrap();
+    let started = std::time::Instant::now();
+
+    let result = camera
+        .submit(&PanTiltCmd::Home)
+        .unwrap()
+        .await_settled(Duration::from_millis(40));
+
+    assert!(matches!(result, Err(Error::Timeout)));
+    assert!(
+        started.elapsed() < Duration::from_millis(500),
+        "the position inquiry must share the handle deadline"
+    );
+}
+
+/// Two commands are submitted before either is awaited. The second command
+/// completes first on another VISCA socket, and both exact outcomes remain
+/// available through their respective handles.
+#[test]
+fn test_multiple_live_submits_preserve_out_of_order_completions() {
     let transport = ScriptedBlockingTransport::new(vec![
-        helpers::command_response(patterns::pan_tilt::HOME.to_vec(), 1),
-        helpers::command_response(patterns::zoom::STOP.to_vec(), 2),
+        Step::OnSend {
+            matches: Some(patterns::pan_tilt::HOME.to_vec()),
+            responses: vec![helpers::ack(1)],
+        },
+        Step::OnSend {
+            matches: Some(patterns::zoom::STOP.to_vec()),
+            responses: vec![helpers::ack(2), helpers::complete(2), helpers::complete(1)],
+        },
     ]);
     let camera: Camera<PtzOpticsG2, _> = Camera::new(transport.clone()).unwrap();
 
     let first = camera.submit(&PanTiltCmd::Home).unwrap();
+    let second = camera.submit(&grafton_visca::command::Zoom::Stop).unwrap();
+
     assert!(
         first.await_applied(TIMEOUT).is_ok(),
         "first op should apply"
     );
-
-    let second = camera.submit(&grafton_visca::command::Zoom::Stop).unwrap();
     assert!(
         second.await_applied(TIMEOUT).is_ok(),
-        "second op should apply"
+        "the already-completed second op should retain its exact outcome"
     );
 
     let sent = transport.sent();
@@ -81,11 +184,47 @@ fn test_multiple_submits_each_complete() {
     assert_eq!(sent[1], patterns::zoom::STOP);
 }
 
+/// A non-target command error is retained just like a successful completion.
+/// Awaiting another handle must not discard the exact error for this handle.
+#[test]
+fn test_multiple_live_submits_preserve_out_of_order_error() {
+    let transport = ScriptedBlockingTransport::new(vec![
+        Step::OnSend {
+            matches: Some(patterns::pan_tilt::HOME.to_vec()),
+            responses: vec![helpers::ack(1)],
+        },
+        Step::OnSend {
+            matches: Some(patterns::zoom::STOP.to_vec()),
+            responses: vec![
+                helpers::ack(2),
+                vec![0x90, 0x62, 0x02, 0xFF],
+                helpers::complete(1),
+            ],
+        },
+    ]);
+    let camera: Camera<PtzOpticsG2, _> = Camera::new(transport).unwrap();
+
+    let first = camera.submit(&PanTiltCmd::Home).unwrap();
+    let second = camera.submit(&grafton_visca::command::Zoom::Stop).unwrap();
+
+    first
+        .await_applied(TIMEOUT)
+        .expect("first command should still complete");
+    let result = second.await_applied(TIMEOUT);
+    assert!(
+        matches!(result, Err(Error::SyntaxError)),
+        "second command should retain its exact error, got {result:?}"
+    );
+}
+
 /// `await_settled` on a continuous/stop handle returns `Error::NotSupported`
-/// (Phase 1 runtime guard) — there is no well-defined physical-settle event.
+/// because there is no well-defined physical-settle event.
 #[test]
 fn test_continuous_await_settled_not_supported() {
-    let transport = ScriptedBlockingTransport::new(vec![]);
+    let transport = ScriptedBlockingTransport::new(vec![Step::OnSend {
+        matches: Some(patterns::pan_tilt::HOME.to_vec()),
+        responses: vec![],
+    }]);
     let camera: Camera<PtzOpticsG2, _> = Camera::new(transport.clone()).unwrap();
 
     let handle = camera.submit_continuous(&PanTiltCmd::Home).unwrap();
@@ -95,44 +234,115 @@ fn test_continuous_await_settled_not_supported() {
         matches!(result, Err(Error::NotSupported)),
         "await_settled on a continuous handle must be NotSupported, got {result:?}"
     );
-    // The guard short-circuits before any I/O.
+    // The guard short-circuits before receive-pumping, after initial dispatch.
+    assert_eq!(transport.sent(), vec![patterns::pan_tilt::HOME.to_vec()]);
+}
+
+/// Blocking operation submission rejects inquiries before any transport I/O,
+/// matching the async cancelable-command path.
+#[test]
+fn test_submit_rejects_inquiry_before_io() {
+    let transport = ScriptedBlockingTransport::new(vec![]);
+    let camera: Camera<PtzOpticsG2, _> = Camera::new(transport.clone()).unwrap();
+
+    let result = camera.submit(&ZoomPositionInquiry);
+    assert!(matches!(result, Err(Error::InquiryNotCancelable)));
     assert!(transport.sent().is_empty());
 }
 
-/// `cancel()` discards a still-queued command before it is ever sent.
+/// Cancel before ACK is recorded by command ID, then emitted for the socket as
+/// soon as a later receive pump processes that ACK.
 #[test]
-fn test_cancel_before_await_does_not_send() {
-    let transport = ScriptedBlockingTransport::new(vec![helpers::command_response(
-        patterns::pan_tilt::HOME.to_vec(),
-        1,
-    )]);
+fn test_cancel_before_ack_is_sent_on_ack() {
+    let transport = ScriptedBlockingTransport::new(vec![
+        Step::OnSend {
+            matches: Some(patterns::pan_tilt::HOME.to_vec()),
+            responses: vec![],
+        },
+        Step::OnSend {
+            matches: Some(patterns::zoom::STOP.to_vec()),
+            responses: vec![helpers::ack(2), helpers::complete(2)],
+        },
+        Step::OnSend {
+            matches: Some(CANCEL_SOCKET_1.to_vec()),
+            responses: vec![],
+        },
+    ]);
     let camera: Camera<PtzOpticsG2, _> = Camera::new(transport.clone()).unwrap();
 
-    let handle = camera.submit(&PanTiltCmd::Home).unwrap();
-    assert!(handle.cancel().is_ok(), "cancel should succeed");
+    let first = camera.submit(&PanTiltCmd::Home).unwrap();
+    first.cancel().expect("pre-ACK cancel request");
+    assert_eq!(transport.sent(), vec![patterns::pan_tilt::HOME.to_vec()]);
 
-    assert!(
-        transport.sent().is_empty(),
-        "a canceled, never-awaited command must not be sent"
+    // The ACK arrives after cancel was requested. Awaiting another live handle
+    // drives the receive loop and emits the deferred socket cancel.
+    transport.add_response(helpers::ack(1));
+    let second = camera.submit(&grafton_visca::command::Zoom::Stop).unwrap();
+    second.await_applied(TIMEOUT).expect("second command");
+
+    assert_eq!(
+        transport.sent(),
+        vec![
+            patterns::pan_tilt::HOME.to_vec(),
+            patterns::zoom::STOP.to_vec(),
+            CANCEL_SOCKET_1.to_vec(),
+        ]
     );
 }
 
-/// Dropping a handle without awaiting/cancelling never stops the command: it is
-/// simply detached (left queued). A subsequent real operation still works.
+/// Once an ACK has assigned a socket, cancel sends that socket's VISCA cancel
+/// immediately without requiring another receive pump.
 #[test]
-fn test_drop_detaches_without_stopping() {
-    let transport = ScriptedBlockingTransport::new(vec![helpers::command_response(
-        patterns::pan_tilt::HOME.to_vec(),
-        1,
-    )]);
+fn test_cancel_after_ack_sends_immediately() {
+    let transport = ScriptedBlockingTransport::new(vec![
+        Step::OnSend {
+            matches: Some(patterns::pan_tilt::HOME.to_vec()),
+            responses: vec![helpers::ack(1)],
+        },
+        Step::OnSend {
+            matches: Some(patterns::zoom::STOP.to_vec()),
+            responses: vec![helpers::ack(2), helpers::complete(1)],
+        },
+        Step::OnSend {
+            matches: Some(CANCEL_SOCKET_2.to_vec()),
+            responses: vec![],
+        },
+    ]);
     let camera: Camera<PtzOpticsG2, _> = Camera::new(transport.clone()).unwrap();
 
-    {
-        // Explicit detach is the documented equivalent of dropping.
-        let handle = camera.submit(&PanTiltCmd::Home).unwrap();
-        handle.detach();
-    }
+    let first = camera.submit(&PanTiltCmd::Home).unwrap();
+    let second = camera.submit(&grafton_visca::command::Zoom::Stop).unwrap();
+    first.await_applied(TIMEOUT).expect("first command");
 
-    // Detach performed no I/O and no cancellation frame.
-    assert!(transport.sent().is_empty());
+    second.cancel().expect("post-ACK cancel");
+    assert_eq!(transport.sent().last().unwrap(), CANCEL_SOCKET_2);
+}
+
+/// Dropping a handle without awaiting/cancelling never stops the command: it is
+/// detached after initial dispatch, and no cancellation frame is emitted.
+#[test]
+fn test_detach_does_not_stop_dispatched_command() {
+    let transport = ScriptedBlockingTransport::new(vec![Step::OnSend {
+        matches: Some(patterns::pan_tilt::HOME.to_vec()),
+        responses: vec![],
+    }]);
+    let camera: Camera<PtzOpticsG2, _> = Camera::new(transport.clone()).unwrap();
+
+    camera.submit(&PanTiltCmd::Home).unwrap().detach();
+
+    assert_eq!(transport.sent(), vec![patterns::pan_tilt::HOME.to_vec()]);
+}
+
+#[test]
+fn test_drop_does_not_stop_dispatched_command() {
+    let transport = ScriptedBlockingTransport::new(vec![Step::OnSend {
+        matches: Some(patterns::pan_tilt::HOME.to_vec()),
+        responses: vec![],
+    }]);
+    let camera: Camera<PtzOpticsG2, _> = Camera::new(transport.clone()).unwrap();
+
+    let handle = camera.submit(&PanTiltCmd::Home).unwrap();
+    drop(handle);
+
+    assert_eq!(transport.sent(), vec![patterns::pan_tilt::HOME.to_vec()]);
 }


### PR DESCRIPTION
## Summary

- Complete the 1.1 operation-handle semantics across blocking, async, and dynamic APIs, including command-derived metadata, exact applied/settled behavior, cancellation, detachment, and out-of-order completion.
- Forward submission through async sessions and add fully integrated operation-handle examples for blocking and Tokio users.
- Align the README, rustdoc, changelog, macro documentation, maintained examples, and release guidance with the intended 1.x scope and the future 2.0 boundary.
- Harden hardware-lab validators and make the two-crate 1.1.0 release workflow validated, ordered, bounded, and safe to rerun.

## Why

The initial 1.1 surface from #539 still had semantic gaps between modes: incomplete metadata parity, fallback settling behavior, response retention and cancellation edge cases, and documentation/examples that did not consistently demonstrate the recommended API. Release automation also needed to account for the macro crate appearing in the registry before packaging the main crate.

This PR closes those integration gaps so 1.1.0 is a coherent, maintainable release rather than a partial API addition, while leaving broader API redesign for 2.0.

## User and developer impact

- Operation handles now expose consistent, mode-honest behavior across supported execution models.
- Existing 1.x users retain the compatibility surface needed for a low-disruption 1.x release.
- Maintained examples are read-only by default, validate CLI input, issue safety STOP commands where appropriate, and report cleanup failures.
- Release maintainers get an explicit checklist, version/tag/lock/changelog validation, exact macro-version gating, package file-list inspection, and idempotent partial reruns.
- Hardware-camera validation remains an explicit pre-release gate and was not run in this environment.

Related to #539.

## Validation

- Full feature matrix: `bash .github/scripts/test-all-features.sh`
- Clippy: `cargo clippy --all-targets --all-features -- -D warnings`
- Examples: blocking, mode-async, Tokio, smol, and Tokio serial configurations
- Rustdoc with warnings denied: blocking, Tokio + dyn, and all features
- Doctests: blocking, Tokio, and all features
- API contract suites: blocking, Tokio, and Tokio + dyn
- MSRV 1.88: blocking and Tokio/dyn/test-utils
- `cargo audit`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- Workflow YAML parsing and release-script shell syntax
- Release metadata validation for `v1.1.0`, including a negative mismatched-version case
- Crates.io polling against an existing exact macro version
- Macro package build and both crate package file-list inspections
- Repository pre-commit hook suite
